### PR TITLE
Add resource root entity

### DIFF
--- a/code/framework/src/integrations/client/scripting/module.cpp
+++ b/code/framework/src/integrations/client/scripting/module.cpp
@@ -79,9 +79,9 @@ namespace Framework::Integrations::Client::Scripting {
         config.resourcesPath = _resourceCachePath;
         config.isClient = true;
         config.cascadeStopDependents = true;
-
+        
         _resourceManager = std::make_unique<Framework::Scripting::ResourceManager>(
-            _engine.get(), config);
+            _engine.get(), _world->GetWorld(), config);
 
         // Register Framework SDK bindings for the new ResourceManager
         RegisterFrameworkBindings();

--- a/code/framework/src/integrations/server/scripting/module.cpp
+++ b/code/framework/src/integrations/server/scripting/module.cpp
@@ -50,7 +50,7 @@ namespace Framework::Integrations::Server::Scripting {
         config.cascadeStopDependents = true;
 
         _resourceManager = std::make_unique<Framework::Scripting::ResourceManager>(
-            _nodeEngine.get(), config);
+            _nodeEngine.get(), _world->GetWorld(), config);
 
         // Register Framework SDK bindings
         RegisterFrameworkBindings();

--- a/code/framework/src/scripting/resource/resource.cpp
+++ b/code/framework/src/scripting/resource/resource.cpp
@@ -1,5 +1,6 @@
 #include "resource.h"
-
+#include "core_modules.h"
+#include "world/engine.h"
 #include <filesystem>
 
 namespace Framework::Scripting {
@@ -27,9 +28,16 @@ namespace Framework::Scripting {
             _errorMessage = _manifest.GetError();
             _state = ResourceState::Error;
         }
+
+        _rootEntity = CoreModules::GetWorldEngine()->GetWorld()->entity(_manifest.GetName().c_str());
+        _rootEntity.set<OwnedResource>({this});
     }
 
     Resource::~Resource() {
+        if (_rootEntity.is_valid()) {
+            _rootEntity.destruct();
+        }
+
         ClearExports();
     }
 
@@ -42,6 +50,7 @@ namespace Framework::Scripting {
         , _stateTimestamp(other._stateTimestamp)
         , _loadTimestamp(other._loadTimestamp)
         , _isolate(other._isolate)
+        , _rootEntity(other._rootEntity)
         , _exports(std::move(other._exports))
         , _restartAttempts(std::move(other._restartAttempts)) {
         other._isolate = nullptr;
@@ -59,10 +68,12 @@ namespace Framework::Scripting {
             _stateTimestamp = other._stateTimestamp;
             _loadTimestamp = other._loadTimestamp;
             _isolate = other._isolate;
+            _rootEntity = other._rootEntity;
             _exports = std::move(other._exports);
             _restartAttempts = std::move(other._restartAttempts);
 
             other._isolate = nullptr;
+            other._rootEntity = {};
         }
         return *this;
     }
@@ -265,6 +276,18 @@ namespace Framework::Scripting {
         return it->second.Get(_isolate);
     }
 
+    void Resource::DestroyChildEntities() {
+        if (!_rootEntity.is_valid()) {
+            return;
+        }
+
+        _rootEntity.world().defer_begin();
+        _rootEntity.children([&](flecs::entity child) {
+            child.destruct();
+        });
+        _rootEntity.world().defer_end();
+    }
+
     bool Resource::TransitionTo(ResourceState newState) {
         if (!IsValidTransition(_state, newState)) {
             return false;
@@ -272,6 +295,10 @@ namespace Framework::Scripting {
 
         _state = newState;
         _stateTimestamp = std::chrono::system_clock::now();
+
+        if (newState == ResourceState::Stopped) {
+            DestroyChildEntities();
+        }
 
         if (newState != ResourceState::Error) {
             ClearError();

--- a/code/framework/src/scripting/resource/resource.cpp
+++ b/code/framework/src/scripting/resource/resource.cpp
@@ -1,5 +1,4 @@
 #include "resource.h"
-#include "core_modules.h"
 #include "world/engine.h"
 #include <filesystem>
 
@@ -17,7 +16,7 @@ namespace Framework::Scripting {
         }
     }
 
-    Resource::Resource(const std::string &path)
+    Resource::Resource(const std::string &path, flecs::world* world)
         : _path(path)
         , _stateTimestamp(std::chrono::system_clock::now()) {
         // Try to load the manifest
@@ -29,7 +28,7 @@ namespace Framework::Scripting {
             _state = ResourceState::Error;
         }
 
-        _rootEntity = CoreModules::GetWorldEngine()->GetWorld()->entity(_manifest.GetName().c_str());
+        _rootEntity = world->entity(_manifest.GetName().c_str());
         _rootEntity.set<OwnedResource>({this});
     }
 
@@ -296,7 +295,7 @@ namespace Framework::Scripting {
         _state = newState;
         _stateTimestamp = std::chrono::system_clock::now();
 
-        if (newState == ResourceState::Stopped) {
+        if (newState == ResourceState::Stopped || newState == ResourceState::Error) {
             DestroyChildEntities();
         }
 

--- a/code/framework/src/scripting/resource/resource.h
+++ b/code/framework/src/scripting/resource/resource.h
@@ -3,6 +3,7 @@
 #include "package_manifest.h"
 
 #include <v8.h>
+#include <flecs/distr/flecs.h>
 
 #include <chrono>
 #include <map>
@@ -44,6 +45,12 @@ namespace Framework::Scripting {
         Stopping, // Shutting down
         Stopped,  // Cleanly stopped, can be restarted
         Error     // Failed to load or runtime error
+    };
+
+    class Resource;
+
+    struct OwnedResource {
+        Resource *value;
     };
 
     /**
@@ -191,6 +198,9 @@ namespace Framework::Scripting {
         v8::Isolate *GetIsolate() const { return _isolate; }
         void SetIsolate(v8::Isolate *isolate) { _isolate = isolate; }
 
+        // Flecs world integration
+        flecs::entity GetRootEntity() const { return _rootEntity; }
+
         // State transitions (called by ResourceManager)
         friend class ResourceManager;
 
@@ -207,6 +217,9 @@ namespace Framework::Scripting {
         // Get restart attempt count without locking
         int GetRestartAttemptCountUnlocked() const;
 
+        // Remove all child entities of the flecs root entity
+        void DestroyChildEntities();
+
         // Path to resource directory
         std::string _path;
 
@@ -222,6 +235,9 @@ namespace Framework::Scripting {
 
         // V8 isolate for this resource (set by manager)
         v8::Isolate *_isolate = nullptr;
+
+        // Flecs root entity
+        flecs::entity _rootEntity;
 
         // Exports registered by this resource
         std::map<std::string, v8::Global<v8::Value>, std::less<>> _exports;

--- a/code/framework/src/scripting/resource/resource.h
+++ b/code/framework/src/scripting/resource/resource.h
@@ -70,7 +70,7 @@ namespace Framework::Scripting {
          * Create a resource from a directory path.
          * @param path Path to the resource directory (containing package.json)
          */
-        explicit Resource(const std::string &path);
+        explicit Resource(const std::string &path, flecs::world* world);
 
         ~Resource();
 

--- a/code/framework/src/scripting/resource/resource_manager.cpp
+++ b/code/framework/src/scripting/resource/resource_manager.cpp
@@ -1,7 +1,6 @@
 #include "resource_manager.h"
 
 #include "../builtins/events.h"
-#include "core_modules.h"
 #include "world/engine.h"
 
 #include <algorithm>
@@ -35,14 +34,15 @@ namespace Framework::Scripting {
         }
     } // anonymous namespace
 
-    ResourceManager::ResourceManager(Engine *jsEngine, const ResourceManagerConfig &config)
+    ResourceManager::ResourceManager(Engine *jsEngine, flecs::world *world, const ResourceManagerConfig &config)
         : _config(config)
+        , _world(world)
         , _jsEngine(jsEngine) {
         if (_jsEngine) {
             _jsEngine->SetResourceManager(this);
         }
 
-        _rootEntity = CoreModules::GetWorldEngine()->GetWorld()->entity("Resources");
+        _rootEntity = world->entity("Resources");
     }
 
     ResourceManager::~ResourceManager() {
@@ -95,7 +95,7 @@ namespace Framework::Scripting {
     }
 
     bool ResourceManager::DiscoverResource(const std::string &path) {
-        auto resource = std::make_unique<Resource>(path);
+        auto resource = std::make_unique<Resource>(path, _world);
 
         if (!resource->IsManifestValid()) {
             Logging::GetLogger(FRAMEWORK_INNER_SCRIPTING)->warn("Invalid package.json in {}: {}", path, resource->GetErrorMessage());

--- a/code/framework/src/scripting/resource/resource_manager.cpp
+++ b/code/framework/src/scripting/resource/resource_manager.cpp
@@ -1,6 +1,8 @@
 #include "resource_manager.h"
 
 #include "../builtins/events.h"
+#include "core_modules.h"
+#include "world/engine.h"
 
 #include <algorithm>
 #include <cctype>
@@ -39,12 +41,17 @@ namespace Framework::Scripting {
         if (_jsEngine) {
             _jsEngine->SetResourceManager(this);
         }
+
+        _rootEntity = CoreModules::GetWorldEngine()->GetWorld()->entity("Resources");
     }
 
     ResourceManager::~ResourceManager() {
         StopAll();
         if (_jsEngine) {
             _jsEngine->SetResourceManager(nullptr);
+        }
+        if (_rootEntity.is_valid()) {
+            _rootEntity.destruct();
         }
     }
 
@@ -104,6 +111,8 @@ namespace Framework::Scripting {
                 Logging::GetLogger(FRAMEWORK_INNER_SCRIPTING)->warn("Duplicate resource name: {}", name);
                 return false;
             }
+
+            resource->GetRootEntity().child_of(_rootEntity);
             _resources[name] = std::move(resource);
         }
 

--- a/code/framework/src/scripting/resource/resource_manager.h
+++ b/code/framework/src/scripting/resource/resource_manager.h
@@ -65,7 +65,7 @@ namespace Framework::Scripting {
      */
     class ResourceManager final {
       public:
-        explicit ResourceManager(Engine *jsEngine, const ResourceManagerConfig &config = {});
+        explicit ResourceManager(Engine *jsEngine, flecs::world *world, const ResourceManagerConfig &config = {});
         ~ResourceManager();
 
         // Non-copyable
@@ -333,6 +333,9 @@ namespace Framework::Scripting {
 
         // JS engine (not owned)
         Engine *_jsEngine = nullptr;
+
+        // Flecs world (not owned)
+        flecs::world *_world = nullptr;
 
         // Resource registry
         std::map<std::string, std::unique_ptr<Resource>, std::less<>> _resources;

--- a/code/framework/src/scripting/resource/resource_manager.h
+++ b/code/framework/src/scripting/resource/resource_manager.h
@@ -364,6 +364,9 @@ namespace Framework::Scripting {
 
         // Events instance owned by this manager
         Events _events;
+
+        // Root entity for all resources
+        flecs::entity _rootEntity;
     };
 
 } // namespace Framework::Scripting

--- a/code/tests/modules/js_features_ut.h
+++ b/code/tests/modules/js_features_ut.h
@@ -228,9 +228,10 @@ MODULE(js_features, {
         NodeEngine engine({});
         EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
 
+        flecs::world world;
         ResourceManagerConfig config;
         config.resourcesPath = EventsTestHelper::GetTestPath();
-        ResourceManager manager(&engine, config);
+        ResourceManager manager(&engine, &world, config);
 
         {
             v8::Isolate *isolate = engine.GetIsolate();
@@ -274,9 +275,10 @@ MODULE(js_features, {
         NodeEngine engine({});
         EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
 
+        flecs::world world;
         ResourceManagerConfig config;
         config.resourcesPath = EventsTestHelper::GetTestPath();
-        ResourceManager manager(&engine, config);
+        ResourceManager manager(&engine, &world, config);
 
         {
             v8::Isolate *isolate = engine.GetIsolate();
@@ -316,9 +318,10 @@ MODULE(js_features, {
         NodeEngine engine({});
         EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
 
+        flecs::world world;
         ResourceManagerConfig config;
         config.resourcesPath = EventsTestHelper::GetTestPath();
-        ResourceManager manager(&engine, config);
+        ResourceManager manager(&engine, &world, config);
 
         {
             v8::Isolate *isolate = engine.GetIsolate();
@@ -359,9 +362,10 @@ MODULE(js_features, {
         NodeEngine engine({});
         EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
 
+        flecs::world world;
         ResourceManagerConfig config;
         config.resourcesPath = EventsTestHelper::GetTestPath();
-        ResourceManager manager(&engine, config);
+        ResourceManager manager(&engine, &world, config);
 
         {
             v8::Isolate *isolate = engine.GetIsolate();
@@ -402,9 +406,10 @@ MODULE(js_features, {
         NodeEngine engine({});
         EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
 
+        flecs::world world;
         ResourceManagerConfig config;
         config.resourcesPath = EventsTestHelper::GetTestPath();
-        ResourceManager manager(&engine, config);
+        ResourceManager manager(&engine, &world, config);
 
         {
             v8::Isolate *isolate = engine.GetIsolate();
@@ -434,9 +439,10 @@ MODULE(js_features, {
         NodeEngine engine({});
         EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
 
+        flecs::world world;
         ResourceManagerConfig config;
         config.resourcesPath = EventsTestHelper::GetTestPath();
-        ResourceManager manager(&engine, config);
+        ResourceManager manager(&engine, &world, config);
 
         {
             v8::Isolate *isolate = engine.GetIsolate();
@@ -480,9 +486,10 @@ MODULE(js_features, {
         NodeEngine engine({});
         EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
 
+        flecs::world world;
         ResourceManagerConfig config;
         config.resourcesPath = EventsTestHelper::GetTestPath();
-        ResourceManager manager(&engine, config);
+        ResourceManager manager(&engine, &world, config);
 
         {
             v8::Isolate *isolate = engine.GetIsolate();

--- a/code/tests/modules/resource_manager_ut.h
+++ b/code/tests/modules/resource_manager_ut.h
@@ -83,12 +83,14 @@ MODULE(resource_manager, {
 
     IT("can create and destroy resource manager", {
         NodeEngine engine;
+        flecs::world world;
+
         EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
 
         ResourceManagerConfig config;
         config.resourcesPath = TestManagerHelper::GetTestResourcePath();
 
-        ResourceManager *manager = new ResourceManager(&engine, config);
+        ResourceManager *manager = new ResourceManager(&engine, &world, config);
         NEQUALS(manager, nullptr);
 
         delete manager;
@@ -97,6 +99,8 @@ MODULE(resource_manager, {
 
     IT("GetConfig returns configuration", {
         NodeEngine engine;
+        flecs::world world;
+
         EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
 
         ResourceManagerConfig config;
@@ -104,7 +108,7 @@ MODULE(resource_manager, {
         config.isClient = true;
         config.cascadeStopDependents = false;
 
-        ResourceManager manager(&engine, config);
+        ResourceManager manager(&engine, &world, config);
 
         const auto &retrievedConfig = manager.GetConfig();
         STREQUALS(retrievedConfig.resourcesPath.c_str(), config.resourcesPath.c_str());
@@ -116,12 +120,14 @@ MODULE(resource_manager, {
 
     IT("SetConfig updates configuration", {
         NodeEngine engine;
+        flecs::world world;
+
         EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
 
         ResourceManagerConfig config;
         config.resourcesPath = "/old/path";
 
-        ResourceManager manager(&engine, config);
+        ResourceManager manager(&engine, &world, config);
 
         ResourceManagerConfig newConfig;
         newConfig.resourcesPath = "/new/path";
@@ -145,12 +151,14 @@ MODULE(resource_manager, {
         })");
 
         NodeEngine engine;
+        flecs::world world;
+
         EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
 
         ResourceManagerConfig config;
         config.resourcesPath = TestManagerHelper::GetTestResourcePath();
 
-        ResourceManager manager(&engine, config);
+        ResourceManager manager(&engine, &world, config);
         size_t discovered = manager.DiscoverResources();
 
         EQUALS(discovered, 2u);
@@ -169,12 +177,14 @@ MODULE(resource_manager, {
         })");
 
         NodeEngine engine;
+        flecs::world world;
+
         EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
 
         ResourceManagerConfig config;
         config.resourcesPath = TestManagerHelper::GetTestResourcePath();
 
-        ResourceManager manager(&engine, config);
+        ResourceManager manager(&engine, &world, config);
 
         bool result = manager.DiscoverResource(TestManagerHelper::GetTestResourcePath() + "/single-disc");
         EQUALS(result, true);
@@ -193,12 +203,14 @@ MODULE(resource_manager, {
         }
 
         NodeEngine engine;
+        flecs::world world;
+
         EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
 
         ResourceManagerConfig config;
         config.resourcesPath = TestManagerHelper::GetTestResourcePath();
 
-        ResourceManager manager(&engine, config);
+        ResourceManager manager(&engine, &world, config);
         size_t discovered = manager.DiscoverResources();
 
         EQUALS(discovered, 0u);
@@ -221,12 +233,14 @@ MODULE(resource_manager, {
         })");
 
         NodeEngine engine;
+        flecs::world world;
+
         EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
 
         ResourceManagerConfig config;
         config.resourcesPath = TestManagerHelper::GetTestResourcePath();
 
-        ResourceManager manager(&engine, config);
+        ResourceManager manager(&engine, &world, config);
         manager.DiscoverResources();
 
         auto names = manager.GetAllResourceNames();
@@ -243,12 +257,14 @@ MODULE(resource_manager, {
         })");
 
         NodeEngine engine;
+        flecs::world world;
+
         EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
 
         ResourceManagerConfig config;
         config.resourcesPath = TestManagerHelper::GetTestResourcePath();
 
-        ResourceManager manager(&engine, config);
+        ResourceManager manager(&engine, &world, config);
         manager.DiscoverResources();
 
         const Resource *resource = manager.GetResource("get-test");
@@ -262,12 +278,14 @@ MODULE(resource_manager, {
 
     IT("GetResource returns nullptr for unknown resource", {
         NodeEngine engine;
+        flecs::world world;
+
         EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
 
         ResourceManagerConfig config;
         config.resourcesPath = TestManagerHelper::GetTestResourcePath();
 
-        ResourceManager manager(&engine, config);
+        ResourceManager manager(&engine, &world, config);
 
         const Resource *resource = manager.GetResource("nonexistent");
         EQUALS(resource, nullptr);
@@ -282,12 +300,14 @@ MODULE(resource_manager, {
         })");
 
         NodeEngine engine;
+        flecs::world world;
+
         EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
 
         ResourceManagerConfig config;
         config.resourcesPath = TestManagerHelper::GetTestResourcePath();
 
-        ResourceManager manager(&engine, config);
+        ResourceManager manager(&engine, &world, config);
         manager.DiscoverResources();
 
         EQUALS(manager.HasResource("has-test"), true);
@@ -306,12 +326,14 @@ MODULE(resource_manager, {
         })");
 
         NodeEngine engine;
+        flecs::world world;
+
         EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
 
         ResourceManagerConfig config;
         config.resourcesPath = TestManagerHelper::GetTestResourcePath();
 
-        ResourceManager manager(&engine, config);
+        ResourceManager manager(&engine, &world, config);
         manager.DiscoverResources();
 
         ResourceState state = manager.GetResourceState("state-test");
@@ -328,12 +350,14 @@ MODULE(resource_manager, {
         })");
 
         NodeEngine engine;
+        flecs::world world;
+
         EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
 
         ResourceManagerConfig config;
         config.resourcesPath = TestManagerHelper::GetTestResourcePath();
 
-        ResourceManager manager(&engine, config);
+        ResourceManager manager(&engine, &world, config);
         manager.DiscoverResources();
 
         EQUALS(manager.IsResourceRunning("running-test"), false);
@@ -358,12 +382,14 @@ MODULE(resource_manager, {
         })");
 
         NodeEngine engine;
+        flecs::world world;
+
         EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
 
         ResourceManagerConfig config;
         config.resourcesPath = TestManagerHelper::GetTestResourcePath();
 
-        ResourceManager manager(&engine, config);
+        ResourceManager manager(&engine, &world, config);
         manager.DiscoverResources();
 
         auto deps = manager.GetDependencies("dep-child");
@@ -387,12 +413,14 @@ MODULE(resource_manager, {
         })");
 
         NodeEngine engine;
+        flecs::world world;
+
         EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
 
         ResourceManagerConfig config;
         config.resourcesPath = TestManagerHelper::GetTestResourcePath();
 
-        ResourceManager manager(&engine, config);
+        ResourceManager manager(&engine, &world, config);
         manager.DiscoverResources();
 
         auto dependents = manager.GetDependents("parent-res");
@@ -411,12 +439,14 @@ MODULE(resource_manager, {
         })");
 
         NodeEngine engine;
+        flecs::world world;
+
         EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
 
         ResourceManagerConfig config;
         config.resourcesPath = TestManagerHelper::GetTestResourcePath();
 
-        ResourceManager manager(&engine, config);
+        ResourceManager manager(&engine, &world, config);
         manager.DiscoverResources();
 
         EQUALS(manager.GetRunningResourceCount(), 0u);
@@ -440,12 +470,14 @@ MODULE(resource_manager, {
         outsideFile.close();
 
         NodeEngine engine;
+        flecs::world world;
+
         EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
 
         ResourceManagerConfig config;
         config.resourcesPath = TestManagerHelper::GetTestResourcePath();
 
-        ResourceManager manager(&engine, config);
+        ResourceManager manager(&engine, &world, config);
         manager.DiscoverResources();
 
         auto startResult = manager.StartResource("escape-test");
@@ -470,12 +502,14 @@ MODULE(resource_manager, {
         TestManagerHelper::CreateTestScript("callback-start", "main.js", "// empty script");
 
         NodeEngine engine;
+        flecs::world world;
+
         EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
 
         ResourceManagerConfig config;
         config.resourcesPath = TestManagerHelper::GetTestResourcePath();
 
-        ResourceManager manager(&engine, config);
+        ResourceManager manager(&engine, &world, config);
 
         std::string startedResource;
         manager.SetOnResourceStarted([&startedResource](const std::string &name) {
@@ -503,12 +537,14 @@ MODULE(resource_manager, {
         TestManagerHelper::CreateTestScript("callback-stop", "main.js", "// empty script");
 
         NodeEngine engine;
+        flecs::world world;
+
         EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
 
         ResourceManagerConfig config;
         config.resourcesPath = TestManagerHelper::GetTestResourcePath();
 
-        ResourceManager manager(&engine, config);
+        ResourceManager manager(&engine, &world, config);
 
         std::string stoppedResource;
         manager.SetOnResourceStopped([&stoppedResource](const std::string &name) {
@@ -532,9 +568,11 @@ MODULE(resource_manager, {
         EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
 
         ResourceManagerConfig config;
+        flecs::world world;
+
         config.resourcesPath = TestManagerHelper::GetTestResourcePath();
 
-        ResourceManager manager(&engine, config);
+        ResourceManager manager(&engine, &world, config);
 
         STREQUALS(manager.GetCurrentResourceContext().c_str(), "");
 
@@ -545,6 +583,61 @@ MODULE(resource_manager, {
         STREQUALS(manager.GetCurrentResourceContext().c_str(), "");
 
         engine.Shutdown();
+    });
+
+    // ==================== Root entity ====================
+
+    IT("child entities should be removed", {
+        TestManagerHelper::CreateTestResource("child-entities", R"({
+            "name": "child-entities",
+            "version": "1.0.0",
+            "mafiahub": {
+                "server": "main.js"
+            }
+        })");
+        TestManagerHelper::CreateTestScript("child-entities", "main.js", "// empty script");
+
+        NodeEngine engine;
+        flecs::world world;
+
+        EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
+
+        ResourceManagerConfig config;
+        config.resourcesPath = TestManagerHelper::GetTestResourcePath();
+
+        flecs::entity root;
+        {
+            ResourceManager manager(&engine, &world, config);
+
+            manager.DiscoverResources();
+            manager.StartResource("child-entities");
+
+            const Resource *resource = manager.GetResource("child-entities");
+            flecs::entity childEntity = world.entity("child");
+            root = resource->GetRootEntity();
+            childEntity.child_of(root);
+
+            int beforeChildCount = 0;
+            root.children([&](flecs::entity) {
+                beforeChildCount++;
+            });
+
+            manager.StopResource("child-entities");
+
+            int childCount = 0;
+            root.children([&](flecs::entity) {
+                childCount++;
+            });
+
+            EQUALS(beforeChildCount, 1);
+            EQUALS(childCount, 0);
+            EQUALS(root.is_alive(), true); // Root entity should be alive even if resource is stopped
+        }
+
+        EQUALS(root.is_alive(), false);
+
+        engine.Shutdown();
+        TestManagerHelper::Cleanup();
     });
 
     // ==================== Cleanup ====================

--- a/code/tests/modules/resource_ut.h
+++ b/code/tests/modules/resource_ut.h
@@ -102,7 +102,8 @@ MODULE(resource, {
             "description": "A test resource"
         })");
 
-        Resource resource(TestResourceHelper::GetTestResourcePath() + "/pkg-test-1");
+        flecs::world world;
+        Resource resource(TestResourceHelper::GetTestResourcePath() + "/pkg-test-1", &world);
 
         EQUALS(resource.IsManifestValid(), true);
         STREQUALS(resource.GetName().c_str(), "pkg-test-1");
@@ -129,7 +130,8 @@ MODULE(resource, {
             resourceDir.createDirectory();
         }
 
-        Resource resource(resourcePath);
+        flecs::world world;
+        Resource resource(resourcePath, &world);
 
         EQUALS(resource.IsManifestValid(), false);
         EQUALS(resource.GetState(), ResourceState::Error);
@@ -143,7 +145,8 @@ MODULE(resource, {
             "version": "1.0.0"
         })");
 
-        Resource resource(TestResourceHelper::GetTestResourcePath() + "/pkg-test-2");
+        flecs::world world;
+        Resource resource(TestResourceHelper::GetTestResourcePath() + "/pkg-test-2", &world);
 
         EQUALS(resource.IsManifestValid(), false);
         EQUALS(resource.GetState(), ResourceState::Error);
@@ -158,7 +161,8 @@ MODULE(resource, {
         })");
 
         // Path with trailing slash
-        Resource resource(TestResourceHelper::GetTestResourcePath() + "/path-test/");
+        flecs::world world;
+        Resource resource(TestResourceHelper::GetTestResourcePath() + "/path-test/", &world);
 
         EQUALS(resource.IsManifestValid(), true);
         STREQUALS(resource.GetName().c_str(), "path-test");
@@ -174,7 +178,8 @@ MODULE(resource, {
             "version": "1.0.0"
         })");
 
-        Resource resource(TestResourceHelper::GetTestResourcePath() + "/state-test-1");
+        flecs::world world;
+        Resource resource(TestResourceHelper::GetTestResourcePath() + "/state-test-1", &world);
 
         EQUALS(resource.GetState(), ResourceState::Unloaded);
         EQUALS(resource.IsRunning(), false);
@@ -189,7 +194,8 @@ MODULE(resource, {
             "version": "1.0.0"
         })");
 
-        Resource resource(TestResourceHelper::GetTestResourcePath() + "/state-test-2");
+        flecs::world world;
+        Resource resource(TestResourceHelper::GetTestResourcePath() + "/state-test-2", &world);
 
         EQUALS(resource.GetState(), ResourceState::Error);
         EQUALS(resource.IsRunning(), false);
@@ -211,7 +217,8 @@ MODULE(resource, {
             }
         })");
 
-        Resource resource(TestResourceHelper::GetTestResourcePath() + "/entry-test");
+        flecs::world world;
+        Resource resource(TestResourceHelper::GetTestResourcePath() + "/entry-test", &world);
 
         std::string serverEntry = resource.GetServerEntryPoint();
         std::string clientEntry = resource.GetClientEntryPoint();
@@ -229,7 +236,8 @@ MODULE(resource, {
             "version": "1.0.0"
         })");
 
-        Resource resource(TestResourceHelper::GetTestResourcePath() + "/no-entry");
+        flecs::world world;
+        Resource resource(TestResourceHelper::GetTestResourcePath() + "/no-entry", &world);
 
         STREQUALS(resource.GetServerEntryPoint().c_str(), "");
         STREQUALS(resource.GetClientEntryPoint().c_str(), "");
@@ -248,7 +256,8 @@ MODULE(resource, {
             }
         })");
 
-        Resource resource(TestResourceHelper::GetTestResourcePath() + "/export-test");
+        flecs::world world;
+        Resource resource(TestResourceHelper::GetTestResourcePath() + "/export-test", &world);
 
         EQUALS(resource.HasExport("getData"), true);
         EQUALS(resource.HasExport("setConfig"), true);
@@ -271,7 +280,8 @@ MODULE(resource, {
             }
         })");
 
-        Resource resource(TestResourceHelper::GetTestResourcePath() + "/depends-test");
+        flecs::world world;
+        Resource resource(TestResourceHelper::GetTestResourcePath() + "/depends-test", &world);
 
         EQUALS(resource.DependsOn("core"), true);
         EQUALS(resource.DependsOn("utils"), true);
@@ -288,7 +298,8 @@ MODULE(resource, {
             "version": "1.0.0"
         })");
 
-        Resource resource(TestResourceHelper::GetTestResourcePath() + "/restart-test-1");
+        flecs::world world;
+        Resource resource(TestResourceHelper::GetTestResourcePath() + "/restart-test-1", &world);
 
         EQUALS(resource.GetRestartAttemptCount(), 0);
 
@@ -308,7 +319,8 @@ MODULE(resource, {
             "version": "1.0.0"
         })");
 
-        Resource resource(TestResourceHelper::GetTestResourcePath() + "/restart-test-2");
+        flecs::world world;
+        Resource resource(TestResourceHelper::GetTestResourcePath() + "/restart-test-2", &world);
 
         resource.RecordRestartAttempt();
         resource.RecordRestartAttempt();
@@ -326,7 +338,8 @@ MODULE(resource, {
             "version": "1.0.0"
         })");
 
-        Resource resource(TestResourceHelper::GetTestResourcePath() + "/backoff-test");
+        flecs::world world;
+        Resource resource(TestResourceHelper::GetTestResourcePath() + "/backoff-test", &world);
 
         EQUALS(resource.GetRestartBackoffMs(), 0);
 
@@ -349,7 +362,8 @@ MODULE(resource, {
             "version": "1.0.0"
         })");
 
-        Resource original(TestResourceHelper::GetTestResourcePath() + "/move-test-1");
+        flecs::world world;
+        Resource original(TestResourceHelper::GetTestResourcePath() + "/move-test-1", &world);
         original.RecordRestartAttempt();
 
         Resource moved(std::move(original));
@@ -371,8 +385,9 @@ MODULE(resource, {
             "version": "2.0.0"
         })");
 
-        Resource original(TestResourceHelper::GetTestResourcePath() + "/move-test-2a");
-        Resource target(TestResourceHelper::GetTestResourcePath() + "/move-test-2b");
+        flecs::world world;
+        Resource original(TestResourceHelper::GetTestResourcePath() + "/move-test-2a", &world);
+        Resource target(TestResourceHelper::GetTestResourcePath() + "/move-test-2b", &world);
 
         target = std::move(original);
 
@@ -391,9 +406,34 @@ MODULE(resource, {
         })");
 
         std::string expectedPath = TestResourceHelper::GetTestResourcePath() + "/path-access";
-        Resource resource(expectedPath);
+        flecs::world world;
+        Resource resource(expectedPath, &world);
 
         STREQUALS(resource.GetPath().c_str(), expectedPath.c_str());
+
+        TestResourceHelper::Cleanup();
+    });
+
+    // ==================== Root entity ====================
+
+    IT("Resource creates root resource", {
+        TestResourceHelper::CreateTestResource("fooResource", R"({
+            "name": "foo-bar",
+            "version": "1.0.0"
+        })");
+
+        std::string expectedPath = TestResourceHelper::GetTestResourcePath() + "/fooResource";
+        flecs::world world;
+        flecs::entity root;
+        {
+            Resource resource(expectedPath, &world);
+
+            root = resource.GetRootEntity();
+            EQUALS(root.is_alive(), true);
+            STREQUALS(root.name().c_str(), "foo-bar");
+            EQUALS(root.get<OwnedResource>().value, &resource);
+        }
+        EQUALS(root.is_alive(), false);
 
         TestResourceHelper::Cleanup();
     });

--- a/code/tests/modules/timer_context_ut.h
+++ b/code/tests/modules/timer_context_ut.h
@@ -126,9 +126,10 @@ MODULE(timer_context, {
         NodeEngine engine({});
         EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
 
+        flecs::world world;
         ResourceManagerConfig config;
         config.resourcesPath = TimerContextTestHelper::GetTestPath();
-        ResourceManager manager(&engine, config);
+        ResourceManager manager(&engine, &world, config);
         manager.DiscoverResources();
 
         {
@@ -180,9 +181,10 @@ MODULE(timer_context, {
         NodeEngine engine({});
         EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
 
+        flecs::world world;
         ResourceManagerConfig config;
         config.resourcesPath = TimerContextTestHelper::GetTestPath();
-        ResourceManager manager(&engine, config);
+        ResourceManager manager(&engine, &world, config);
 
         {
             v8::Isolate *isolate = engine.GetIsolate();
@@ -216,9 +218,10 @@ MODULE(timer_context, {
         NodeEngine engine({});
         EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
 
+        flecs::world world;
         ResourceManagerConfig config;
         config.resourcesPath = TimerContextTestHelper::GetTestPath();
-        ResourceManager manager(&engine, config);
+        ResourceManager manager(&engine, &world, config);
         manager.DiscoverResources();
 
         {


### PR DESCRIPTION
This pull request adds to each resource a root entity which can be used as an handle for all entities created for given resource. When entity get added as a child of resource its lifetime is tied to resource lifetime and get automatically removed when resource stopped.

In flecs explorer an example created entity will be visible in hierarchy:
<img width="1027" height="131" alt="image" src="https://github.com/user-attachments/assets/514ddb63-c524-4fed-a0f6-21c153bd5c8c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resources are integrated with the world engine, have a root entity, and now automatically remove child entities during stop/error transitions.

* **Refactor**
  * Resource ownership and manager hierarchy moved to the world/entity system so resource entities are parented under a manager root.

* **Chores**
  * Public constructors updated to accept a world context; tests updated accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->