### PR TITLE
Fix error in README and fix build problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ cmake -B build
 cmake --build build
 
 # Run framework tests
-cmake --build --target RunFrameworkTests
+cmake --build build --target RunFrameworkTests
 ```
 
 ## Add a multi-player project to the framework

--- a/vendors/discord/CMakeLists.txt
+++ b/vendors/discord/CMakeLists.txt
@@ -5,7 +5,7 @@ target_include_directories(DiscordSDK PUBLIC "src")
 if (WIN32)
     target_link_directories(DiscordSDK PUBLIC "lib/x86")
     add_custom_command(TARGET DiscordSDK POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/lib/x86/discord_game_sdk.dll" "${CMAKE_BINARY_DIR}/bin"
+            COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/lib/x86/discord_game_sdk.dll" "${CMAKE_BINARY_DIR}/bin/"
             )
     target_link_libraries(DiscordSDK PUBLIC discord_game_sdk)
 elseif (APPLE)

--- a/vendors/sentry/CMakeLists.txt
+++ b/vendors/sentry/CMakeLists.txt
@@ -3,13 +3,13 @@ if(CMAKE_CL_64)
     target_link_directories(Sentry PUBLIC "lib/win_64")
     file(GLOB SENTRY_LIBS "lib/win_64/*.lib")
     add_custom_command(TARGET Sentry POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/bin/win_64/crashpad_handler.exe" "${CMAKE_BINARY_DIR}/bin"
+            COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/bin/win_64/crashpad_handler.exe" "${CMAKE_BINARY_DIR}/bin/"
             )
 elseif(WIN32)
     target_link_directories(Sentry PUBLIC "lib/win_32")
     file(GLOB SENTRY_LIBS "lib/win_32/*.lib")
     add_custom_command(TARGET Sentry POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/bin/win_32/crashpad_handler.exe" "${CMAKE_BINARY_DIR}/bin"
+            COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/bin/win_32/crashpad_handler.exe" "${CMAKE_BINARY_DIR}/bin/"
             )
 elseif(APPLE)
     target_link_directories(Sentry PUBLIC "lib/osx")


### PR DESCRIPTION
Fixes a small error in the command specified in the README to run the framework tests.

Fixes a problem (only on Windows, maybe?) where a missing backslash caused CMake to create a file instead of a directory, thus causing a build error.