### PR TITLE
mixed platform support

### DIFF
--- a/code/framework/src/launcher/project.cpp
+++ b/code/framework/src/launcher/project.cpp
@@ -347,6 +347,17 @@ namespace Framework::Launcher {
                 
                 if (_config.promptSelectionFunctor)
                     _config.classicGamePath = _config.promptSelectionFunctor(_config.classicGamePath);
+
+                if (_config.preferSteam) {
+                    auto steamDllName = _config.arch == ProjectArchitecture::CPU_X64 ? "/steam_api64.dll" : "/steam_api.dll";
+                    auto steamDll     = cppfs::fs::open(Utils::StringUtils::WideToNormal(_config.classicGamePath) + steamDllName);
+
+                    if (steamDll.exists()) {
+                        Logging::GetLogger(FRAMEWORK_INNER_LAUNCHER)->info("Steam dll found in the game directory, switching to steam platform");
+                        _config.platform = ProjectPlatform::STEAM;
+                        return RunInnerSteamChecks();
+                    }
+                }
             }
             else {
                 ExitProcess(0);

--- a/code/framework/src/launcher/project.h
+++ b/code/framework/src/launcher/project.h
@@ -34,6 +34,9 @@ namespace Framework::Launcher {
         // allows us to load client ourselves, otherwise stick to Framework's standard loading routine
         bool loadClientManually = false;
 
+        // if promptForGameExe is true, and steam dll is found in the game's library, switch to steam platform
+        bool preferSteam = false;
+
         // game exe integrity checks (uses CRC32 checksum)
         bool verifyGameIntegrity = false;
         std::vector<uint32_t> supportedGameVersions;


### PR DESCRIPTION
Using classic platform, preferSteam and promptForGameExe will look for steam dll in the game directory and switch to steam platform.