### PR TITLE
Shared ringbuffer sink for all loggers

### DIFF
--- a/code/framework/src/logging/logger.cpp
+++ b/code/framework/src/logging/logger.cpp
@@ -48,7 +48,12 @@ namespace Framework::Logging {
         auto fileLogger        = std::make_shared<spdlog::sinks::rotating_file_sink_mt>(fileLogName, _maxFileSize, _maxFileCount);
         fileLogger->set_level(spdlog::level::trace);
 
-        std::vector<spdlog::sink_ptr> sinks {consoleLogger, fileLogger};
+        if (!ringbuffer_sink) {
+            ringbuffer_sink = std::make_shared<spdlog::sinks::ringbuffer_sink_mt>(128); // TODO 128 for now
+            ringbuffer_sink->set_level(spdlog::level::info);
+        }
+
+        std::vector<spdlog::sink_ptr> sinks {consoleLogger, fileLogger, ringbuffer_sink};
         auto spdLogger = std::make_shared<spdlog::async_logger>(logName, sinks.begin(), sinks.end(), spdlog::thread_pool(), spdlog::async_overflow_policy::block);
         spdLogger->set_level(spdlog::level::trace);
         

--- a/code/framework/src/logging/logger.h
+++ b/code/framework/src/logging/logger.h
@@ -13,6 +13,7 @@
 #include <spdlog/async.h>
 #include <spdlog/spdlog.h>
 #include <unordered_map>
+#include <spdlog/sinks/ringbuffer_sink.h>
 
 #define FRAMEWORK_INNER_NETWORKING   "Networking"
 #define FRAMEWORK_INNER_SCRIPTING    "Scripting"
@@ -37,6 +38,7 @@ namespace Framework::Logging {
         size_t _maxFileSize    = 1024 * 1024 * 10;
         size_t _maxFileCount   = 10;
         bool _loggingPaused    = false;
+        std::shared_ptr<spdlog::sinks::ringbuffer_sink_mt> ringbuffer_sink;
 
       public:
         Logger();
@@ -82,6 +84,10 @@ namespace Framework::Logging {
 
         size_t GetMaxFileCount() const {
             return _maxFileCount;
+        }
+
+        std::shared_ptr<spdlog::sinks::ringbuffer_sink_mt> GetRingBuffer() {
+            return ringbuffer_sink;
         }
     };
 


### PR DESCRIPTION
This is so that all logs are available to be read from the buffer if needed.