### PR TITLE
Implement parent class inheritance for V8Class

### DIFF
--- a/code/framework/src/scripting/v8_helpers/v8_class.h
+++ b/code/framework/src/scripting/v8_helpers/v8_class.h
@@ -18,10 +18,13 @@ namespace Framework::Scripting::Helpers {
         ClassInitCallback _initCb;
         v8::FunctionCallback _constructor;
         v8::Persistent<v8::FunctionTemplate> _fnTpl;
+        V8Class *_parent;
 
       public:
-        V8Class(const std::string &, ClassInitCallback &&init = {});
-        V8Class(const std::string &, v8::FunctionCallback, ClassInitCallback &&cb = {});
+        V8Class(const std::string &, ClassInitCallback && = {});
+        V8Class(const std::string &, v8::FunctionCallback, ClassInitCallback && = {});
+        V8Class(const std::string &, V8Class &, ClassInitCallback && = {});
+        V8Class(const std::string &, V8Class &, v8::FunctionCallback, ClassInitCallback && = {});
 
         V8HelperError Load();
         V8HelperError Register(v8::Local<v8::Context>, v8::Local<v8::Object>);


### PR DESCRIPTION
This allows a `V8Class` to have another `V8Class` as a parent, the child class will then inherit the methods/properties from the parent class.