### PR TITLE
Enable stack trace for uncaught exceptions

### DIFF
--- a/code/framework/src/scripting/engine.cpp
+++ b/code/framework/src/scripting/engine.cpp
@@ -49,7 +49,8 @@ namespace Framework::Scripting {
         _isolate->SetFatalErrorHandler([](const char *location, const char *message) {
             if (location) {
                 Logging::GetLogger(FRAMEWORK_INNER_SCRIPTING)->debug("{} {}", location, message);
-            } else {
+            }
+            else {
                 Logging::GetLogger(FRAMEWORK_INNER_SCRIPTING)->debug("{}", message);
             }
         });
@@ -70,6 +71,8 @@ namespace Framework::Scripting {
             Logging::GetLogger(FRAMEWORK_INNER_SCRIPTING)->debug("{}: {}", *res, *msg);
             Logging::GetLogger(FRAMEWORK_INNER_SCRIPTING)->debug("{}", *trace);
         });
+
+        _isolate->SetCaptureStackTraceForUncaughtExceptions(true);
 
         v8::HandleScope isolateHandleScope(_isolate);
         v8::Local<v8::ObjectTemplate> globalObjTemplate = v8::ObjectTemplate::New(_isolate);


### PR DESCRIPTION
Embedders of the framework will probably want to handle uncaught exceptions (or maybe the framework should even do this?) and also display the stack trace (to find out where the exception originates from), but that is disabled in V8 by default.
This PR enables the stack trace in uncaught exceptions, so it can be displayed to the user when it is handled.