### PR TITLE
visual studio filters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.20)
 cmake_policy(SET CMP0091 NEW)
 project(Framework CXX)
 
+include("scripts/get_all_targets.cmake")
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)

--- a/code/framework/CMakeLists.txt
+++ b/code/framework/CMakeLists.txt
@@ -147,3 +147,9 @@ IF(WIN32)
     add_definitions(-D_USE_MATH_DEFINES)
     add_definitions(-DNOMINMAX)
 ENDIF()
+
+# Put framework projects in the framework folder in MSVC
+if (MSVC)
+    get_all_targets(all_targets)
+    set_target_properties(${all_targets} PROPERTIES FOLDER framework)
+endif ()

--- a/code/tests/CMakeLists.txt
+++ b/code/tests/CMakeLists.txt
@@ -6,3 +6,9 @@ target_link_libraries(FrameworkTests Framework)
 add_custom_target(RunFrameworkTests
         COMMAND $<TARGET_FILE:FrameworkTests>
         DEPENDS $<TARGET_FILE:FrameworkTests>)
+
+# Put test projects in the framework/tests folder in MSVC
+if (MSVC)
+    get_all_targets(all_targets)
+    set_target_properties(${all_targets} PROPERTIES FOLDER framework/tests)
+endif ()

--- a/scripts/get_all_targets.cmake
+++ b/scripts/get_all_targets.cmake
@@ -1,0 +1,17 @@
+# Function to get targets within a directory (and subdirectories)
+# https://newbedev.com/how-do-i-iterate-over-all-cmake-targets-programmatically
+function(get_all_targets var)
+    set(targets)
+    get_all_targets_recursive(targets ${CMAKE_CURRENT_SOURCE_DIR})
+    set(${var} ${targets} PARENT_SCOPE)
+endfunction()
+
+macro(get_all_targets_recursive targets dir)
+    get_property(subdirectories DIRECTORY ${dir} PROPERTY SUBDIRECTORIES)
+    foreach(subdir ${subdirectories})
+        get_all_targets_recursive(${targets} ${subdir})
+    endforeach()
+
+    get_property(current_targets DIRECTORY ${dir} PROPERTY BUILDSYSTEM_TARGETS)
+    list(APPEND ${targets} ${current_targets})
+endmacro()

--- a/vendors/CMakeLists.txt
+++ b/vendors/CMakeLists.txt
@@ -97,3 +97,8 @@ if (WIN32)
     add_subdirectory(ntdll)
 endif ()
 
+# Put vendor projects in the framework/vendors folder in MSVC
+if (MSVC)
+    get_all_targets(all_targets)
+    set_target_properties(${all_targets} PROPERTIES FOLDER framework/vendors)
+endif ()


### PR DESCRIPTION
Added some stuff to the CMakeLists files to group the projects in visual studio, see the image below:

![kép](https://user-images.githubusercontent.com/10908255/137311632-4cd578cd-f786-4f55-a2ac-ea51f45d568f.png)

I'm not sure if i did setup the solution correctly or it was a bug because of VS2022 but there were no filters and i had trouble finding my projects in the list.