### PR TITLE
Move Locker outside of for-loop in InvokeEvent

### DIFF
--- a/code/framework/src/scripting/resource_manager.cpp
+++ b/code/framework/src/scripting/resource_manager.cpp
@@ -1,4 +1,5 @@
 #include "resource_manager.h"
+
 #include "engine.h"
 
 #include <cppfs/FileHandle.h>
@@ -77,13 +78,13 @@ namespace Framework::Scripting {
     }
 
     void ResourceManager::InvokeEvent(const std::string &eventName, InvokeEventCallback cb) {
-        for (auto resPair : _resources) { 
-            const auto res = resPair.second;
+        auto isolate = _engine->GetIsolate();
+        v8::Locker locker(isolate);
+        v8::Isolate::Scope isolateScope(isolate);
+        v8::HandleScope handleScope(isolate);
 
-            auto isolate = _engine->GetIsolate();
-            v8::Locker locker(isolate);
-            v8::Isolate::Scope isolateScope(isolate);
-            v8::HandleScope handleScope(isolate);
+        for (auto resPair : _resources) {
+            const auto res = resPair.second;
 
             auto ctx = res->GetContext();
             v8::Context::Scope contextScope(ctx);


### PR DESCRIPTION
As all resources share the same isolate, it is not needed to create the Locker for every iteration of the for-loop, so we can move the Locker outside of the for-loop to save some performance.