### PR TITLE
Respect the Liskov substitution principle for RGB and RGBA

### DIFF
--- a/code/framework/src/scripting/engines/node/builtins/color_rgb.h
+++ b/code/framework/src/scripting/engines/node/builtins/color_rgb.h
@@ -17,13 +17,13 @@
 #include <sstream>
 
 namespace Framework::Scripting::Engines::Node::Builtins {
-    class ColorRGB {
-      protected:
-        glm::ivec4 _data;
+    class ColorRGB final {
+      private:
+        glm::ivec3 _data;
 
       public:
         ColorRGB(int r, int g, int b) {
-            _data = {r, g, b, 255};
+            _data = {r, g, b};
         }
 
         int GetR() const {
@@ -61,22 +61,22 @@ namespace Framework::Scripting::Engines::Node::Builtins {
         }
 
         void Add(int r, int g, int b) {
-            const glm::ivec4 newVec(r, g, b, 0);
+            const glm::ivec3 newVec(r, g, b);
             _data += newVec;
         }
 
         void Sub(int r, int g, int b) {
-            const glm::ivec4 newVec(r, g, b, 0);
+            const glm::ivec3 newVec(r, g, b);
             _data -= newVec;
         }
 
         void Mul(int r, int g, int b) {
-            const glm::ivec4 newVec(r, g, b, 1);
+            const glm::ivec3 newVec(r, g, b);
             _data *= newVec;
         }
 
         void Div(int r, int g, int b) {
-            const glm::ivec4 newVec(r, g, b, 1);
+            const glm::ivec3 newVec(r, g, b);
             _data /= newVec;
         }
 
@@ -91,11 +91,14 @@ namespace Framework::Scripting::Engines::Node::Builtins {
 
             v8pp::class_<ColorRGB> cls(isolate);
             cls.ctor<int, int, int>();
+
             cls.property("r", &ColorRGB::GetR);
             cls.property("g", &ColorRGB::GetG);
             cls.property("b", &ColorRGB::GetB);
+
             cls.function("toString", &ColorRGB::ToString);
             cls.function("toArray", &ColorRGB::ToArray);
+
             cls.function("add", &ColorRGB::Add);
             cls.function("sub", &ColorRGB::Sub);
             cls.function("mul", &ColorRGB::Mul);

--- a/code/framework/src/scripting/engines/node/builtins/color_rgba.h
+++ b/code/framework/src/scripting/engines/node/builtins/color_rgba.h
@@ -16,17 +16,42 @@
 #include <list>
 #include <sstream>
 
-#include "color_rgb.h"
-
 namespace Framework::Scripting::Engines::Node::Builtins {
-    class ColorRGBA: public ColorRGB {
+    class ColorRGBA final {
+      private:
+        glm::ivec4 _data;
+
       public:
-        ColorRGBA(int r, int g, int b, int a): ColorRGB(r, g, b) {
-            _data.a = a;
+        ColorRGBA(int r, int g, int b, int a) {
+            _data = {r, g, b, a};
+        }
+
+        int GetR() const {
+            return _data.r;
+        }
+
+        int GetG() const {
+            return _data.g;
+        }
+
+        int GetB() const {
+            return _data.b;
         }
 
         int GetA() const {
             return _data.a;
+        }
+
+        float GetFloatR() const {
+            return static_cast<float>(_data.r) / 255.0f;
+        }
+
+        float GetFloatG() const {
+            return static_cast<float>(_data.g) / 255.0f;
+        }
+
+        float GetFloatB() const {
+            return static_cast<float>(_data.b) / 255.0f;
         }
 
         float GetFloatA() const {
@@ -73,11 +98,16 @@ namespace Framework::Scripting::Engines::Node::Builtins {
             }
 
             v8pp::class_<ColorRGBA> cls(isolate);
-            cls.inherit<ColorRGB>();
             cls.ctor<int, int, int, int>();
+
+            cls.property("r", &ColorRGBA::GetR);
+            cls.property("g", &ColorRGBA::GetG);
+            cls.property("b", &ColorRGBA::GetB);
             cls.property("a", &ColorRGBA::GetA);
+
             cls.function("toString", &ColorRGBA::ToString);
             cls.function("toArray", &ColorRGBA::ToArray);
+
             cls.function("add", &ColorRGBA::Add);
             cls.function("sub", &ColorRGBA::Sub);
             cls.function("mul", &ColorRGBA::Mul);

--- a/code/framework/src/scripting/engines/node/builtins/quaternion.h
+++ b/code/framework/src/scripting/engines/node/builtins/quaternion.h
@@ -25,7 +25,7 @@
 #include <v8pp/module.hpp>
 
 namespace Framework::Scripting::Engines::Node::Builtins {
-    class Quaternion {
+    class Quaternion final {
       private:
         glm::quat _data;
 
@@ -118,13 +118,16 @@ namespace Framework::Scripting::Engines::Node::Builtins {
 
             v8pp::class_<Quaternion> cls(isolate);
             cls.ctor<float, float, float, float>();
+
             cls.property("w", &Quaternion::GetW);
             cls.property("x", &Quaternion::GetX);
             cls.property("y", &Quaternion::GetY);
             cls.property("z", &Quaternion::GetZ);
             cls.property("length", &Quaternion::GetLength);
+
             cls.function("toString", &Quaternion::ToString);
             cls.function("toArray", &Quaternion::ToArray);
+
             cls.function("add", &Quaternion::Add);
             cls.function("sub", &Quaternion::Sub);
             cls.function("mul", &Quaternion::Mul);

--- a/code/framework/src/scripting/engines/node/builtins/vector_2.h
+++ b/code/framework/src/scripting/engines/node/builtins/vector_2.h
@@ -17,7 +17,7 @@
 #include <sstream>
 
 namespace Framework::Scripting::Engines::Node::Builtins {
-    class Vector2 {
+    class Vector2 final {
       private:
         glm::vec2 _data;
 
@@ -80,11 +80,14 @@ namespace Framework::Scripting::Engines::Node::Builtins {
 
             v8pp::class_<Vector2> cls(isolate);
             cls.ctor<double, double>();
+
             cls.property("x", &Vector2::GetX);
             cls.property("y", &Vector2::GetY);
             cls.property("length", &Vector2::GetLength);
+
             cls.function("toString", &Vector2::ToString);
             cls.function("toArray", &Vector2::ToArray);
+
             cls.function("add", &Vector2::Add);
             cls.function("sub", &Vector2::Sub);
             cls.function("mul", &Vector2::Mul);

--- a/code/framework/src/scripting/engines/node/builtins/vector_3.h
+++ b/code/framework/src/scripting/engines/node/builtins/vector_3.h
@@ -17,7 +17,7 @@
 #include <sstream>
 
 namespace Framework::Scripting::Engines::Node::Builtins {
-    class Vector3 {
+    class Vector3 final {
       private:
         glm::vec3 _data;
 
@@ -84,12 +84,15 @@ namespace Framework::Scripting::Engines::Node::Builtins {
 
             v8pp::class_<Vector3> cls(isolate);
             cls.ctor<double, double, double>();
+
             cls.property("x", &Vector3::GetX);
             cls.property("y", &Vector3::GetY);
             cls.property("z", &Vector3::GetZ);
             cls.property("length", &Vector3::GetLength);
+
             cls.function("toString", &Vector3::ToString);
             cls.function("toArray", &Vector3::ToArray);
+
             cls.function("add", &Vector3::Add);
             cls.function("sub", &Vector3::Sub);
             cls.function("mul", &Vector3::Mul);


### PR DESCRIPTION
Inheriting RGBA from RGB was an error: this does not respect the [Liskov substitution principle](https://en.wikipedia.org/wiki/Liskov_substitution_principle) since we rewrite the signatures of the methods.

Also: Consider RGB, RGBA, Vector2, Vector3 and Quaternion as final classes