### PR TITLE
Harden Entity wrapper creation

### DIFF
--- a/code/framework/src/integrations/server/instance.cpp
+++ b/code/framework/src/integrations/server/instance.cpp
@@ -111,23 +111,6 @@ namespace Framework::Integrations::Server {
             return ServerError::SERVER_WORLD_INIT_FAILED;
         }
 
-        const auto sdkCallback = [this](Framework::Scripting::SDKRegisterWrapper<Framework::Scripting::ServerEngine> sdk) {
-            this->RegisterScriptingBuiltins(sdk.GetEngine());
-        };
-
-        // Initialize the scripting engine
-        _scriptingEngine->SetMainPath("gamemode");
-        _scriptingEngine->LoadManifest();
-        if (_scriptingEngine->InitServerEngine(sdkCallback) != Framework::Scripting::ModuleError::MODULE_NONE) {
-            Logging::GetLogger(FRAMEWORK_INNER_SERVER)->critical("Failed to initialize the scripting engine");
-            return ServerError::SERVER_SCRIPTING_INIT_FAILED;
-        }
-
-        if (_opts.firebaseEnabled && _firebaseWrapper->Init(_opts.firebaseProjectId, _opts.firebaseAppId, _opts.firebaseApiKey) != External::Firebase::FirebaseError::FIREBASE_NONE) {
-            Logging::GetLogger(FRAMEWORK_INNER_SERVER)->critical("Failed to initialize the firebase wrapper");
-            return ServerError::SERVER_FIREBASE_WRAPPER_INIT_FAILED;
-        }
-
         /*if (_opts.bindPublicServer && !_masterlist->Init(_opts.bindSecretKey)) {
             Logging::GetLogger(FRAMEWORK_INNER_SERVER)->error("Failed to contact masterlist server: Push key is empty");
         }*/
@@ -152,6 +135,23 @@ namespace Framework::Integrations::Server {
 
         // Initialize mod subsystems
         PostInit();
+    
+        const auto sdkCallback = [this](Framework::Scripting::SDKRegisterWrapper<Framework::Scripting::ServerEngine> sdk) {
+            this->RegisterScriptingBuiltins(sdk.GetEngine());
+        };
+
+        // Initialize the scripting engine
+        _scriptingEngine->SetMainPath("gamemode");
+        _scriptingEngine->LoadManifest();
+        if (_scriptingEngine->InitServerEngine(sdkCallback) != Framework::Scripting::ModuleError::MODULE_NONE) {
+            Logging::GetLogger(FRAMEWORK_INNER_SERVER)->critical("Failed to initialize the scripting engine");
+            return ServerError::SERVER_SCRIPTING_INIT_FAILED;
+        }
+
+        if (_opts.firebaseEnabled && _firebaseWrapper->Init(_opts.firebaseProjectId, _opts.firebaseAppId, _opts.firebaseApiKey) != External::Firebase::FirebaseError::FIREBASE_NONE) {
+            Logging::GetLogger(FRAMEWORK_INNER_SERVER)->critical("Failed to initialize the firebase wrapper");
+            return ServerError::SERVER_FIREBASE_WRAPPER_INIT_FAILED;
+        }
 
         // Load the gamemode
         _scriptingEngine->GetServerEngine()->LoadScript();

--- a/code/framework/src/integrations/server/scripting/builtins/node/entity.h
+++ b/code/framework/src/integrations/server/scripting/builtins/node/entity.h
@@ -34,11 +34,21 @@ namespace Framework::Integrations::Scripting {
         flecs::entity _ent {};
 
       public:
-        Entity(flecs::entity_t ent) {
-            _ent = flecs::entity(CoreModules::GetWorldEngine()->GetWorld()->get_world(), ent);
-        }
         Entity(flecs::entity ent) {
             _ent = ent;
+
+            if (!_ent.is_valid() || !_ent.is_alive()) {
+                throw std::runtime_error(fmt::format("[Scripting] Entity handle '{}' is invalid!", ent));
+            }
+
+            const auto st = _ent.get<Framework::World::Modules::Base::Streamable>();
+            if (!st) {
+                throw std::runtime_error(fmt::format("[Scripting] Entity '{}' is protected!", ent));
+            }
+        }
+
+        Entity(flecs::entity_t ent) {
+            Entity(flecs::entity(CoreModules::GetWorldEngine()->GetWorld()->get_world(), ent));
         }
 
         flecs::entity_t GetID() const {

--- a/code/framework/src/integrations/server/scripting/builtins/node/entity.h
+++ b/code/framework/src/integrations/server/scripting/builtins/node/entity.h
@@ -33,22 +33,25 @@ namespace Framework::Integrations::Scripting {
       protected:
         flecs::entity _ent {};
 
-      public:
-        Entity(flecs::entity ent) {
-            _ent = ent;
-
+        void ValidateEntity() {
             if (!_ent.is_valid() || !_ent.is_alive()) {
-                throw std::runtime_error(fmt::format("[Scripting] Entity handle '{}' is invalid!", ent));
+                throw std::runtime_error(fmt::format("Entity handle '{}' is invalid!", _ent.id()));
             }
 
             const auto st = _ent.get<Framework::World::Modules::Base::Streamable>();
             if (!st) {
-                throw std::runtime_error(fmt::format("[Scripting] Entity '{}' is protected!", ent));
+                throw std::runtime_error(fmt::format("Entity '{}' is protected!", _ent.id()));
             }
+        }
+      public:
+        Entity(flecs::entity ent) {
+            _ent = ent;
+            ValidateEntity();
         }
 
         Entity(flecs::entity_t ent) {
-            Entity(flecs::entity(CoreModules::GetWorldEngine()->GetWorld()->get_world(), ent));
+            _ent = flecs::entity(CoreModules::GetWorldEngine()->GetWorld()->get_world(), ent);
+            ValidateEntity();
         }
 
         flecs::entity_t GetID() const {


### PR DESCRIPTION
Throw an exception if an Entity handle is either invalid, not alive or not streamable (ie. not created directly by MP).

Exception is then caught by the sol3 wrapper and handled gracefully (console shows the error).