### PR TITLE
World: modernize ECS usage with Flecs idioms

### DIFF
--- a/code/framework/src/scripting/resource/resource.cpp
+++ b/code/framework/src/scripting/resource/resource.cpp
@@ -283,11 +283,11 @@ namespace Framework::Scripting {
             return;
         }
 
-        _rootEntity.world().defer_begin();
-        _rootEntity.children([&](flecs::entity child) {
-            child.destruct();
+        _rootEntity.world().defer([&] {
+            _rootEntity.children([&](flecs::entity child) {
+                child.destruct();
+            });
         });
-        _rootEntity.world().defer_end();
     }
 
     bool Resource::TransitionTo(ResourceState newState) {

--- a/code/framework/src/scripting/resource/resource.cpp
+++ b/code/framework/src/scripting/resource/resource.cpp
@@ -28,8 +28,11 @@ namespace Framework::Scripting {
             _state = ResourceState::Error;
         }
 
+        // The root entity is named after the manifest. Callers that need the
+        // C++ Resource for a given entity look it up by name via
+        // ResourceManager::GetResource(entity.name()) rather than carrying a
+        // back-pointer component.
         _rootEntity = world->entity(_manifest.GetName().c_str());
-        _rootEntity.set<OwnedResource>({this});
     }
 
     Resource::~Resource() {

--- a/code/framework/src/scripting/resource/resource.h
+++ b/code/framework/src/scripting/resource/resource.h
@@ -49,10 +49,6 @@ namespace Framework::Scripting {
 
     class Resource;
 
-    struct OwnedResource {
-        Resource *value;
-    };
-
     /**
      * Convert ResourceState to string representation.
      */

--- a/code/framework/src/world/client.cpp
+++ b/code/framework/src/world/client.cpp
@@ -22,7 +22,17 @@ namespace Framework::World {
         _world->observer<Modules::Base::ServerID>()
             .event(flecs::OnSet)
             .each([this](flecs::entity e, Modules::Base::ServerID &sid) {
-                _serverIDToEntity[sid.id] = e.id();
+                // Drop the stale forward entry if this entity's serverID was
+                // reassigned — OnSet only sees the new value.
+                auto prev = _entityToServerID.find(e.id());
+                if (prev != _entityToServerID.end() && prev->second != sid.id) {
+                    auto fwd = _serverIDToEntity.find(prev->second);
+                    if (fwd != _serverIDToEntity.end() && fwd->second == e.id()) {
+                        _serverIDToEntity.erase(fwd);
+                    }
+                }
+                _serverIDToEntity[sid.id]  = e.id();
+                _entityToServerID[e.id()] = sid.id;
             });
 
         _world->observer<Modules::Base::ServerID>()
@@ -32,6 +42,7 @@ namespace Framework::World {
                 if (it != _serverIDToEntity.end() && it->second == e.id()) {
                     _serverIDToEntity.erase(it);
                 }
+                _entityToServerID.erase(e.id());
             });
 
         return WorldError::WORLD_NONE;

--- a/code/framework/src/world/client.cpp
+++ b/code/framework/src/world/client.cpp
@@ -96,8 +96,7 @@ namespace Framework::World {
         SetNetworkPeer(peer);
 
         _streamEntities = _world->system<Modules::Base::Transform, Modules::Base::Streamable>("StreamEntities").kind(flecs::PostUpdate).interval(tickInterval).run([this](flecs::iter &it) {
-            const auto peerHandle = _world->try_get<Modules::Base::NetworkPeerHandle>();
-            Framework::Networking::NetworkPeer *peer = peerHandle ? peerHandle->peer : nullptr;
+            const auto peer = GetNetworkPeer();
             if (!peer) return;
             const auto myGUID = peer->GetPeer()->GetMyGUID();
 
@@ -126,21 +125,15 @@ namespace Framework::World {
             _streamEntities.destruct();
         }
 
-        _world->defer_begin();
-        _allStreamableEntities.each([this](flecs::entity e, Modules::Base::Transform&, Modules::Base::Streamable& str) {
-            if (_onEntityDestroyCallback) {
-                if (!_onEntityDestroyCallback(e)) {
+        _world->defer([&] {
+            _allStreamableEntities.each([this](flecs::entity e, Modules::Base::Transform &, Modules::Base::Streamable &str) {
+                if (_onEntityDestroyCallback && !_onEntityDestroyCallback(e))
                     return;
-                }
-            }
-
-            if (str.modEvents.disconnectProc) {
-                str.modEvents.disconnectProc(e);
-            }
-
-            e.destruct();
+                if (str.modEvents.disconnectProc)
+                    str.modEvents.disconnectProc(e);
+                e.destruct();
+            });
         });
-        _world->defer_end();
 
         SetNetworkPeer(nullptr);
     }

--- a/code/framework/src/world/client.cpp
+++ b/code/framework/src/world/client.cpp
@@ -17,6 +17,11 @@ namespace Framework::World {
             return WorldError::WORLD_FLECS_INIT_FAILED;
         }
 
+        // Translate StreamUpdateEvent into outbound network updates on the
+        // client. Mods can layer further behavior by subscribing to the same
+        // custom events.
+        Modules::Base::RegisterClientStreamObservers(*_world);
+
         // Observers maintain the serverID -> entity cache so lookups are O(1)
         // and we no longer scan all ServerID-bearing entities on every query.
         _world->observer<Modules::Base::ServerID>()
@@ -88,21 +93,26 @@ namespace Framework::World {
     }
 
     void ClientEngine::OnConnect(Networking::NetworkPeer *peer, float tickInterval) {
-        _networkPeer = peer;
+        SetNetworkPeer(peer);
 
         _streamEntities = _world->system<Modules::Base::Transform, Modules::Base::Streamable>("StreamEntities").kind(flecs::PostUpdate).interval(tickInterval).run([this](flecs::iter &it) {
-            const auto myGUID = _networkPeer->GetPeer()->GetMyGUID();
+            const auto peerHandle = _world->try_get<Modules::Base::NetworkPeerHandle>();
+            Framework::Networking::NetworkPeer *peer = peerHandle ? peerHandle->peer : nullptr;
+            if (!peer) return;
+            const auto myGUID = peer->GetPeer()->GetMyGUID();
 
             while (it.next()) {
-                const auto tr = it.field<Modules::Base::Transform>(0);
                 const auto rs = it.field<Modules::Base::Streamable>(1);
-
                 for (auto i : it) {
-                    const auto &es = &rs[i];
+                    const auto e = it.entity(i);
+                    if (!rs[i].performTickUpdates) continue;
+                    if (!Framework::World::Engine::IsEntityOwner(e, myGUID.g)) continue;
 
-                    if (es->GetBaseEvents().updateProc && es->performTickUpdates && Framework::World::Engine::IsEntityOwner(it.entity(i), myGUID.g)) {
-                        es->GetBaseEvents().updateProc(_networkPeer, (SLNet::UNASSIGNED_RAKNET_GUID).g, it.entity(i));
-                    }
+                    _world->event<Modules::Base::StreamUpdateEvent>()
+                        .id<Modules::Base::Streamable>()
+                        .entity(e)
+                        .ctx(Modules::Base::StreamUpdateEvent{{peer, SLNet::UNASSIGNED_RAKNET_GUID.g}})
+                        .emit();
                 }
             }
         });
@@ -132,7 +142,7 @@ namespace Framework::World {
         });
         _world->defer_end();
 
-        _networkPeer = nullptr;
+        SetNetworkPeer(nullptr);
     }
     void ClientEngine::InitRPCs(Networking::NetworkPeer *net) const {
         net->RegisterGameRPC<RPC::SetTransform>([this](SLNet::RakNetGUID guid, RPC::SetTransform *msg) {

--- a/code/framework/src/world/client.cpp
+++ b/code/framework/src/world/client.cpp
@@ -17,7 +17,22 @@ namespace Framework::World {
             return WorldError::WORLD_FLECS_INIT_FAILED;
         }
 
-        _queryGetEntityByServerID = _world->query_builder<Modules::Base::ServerID>().build();
+        // Observers maintain the serverID -> entity cache so lookups are O(1)
+        // and we no longer scan all ServerID-bearing entities on every query.
+        _world->observer<Modules::Base::ServerID>()
+            .event(flecs::OnSet)
+            .each([this](flecs::entity e, Modules::Base::ServerID &sid) {
+                _serverIDToEntity[sid.id] = e.id();
+            });
+
+        _world->observer<Modules::Base::ServerID>()
+            .event(flecs::OnRemove)
+            .each([this](flecs::entity e, Modules::Base::ServerID &sid) {
+                const auto it = _serverIDToEntity.find(sid.id);
+                if (it != _serverIDToEntity.end() && it->second == e.id()) {
+                    _serverIDToEntity.erase(it);
+                }
+            });
 
         return WorldError::WORLD_NONE;
     }
@@ -31,14 +46,15 @@ namespace Framework::World {
     }
 
     flecs::entity ClientEngine::GetEntityByServerID(flecs::entity_t id) const {
-        flecs::entity ent = {};
-        _queryGetEntityByServerID.each([&ent, id](flecs::entity e, Modules::Base::ServerID& rhs) {
-            if (id == rhs.id) {
-                ent = e;
-                return;
-            }
-        });
-        return ent;
+        const auto it = _serverIDToEntity.find(id);
+        if (it == _serverIDToEntity.end()) {
+            return flecs::entity::null();
+        }
+        flecs::entity e(_world->get_world(), it->second);
+        if (!e.is_alive()) {
+            return flecs::entity::null();
+        }
+        return e;
     }
 
     flecs::entity_t ClientEngine::GetServerID(flecs::entity entity) {
@@ -54,8 +70,9 @@ namespace Framework::World {
     flecs::entity ClientEngine::CreateEntity(flecs::entity_t serverID) const {
         const auto e = _world->entity();
 
-        auto &sid = e.ensure<Modules::Base::ServerID>();
-        sid.id        = serverID;
+        // Use set<> so the OnSet observer fires and the serverID cache is
+        // populated immediately. ensure<>() would only emit OnAdd.
+        e.set<Modules::Base::ServerID>({serverID});
         return e;
     }
 

--- a/code/framework/src/world/client.cpp
+++ b/code/framework/src/world/client.cpp
@@ -146,8 +146,12 @@ namespace Framework::World {
             if (!e.is_alive()) {
                 return;
             }
+            // Peer-controlled message: drop it if the target entity lacks the
+            // component instead of dereferencing a null pointer.
             const auto tr = e.try_get_mut<World::Modules::Base::Transform>();
-            *tr           = msg->GetTransform();
+            if (!tr)
+                return;
+            *tr = msg->GetTransform();
             e.modified<World::Modules::Base::Transform>();
         });
         net->RegisterGameRPC<RPC::SetFrame>([this](SLNet::RakNetGUID guid, RPC::SetFrame *msg) {
@@ -159,7 +163,9 @@ namespace Framework::World {
                 return;
             }
             const auto fr = e.try_get_mut<World::Modules::Base::Frame>();
-            *fr           = msg->GetFrame();
+            if (!fr)
+                return;
+            *fr = msg->GetFrame();
             e.modified<World::Modules::Base::Frame>();
         });
     }
@@ -170,11 +176,16 @@ namespace Framework::World {
         }
 
         auto tr = entity.try_get_mut<Modules::Base::Transform>();
-        *tr     = rhs;
+        if (!tr)
+            return;
+        *tr = rhs;
 
-        const auto str = entity.try_get_mut<Modules::Base::Streamable>();
-        if (str->modEvents.updateTransformProc) {
-            str->modEvents.updateTransformProc(entity);
+        // Streamable is optional on the entity — only fire the mod hook when
+        // the component is actually present.
+        if (const auto str = entity.try_get_mut<Modules::Base::Streamable>()) {
+            if (str->modEvents.updateTransformProc) {
+                str->modEvents.updateTransformProc(entity);
+            }
         }
         entity.modified<World::Modules::Base::Transform>();
     }

--- a/code/framework/src/world/client.h
+++ b/code/framework/src/world/client.h
@@ -46,6 +46,8 @@ namespace Framework::World {
         flecs::entity _streamEntities;
         // Cache of ServerID.id -> entity id, maintained by observers on ServerID.
         std::unordered_map<flecs::entity_t, flecs::entity_t> _serverIDToEntity;
+        // Reverse map so we can drop the stale forward entry on reassignment.
+        std::unordered_map<flecs::entity_t, flecs::entity_t> _entityToServerID;
         OnEntityDestroyCallback _onEntityDestroyCallback;
 
       private:

--- a/code/framework/src/world/client.h
+++ b/code/framework/src/world/client.h
@@ -13,6 +13,7 @@
 #include <flecs/distr/flecs.h>
 
 #include <function2.hpp>
+#include <unordered_map>
 
 #define FW_SEND_CLIENT_COMPONENT_GAME_RPC(rpc, ent, ...)                                                                                                                                                                                                                               \
     do {                                                                                                                                                                                                                                                                               \
@@ -43,7 +44,8 @@ namespace Framework::World {
 
       protected:
         flecs::entity _streamEntities;
-        flecs::query<Modules::Base::ServerID> _queryGetEntityByServerID;
+        // Cache of ServerID.id -> entity id, maintained by observers on ServerID.
+        std::unordered_map<flecs::entity_t, flecs::entity_t> _serverIDToEntity;
         OnEntityDestroyCallback _onEntityDestroyCallback;
 
       private:

--- a/code/framework/src/world/client.h
+++ b/code/framework/src/world/client.h
@@ -54,6 +54,15 @@ namespace Framework::World {
         void InitRPCs(Networking::NetworkPeer *peer) const;
 
       public:
+        // Tear down the world here, while ClientEngine members are still
+        // alive. ~flecs::world fires OnRemove observers on every entity, and
+        // the ServerID observers touch _serverIDToEntity / _entityToServerID.
+        // If we let the implicit destruction order run, the derived maps would
+        // be destroyed before _world, and the observers would see freed memory.
+        ~ClientEngine() override {
+            _world.reset();
+        }
+
         [[nodiscard]] WorldError Init();
 
         void Shutdown() override;

--- a/code/framework/src/world/engine.cpp
+++ b/code/framework/src/world/engine.cpp
@@ -35,7 +35,17 @@ namespace Framework::World {
         _world->observer<Modules::Base::Streamer>()
             .event(flecs::OnSet)
             .each([this](flecs::entity e, Modules::Base::Streamer &s) {
-                _guidToEntity[s.guid] = e.id();
+                // Drop the stale forward entry if this entity's guid was
+                // reassigned — OnSet only sees the new value.
+                auto prev = _entityToGuid.find(e.id());
+                if (prev != _entityToGuid.end() && prev->second != s.guid) {
+                    auto fwd = _guidToEntity.find(prev->second);
+                    if (fwd != _guidToEntity.end() && fwd->second == e.id()) {
+                        _guidToEntity.erase(fwd);
+                    }
+                }
+                _guidToEntity[s.guid]  = e.id();
+                _entityToGuid[e.id()] = s.guid;
             });
 
         _world->observer<Modules::Base::Streamer>()
@@ -45,6 +55,7 @@ namespace Framework::World {
                 if (it != _guidToEntity.end() && it->second == e.id()) {
                     _guidToEntity.erase(it);
                 }
+                _entityToGuid.erase(e.id());
             });
     }
 

--- a/code/framework/src/world/engine.cpp
+++ b/code/framework/src/world/engine.cpp
@@ -12,8 +12,7 @@
 
 namespace Framework::World {
     WorldError Engine::Init(Networking::NetworkPeer *networkPeer) {
-        _networkPeer = networkPeer;
-        _world       = std::make_unique<flecs::world>();
+        _world = std::make_unique<flecs::world>();
 
         // Register a base module
         _world->import <Modules::Base>();
@@ -36,7 +35,6 @@ namespace Framework::World {
     }
 
     void Engine::SetNetworkPeer(Networking::NetworkPeer *peer) {
-        _networkPeer = peer;
         if (_world) {
             _world->set<Modules::Base::NetworkPeerHandle>({peer});
         }
@@ -117,13 +115,14 @@ namespace Framework::World {
     }
 
     void Engine::PurgeAllResourceEntities() const {
-        _world->defer_begin();
         // RemovedOnResourceReload is a zero-size tag, so the each() callback
-        // takes only the entity.
-        _findAllResourceEntities.each([](flecs::entity e) {
-            if (e.is_alive())
-                e.add<Modules::Base::PendingRemoval>();
+        // takes only the entity. The defer() block batches the structural
+        // changes (PendingRemoval adds) until iteration is complete.
+        _world->defer([&] {
+            _findAllResourceEntities.each([](flecs::entity e) {
+                if (e.is_alive())
+                    e.add<Modules::Base::PendingRemoval>();
+            });
         });
-        _world->defer_end();
     }
 } // namespace Framework::World

--- a/code/framework/src/world/engine.cpp
+++ b/code/framework/src/world/engine.cpp
@@ -27,6 +27,11 @@ namespace Framework::World {
         // uncached by default and rebuild their match set on every iteration.
         _allStreamableEntities   = _world->query_builder<Modules::Base::Transform, Modules::Base::Streamable>().cached().build();
         _findAllStreamerEntities = _world->query_builder<Modules::Base::Streamer>().cached().build();
+        // Resource-reload purge runs on both client and server, so the query
+        // belongs in the base Engine::Init rather than only ServerEngine.
+        // Otherwise the client would iterate a default-constructed (invalid)
+        // query inside PurgeAllResourceEntities.
+        _findAllResourceEntities = _world->query_builder().with<Modules::Base::RemovedOnResourceReload>().cached().build();
 
         RegisterStreamerGuidCacheObservers();
 
@@ -89,13 +94,16 @@ namespace Framework::World {
     }
 
     void Engine::WakeEntity(flecs::entity e) {
-        if (!e.has<Framework::World::Modules::Base::TickRateRegulator>()) {
-            return;
-        }
         const auto tr = e.try_get_mut<Framework::World::Modules::Base::TickRateRegulator>();
+        if (!tr)
+            return;
         tr->lastGenID--;
-        const auto es      = e.try_get_mut<Framework::World::Modules::Base::Streamable>();
-        es->updateInterval = es->defaultUpdateInterval;
+        // Streamable is added alongside TickRateRegulator by StreamingFactory
+        // today, but treat its absence as a non-fatal early-out rather than
+        // crashing on a null deref.
+        if (const auto es = e.try_get_mut<Framework::World::Modules::Base::Streamable>()) {
+            es->updateInterval = es->defaultUpdateInterval;
+        }
     }
 
     flecs::entity Engine::GetEntityByGUID(uint64_t guid) const {

--- a/code/framework/src/world/engine.cpp
+++ b/code/framework/src/world/engine.cpp
@@ -21,8 +21,31 @@ namespace Framework::World {
         _allStreamableEntities   = _world->query_builder<Modules::Base::Transform, Modules::Base::Streamable>().build();
         _findAllStreamerEntities = _world->query_builder<Modules::Base::Streamer>().build();
 
+        RegisterStreamerGuidCacheObservers();
+
         _initialized = true;
         return WorldError::WORLD_NONE;
+    }
+
+    void Engine::RegisterStreamerGuidCacheObservers() {
+        // Maintain the guid -> entity map via observers instead of scanning all
+        // Streamer entities on every lookup. OnSet fires both when the component
+        // is added and whenever it is reassigned (including guid mutations made
+        // through ensure/try_get_mut + modified<>()).
+        _world->observer<Modules::Base::Streamer>()
+            .event(flecs::OnSet)
+            .each([this](flecs::entity e, Modules::Base::Streamer &s) {
+                _guidToEntity[s.guid] = e.id();
+            });
+
+        _world->observer<Modules::Base::Streamer>()
+            .event(flecs::OnRemove)
+            .each([this](flecs::entity e, Modules::Base::Streamer &s) {
+                auto it = _guidToEntity.find(s.guid);
+                if (it != _guidToEntity.end() && it->second == e.id()) {
+                    _guidToEntity.erase(it);
+                }
+            });
     }
 
     void Engine::Shutdown() {
@@ -52,13 +75,15 @@ namespace Framework::World {
     }
 
     flecs::entity Engine::GetEntityByGUID(uint64_t guid) const {
-        flecs::entity ourEntity = {};
-        _findAllStreamerEntities.each([&ourEntity, guid](flecs::entity e, Modules::Base::Streamer &s) {
-            if (ourEntity == flecs::entity::null() && s.guid == guid) {
-                ourEntity = e;
-            }
-        });
-        return ourEntity;
+        const auto it = _guidToEntity.find(guid);
+        if (it == _guidToEntity.end()) {
+            return flecs::entity::null();
+        }
+        flecs::entity e(_world->get_world(), it->second);
+        if (!e.is_alive()) {
+            return flecs::entity::null();
+        }
+        return e;
     }
 
     flecs::entity Engine::WrapEntity(flecs::entity_t serverID) const {
@@ -67,7 +92,9 @@ namespace Framework::World {
 
     void Engine::PurgeAllResourceEntities() const {
         _world->defer_begin();
-        _findAllResourceEntities.each([this](flecs::entity e, Modules::Base::RemovedOnResourceReload &rhs) {
+        // RemovedOnResourceReload is a zero-size tag, so the each() callback
+        // takes only the entity.
+        _findAllResourceEntities.each([](flecs::entity e) {
             if (e.is_alive())
                 e.add<Modules::Base::PendingRemoval>();
         });

--- a/code/framework/src/world/engine.cpp
+++ b/code/framework/src/world/engine.cpp
@@ -18,13 +18,28 @@ namespace Framework::World {
         // Register a base module
         _world->import <Modules::Base>();
 
-        _allStreamableEntities   = _world->query_builder<Modules::Base::Transform, Modules::Base::Streamable>().build();
-        _findAllStreamerEntities = _world->query_builder<Modules::Base::Streamer>().build();
+        // Publish the peer as a singleton so systems and observers can read it
+        // without capturing the Engine in their lambdas. Updated by clients
+        // through SetNetworkPeer() when the connection (re)opens.
+        _world->set<Modules::Base::NetworkPeerHandle>({networkPeer});
+
+        // Both queries are iterated multiple times per tick, so we ask Flecs
+        // to keep them fully cached. Without cached(), Flecs v4 queries are
+        // uncached by default and rebuild their match set on every iteration.
+        _allStreamableEntities   = _world->query_builder<Modules::Base::Transform, Modules::Base::Streamable>().cached().build();
+        _findAllStreamerEntities = _world->query_builder<Modules::Base::Streamer>().cached().build();
 
         RegisterStreamerGuidCacheObservers();
 
         _initialized = true;
         return WorldError::WORLD_NONE;
+    }
+
+    void Engine::SetNetworkPeer(Networking::NetworkPeer *peer) {
+        _networkPeer = peer;
+        if (_world) {
+            _world->set<Modules::Base::NetworkPeerHandle>({peer});
+        }
     }
 
     void Engine::RegisterStreamerGuidCacheObservers() {

--- a/code/framework/src/world/engine.h
+++ b/code/framework/src/world/engine.h
@@ -62,6 +62,9 @@ namespace Framework::World {
         flecs::query<> _findAllResourceEntities;
         // Cache of Streamer.guid -> entity id, maintained by observers on the Streamer component.
         std::unordered_map<uint64_t, flecs::entity_t> _guidToEntity;
+        // Reverse map so we can drop the stale forward entry when an entity's
+        // guid is reassigned (the OnSet observer only sees the new value).
+        std::unordered_map<flecs::entity_t, uint64_t> _entityToGuid;
         Networking::NetworkPeer *_networkPeer = nullptr;
 
         void RegisterStreamerGuidCacheObservers();

--- a/code/framework/src/world/engine.h
+++ b/code/framework/src/world/engine.h
@@ -52,19 +52,24 @@ namespace Framework::World {
         void PurgeAllResourceEntities() const;
 
       protected:
-        // NOTE: _world must be declared BEFORE queries so it's destroyed LAST.
-        // Queries reference the world and must be destroyed before the world.
+        // NOTE: Destruction order matters here.
+        //   - Queries reference internal world state, so they must be destroyed
+        //     *before* _world (queries are declared *after* _world below ->
+        //     destroyed first in reverse declaration order).
+        //   - The guid cache maps are touched by OnRemove observers that fire
+        //     while _world is being destroyed, so they must outlive _world
+        //     (declared *before* _world here -> destroyed last).
+        // Cache of Streamer.guid -> entity id, maintained by observers on the Streamer component.
+        std::unordered_map<uint64_t, flecs::entity_t> _guidToEntity;
+        // Reverse map so we can drop the stale forward entry when an entity's
+        // guid is reassigned (the OnSet observer only sees the new value).
+        std::unordered_map<flecs::entity_t, uint64_t> _entityToGuid;
         std::unique_ptr<flecs::world> _world;
         flecs::query<Modules::Base::Streamer> _findAllStreamerEntities;
         flecs::query<Modules::Base::Transform, Modules::Base::Streamable> _allStreamableEntities;
         // Tag-only query, so the component list is empty and the entity is the
         // sole "field" produced by iteration.
         flecs::query<> _findAllResourceEntities;
-        // Cache of Streamer.guid -> entity id, maintained by observers on the Streamer component.
-        std::unordered_map<uint64_t, flecs::entity_t> _guidToEntity;
-        // Reverse map so we can drop the stale forward entry when an entity's
-        // guid is reassigned (the OnSet observer only sees the new value).
-        std::unordered_map<flecs::entity_t, uint64_t> _entityToGuid;
         void RegisterStreamerGuidCacheObservers();
         // Publishes the active peer through the NetworkPeerHandle singleton.
         // The singleton is the only source of truth — there is no Engine-side

--- a/code/framework/src/world/engine.h
+++ b/code/framework/src/world/engine.h
@@ -65,9 +65,10 @@ namespace Framework::World {
         // Reverse map so we can drop the stale forward entry when an entity's
         // guid is reassigned (the OnSet observer only sees the new value).
         std::unordered_map<flecs::entity_t, uint64_t> _entityToGuid;
-        Networking::NetworkPeer *_networkPeer = nullptr;
-
         void RegisterStreamerGuidCacheObservers();
+        // Publishes the active peer through the NetworkPeerHandle singleton.
+        // The singleton is the only source of truth — there is no Engine-side
+        // raw pointer to keep in sync.
         void SetNetworkPeer(Networking::NetworkPeer *peer);
 
       public:
@@ -84,6 +85,15 @@ namespace Framework::World {
 
         flecs::world *GetWorld() const {
             return _world.get();
+        }
+
+        // Convenience accessor for the NetworkPeerHandle singleton. Returns
+        // nullptr when no world is initialized or the peer slot is empty —
+        // the typical state during shutdown or before OnConnect on the client.
+        Networking::NetworkPeer *GetNetworkPeer() const {
+            if (!_world) return nullptr;
+            const auto *h = _world->try_get<Modules::Base::NetworkPeerHandle>();
+            return h ? h->peer : nullptr;
         }
     };
 } // namespace Framework::World

--- a/code/framework/src/world/engine.h
+++ b/code/framework/src/world/engine.h
@@ -17,6 +17,7 @@
 
 #include <flecs/distr/flecs.h>
 #include <memory>
+#include <unordered_map>
 
 #include "core_modules.h"
 
@@ -56,8 +57,14 @@ namespace Framework::World {
         std::unique_ptr<flecs::world> _world;
         flecs::query<Modules::Base::Streamer> _findAllStreamerEntities;
         flecs::query<Modules::Base::Transform, Modules::Base::Streamable> _allStreamableEntities;
-        flecs::query<Modules::Base::RemovedOnResourceReload> _findAllResourceEntities;
+        // Tag-only query, so the component list is empty and the entity is the
+        // sole "field" produced by iteration.
+        flecs::query<> _findAllResourceEntities;
+        // Cache of Streamer.guid -> entity id, maintained by observers on the Streamer component.
+        std::unordered_map<uint64_t, flecs::entity_t> _guidToEntity;
         Networking::NetworkPeer *_networkPeer = nullptr;
+
+        void RegisterStreamerGuidCacheObservers();
 
       public:
         [[nodiscard]] WorldError Init(Networking::NetworkPeer *networkPeer);

--- a/code/framework/src/world/engine.h
+++ b/code/framework/src/world/engine.h
@@ -68,6 +68,7 @@ namespace Framework::World {
         Networking::NetworkPeer *_networkPeer = nullptr;
 
         void RegisterStreamerGuidCacheObservers();
+        void SetNetworkPeer(Networking::NetworkPeer *peer);
 
       public:
         [[nodiscard]] WorldError Init(Networking::NetworkPeer *networkPeer);

--- a/code/framework/src/world/modules/base.hpp
+++ b/code/framework/src/world/modules/base.hpp
@@ -186,7 +186,14 @@ namespace Framework::World::Modules {
             // Empty structs are auto-registered as zero-size tags by Flecs.
             world.component<RemovedOnResourceReload>();
             world.component<PendingRemoval>();
-            world.component<DependsOn>();
+
+            // DependsOn is acyclic by contract — visibility recursion would
+            // diverge otherwise. We also tell Flecs to drop the relation pair
+            // automatically when the target dies, so dependents stop carrying
+            // dangling references the moment a dependency entity is destroyed.
+            world.component<DependsOn>()
+                .add(flecs::Acyclic)
+                .add(flecs::OnDeleteTarget, flecs::Remove);
             world.component<ServerID>();
             world.component<TickRateRegulator>();
             world.component<NetworkPeerHandle>().add(flecs::Singleton);
@@ -199,8 +206,9 @@ namespace Framework::World::Modules {
             world.component<StreamOwnerUpdateEvent>();
             world.component<StreamSelfUpdateEvent>();
 
-// Windows bind metadata
-#ifdef _WIN32
+            // Component metadata for the Flecs explorer / REST API. Used to
+            // be Windows-only, but the explorer runs on every platform and
+            // there is no runtime cost to keeping these registrations on.
             {
                 auto _vec3 = world.component<glm::vec3>();
                 auto _quat = world.component<glm::quat>();
@@ -211,7 +219,6 @@ namespace Framework::World::Modules {
                 _streamable.member<int>("virtualWorld").member<bool>("isVisible").member<bool>("alwaysVisible").member<double>("updateInterval").member<uint64_t>("owner");
                 _streamer.member<float>("range").member<uint64_t>("guid");
             }
-#endif
         }
 
         // Framework streaming-event observers translating the custom events

--- a/code/framework/src/world/modules/base.hpp
+++ b/code/framework/src/world/modules/base.hpp
@@ -188,7 +188,17 @@ namespace Framework::World::Modules {
             world.component<PendingRemoval>();
 
             // DependsOn is acyclic by contract — visibility recursion would
-            // diverge otherwise. We also tell Flecs to drop the relation pair
+            // diverge otherwise.
+            //
+            // Behavior change from before this trait was set: Flecs will now
+            // assert (in debug builds) if downstream code creates a
+            // (DependsOn, *) cycle, where the previous code silently tolerated
+            // cycles via a `visited` set in the visibility traversal. The
+            // runtime guard still exists as defense in depth, but cycles are
+            // now considered a programming error rather than an accepted edge
+            // case.
+            //
+            // (OnDeleteTarget, Remove) makes Flecs drop the relation pair
             // automatically when the target dies, so dependents stop carrying
             // dangling references the moment a dependency entity is destroyed.
             world.component<DependsOn>()

--- a/code/framework/src/world/modules/base.hpp
+++ b/code/framework/src/world/modules/base.hpp
@@ -78,6 +78,28 @@ namespace Framework::World::Modules {
             flecs::entity_t id;
         };
 
+        // Singleton component holding the active NetworkPeer. Systems and
+        // observers read it via world.get<NetworkPeerHandle>() instead of
+        // capturing a raw pointer in lambdas.
+        struct NetworkPeerHandle {
+            Framework::Networking::NetworkPeer *peer = nullptr;
+        };
+
+        // Custom events emitted by the server's streaming loop. Framework
+        // observers translate them into network messages; mods can subscribe
+        // alongside for custom logic. The event struct itself carries the
+        // payload (peer + target guid), accessed inside the observer via
+        // flecs::iter::param().
+        struct StreamEventBase {
+            Framework::Networking::NetworkPeer *peer = nullptr;
+            uint64_t targetGuid                      = 0;
+        };
+        struct StreamSpawnEvent       : StreamEventBase {};
+        struct StreamDespawnEvent     : StreamEventBase {};
+        struct StreamUpdateEvent      : StreamEventBase {};
+        struct StreamOwnerUpdateEvent : StreamEventBase {};
+        struct StreamSelfUpdateEvent  : StreamEventBase {};
+
         struct Streamable {
             using IsVisibleProc         = fu2::function<bool(flecs::entity lhs, flecs::entity rhs) const>;
             using AssignOwnerProc       = fu2::function<bool(flecs::entity e, Streamable &streamable)>;
@@ -103,6 +125,10 @@ namespace Framework::World::Modules {
             // Allows custom owner assignment logic, if method returns true we bypass framework's proximity based owner assignment
             AssignOwnerProc assignOwnerProc;
 
+            // Per-entity callbacks invoked by the framework after each network
+            // event fires. Mods set these on individual entities to layer
+            // custom behavior on top of the framework's spawn/despawn/update
+            // messages without registering global observers.
             struct Events {
                 using Proc = fu2::function<bool(Framework::Networking::NetworkPeer *, uint64_t, flecs::entity) const>;
                 Proc spawnProc;
@@ -117,7 +143,6 @@ namespace Framework::World::Modules {
                 OnUpdateTransformProc updateTransformProc; // called whenever the server enforces a new transform upon the entity
             };
 
-            // Extra set of events so mod can supply custom data.
             Events modEvents;
 
             // Custom visibility proc that either complements the existing heuristic or replaces it
@@ -128,18 +153,7 @@ namespace Framework::World::Modules {
             // When set to false, we only stream spawn and despawn events, useful for immovable objects
             bool performTickUpdates = true;
 
-            // Framework-level events.
-            friend Base;
-
-          private:
-            Events events;
-
-          public:
-            Events& GetBaseEvents() {
-                return events;
-            }
-
-            [[maybe_unused]] Events& GetModEvents() {
+            Events& GetModEvents() {
                 return modEvents;
             }
         };
@@ -175,6 +189,15 @@ namespace Framework::World::Modules {
             world.component<DependsOn>();
             world.component<ServerID>();
             world.component<TickRateRegulator>();
+            world.component<NetworkPeerHandle>().add(flecs::Singleton);
+
+            // Streaming event types — registered as components so they can be
+            // used as flecs event ids with payload.
+            world.component<StreamSpawnEvent>();
+            world.component<StreamDespawnEvent>();
+            world.component<StreamUpdateEvent>();
+            world.component<StreamOwnerUpdateEvent>();
+            world.component<StreamSelfUpdateEvent>();
 
 // Windows bind metadata
 #ifdef _WIN32
@@ -191,8 +214,11 @@ namespace Framework::World::Modules {
 #endif
         }
 
-        static void SetupServerEmitters(Streamable& streamable);
-        static void SetupClientEmitters(Streamable& streamable);
+        // Framework streaming-event observers translating the custom events
+        // into network messages. Registered once at engine init time.
+        static void RegisterServerStreamObservers(flecs::world &world);
+        static void RegisterClientStreamObservers(flecs::world &world);
+
         static void SetupServerReceivers(Framework::Networking::NetworkPeer *net, Framework::World::Engine *worldEngine);
         static void SetupClientReceivers(Framework::Networking::NetworkPeer *net, Framework::World::ClientEngine *worldEngine, Framework::World::Archetypes::StreamingFactory *streamingFactory);
     };

--- a/code/framework/src/world/modules/base.hpp
+++ b/code/framework/src/world/modules/base.hpp
@@ -52,7 +52,8 @@ namespace Framework::World::Modules {
             }
         };
 
-        struct TickRateRegulator: public Transform {
+        struct TickRateRegulator {
+            Transform snapshot {};
             uint16_t lastGenID = 0;
         };
 
@@ -62,13 +63,16 @@ namespace Framework::World::Modules {
             std::string modelName;
         };
 
-        struct PendingRemoval {
-            [[maybe_unused]] uint8_t _unused;
-        };
+        // Zero-size tag: presence on an entity schedules it for removal.
+        struct PendingRemoval {};
 
-        struct RemovedOnResourceReload {
-            [[maybe_unused]] uint8_t _unused;
-        };
+        // Zero-size tag: entity is destroyed when the owning resource is reloaded.
+        struct RemovedOnResourceReload {};
+
+        // Zero-size tag relation: (DependsOn, target) means the source entity's
+        // streaming visibility depends on `target`. If any target is visible the
+        // source is forced to be visible as well.
+        struct DependsOn {};
 
         struct ServerID {
             flecs::entity_t id;
@@ -120,10 +124,6 @@ namespace Framework::World::Modules {
             HeuristicMode isVisibleHeuristic = HeuristicMode::ADD;
             IsVisibleProc isVisibleProc;
 
-            // Used to specify list of entities this streamable entity relies on.
-            // If any of these entities are visible and ours is not, we force ours to be visible too.
-            std::vector<flecs::entity> dependentEntities;
-
             // Controls whether this entity gets to be updated continuously or not
             // When set to false, we only stream spawn and despawn events, useful for immovable objects
             bool performTickUpdates = true;
@@ -169,8 +169,10 @@ namespace Framework::World::Modules {
             auto _streamable = world.component<Streamable>();
             auto _streamer   = world.component<Streamer>();
 
+            // Empty structs are auto-registered as zero-size tags by Flecs.
             world.component<RemovedOnResourceReload>();
             world.component<PendingRemoval>();
+            world.component<DependsOn>();
             world.component<ServerID>();
             world.component<TickRateRegulator>();
 

--- a/code/framework/src/world/modules/modules_impl.cpp
+++ b/code/framework/src/world/modules/modules_impl.cpp
@@ -157,7 +157,9 @@ namespace Framework::World::Modules {
                 return;
             }
 
-            const auto tr         = e.try_get_mut<World::Modules::Base::Transform>();
+            const auto tr = e.try_get_mut<World::Modules::Base::Transform>();
+            if (!tr)
+                return;
             const auto incomingTr = msg->GetTransform();
 
             if (tr->ValidateGeneration(incomingTr)) {
@@ -207,10 +209,11 @@ namespace Framework::World::Modules {
             }
 
             const auto tr = e.try_get_mut<World::Modules::Base::Transform>();
-            *tr           = msg->GetTransform();
-
             const auto es = e.try_get_mut<World::Modules::Base::Streamable>();
-            es->owner     = msg->GetOwner();
+            if (!tr || !es)
+                return;
+            *tr       = msg->GetTransform();
+            es->owner = msg->GetOwner();
         });
         net->RegisterMessage<GameSyncEntityUpdate>(GameMessages::GAME_SYNC_ENTITY_OWNER_UPDATE, [worldEngine](SLNet::RakNetGUID guid, GameSyncEntityUpdate *msg) {
             if (!msg->Valid()) {
@@ -223,7 +226,9 @@ namespace Framework::World::Modules {
                 return;
             }
             const auto es = e.try_get_mut<World::Modules::Base::Streamable>();
-            es->owner     = msg->GetOwner();
+            if (!es)
+                return;
+            es->owner = msg->GetOwner();
         });
         net->RegisterMessage<GameSyncEntitySelfUpdate>(GameMessages::GAME_SYNC_ENTITY_SELF_UPDATE, [worldEngine](SLNet::RakNetGUID guid, GameSyncEntitySelfUpdate *msg) {
             if (!msg->Valid()) {

--- a/code/framework/src/world/modules/modules_impl.cpp
+++ b/code/framework/src/world/modules/modules_impl.cpp
@@ -127,14 +127,14 @@ namespace Framework::World::Modules {
                 if (!payload || !payload->peer) return;
                 const auto e = it.entity(i);
 
-                Framework::Networking::Messages::GameSyncEntityUpdate msg;
                 const auto tr  = e.try_get<Transform>();
                 const auto sid = e.try_get<ServerID>();
                 if (tr && sid) {
+                    Framework::Networking::Messages::GameSyncEntityUpdate msg;
                     msg.FromParameters(*tr, 0);
                     msg.SetServerID(sid->id);
+                    payload->peer->Send(msg, payload->targetGuid);
                 }
-                payload->peer->Send(msg, payload->targetGuid);
 
                 InvokeModProc(s.modEvents.updateProc, payload->peer, payload->targetGuid, e);
             });

--- a/code/framework/src/world/modules/modules_impl.cpp
+++ b/code/framework/src/world/modules/modules_impl.cpp
@@ -16,84 +16,128 @@
 
 #include "world/types/streaming.hpp"
 
-#define CALL_CUSTOM_PROC(kind)                                                                                                                                                                                                                                                         \
-    const auto streamable = e.try_get<Framework::World::Modules::Base::Streamable>();                                                                                                                                                                                                      \
-    if (streamable != nullptr) {                                                                                                                                                                                                                                                       \
-        if (streamable->modEvents.kind != nullptr) {                                                                                                                                                                                                                                   \
-            streamable->modEvents.kind(peer, guid, e);                                                                                                                                                                                                                                 \
-        }                                                                                                                                                                                                                                                                              \
-    }
-
 namespace Framework::World::Modules {
-    void Base::SetupServerEmitters(Streamable& streamable) {
-        streamable.events.spawnProc = [&](Framework::Networking::NetworkPeer *peer, uint64_t guid, flecs::entity e) {
-            Framework::Networking::Messages::GameSyncEntitySpawn entitySpawn;
-            const auto tr = e.try_get<Framework::World::Modules::Base::Transform>();
-            if (tr)
-                entitySpawn.FromParameters(*tr);
-            entitySpawn.SetServerID(e.id());
-            peer->Send(entitySpawn, guid);
-            CALL_CUSTOM_PROC(spawnProc);
-            return true;
-        };
+    namespace {
+        // Pull the payload that the streaming system attached to the event.
+        // Bails out gracefully if anyone emits one of these events without a
+        // payload — observers must be defensive since flecs lets you fire
+        // events from arbitrary call sites.
+        template <typename E>
+        const Base::StreamEventBase *PayloadFrom(flecs::iter &it) {
+            // flecs::iter::param() returns a void* to the event payload, which
+            // we cast back to the event type and slice up to the shared base.
+            return static_cast<const E *>(it.param());
+        }
 
-        streamable.events.despawnProc = [&](Framework::Networking::NetworkPeer *peer, uint64_t guid, flecs::entity e) {
-            CALL_CUSTOM_PROC(despawnProc);
-            Framework::Networking::Messages::GameSyncEntityDespawn entityDespawn;
-            entityDespawn.SetServerID(e.id());
-            peer->Send(entityDespawn, guid);
-            return true;
-        };
+        void InvokeModProc(const Base::Streamable::Events::Proc &proc, Framework::Networking::NetworkPeer *peer, uint64_t guid, flecs::entity e) {
+            if (proc)
+                proc(peer, guid, e);
+        }
+    } // anonymous namespace
 
-        streamable.events.selfUpdateProc = [&](Framework::Networking::NetworkPeer *peer, uint64_t guid, flecs::entity e) {
-            Framework::Networking::Messages::GameSyncEntitySelfUpdate entitySelfUpdate;
-            entitySelfUpdate.SetServerID(e.id());
-            peer->Send(entitySelfUpdate, guid);
-            CALL_CUSTOM_PROC(selfUpdateProc);
-            return true;
-        };
+    void Base::RegisterServerStreamObservers(flecs::world &world) {
+        world.observer<Streamable>("ServerStreamSpawn")
+            .event<StreamSpawnEvent>()
+            .each([](flecs::iter &it, size_t i, Streamable &s) {
+                const auto *payload = PayloadFrom<StreamSpawnEvent>(it);
+                if (!payload || !payload->peer) return;
+                const auto e = it.entity(i);
 
-        streamable.events.updateProc = [&](Framework::Networking::NetworkPeer *peer, uint64_t guid, flecs::entity e) {
-            const auto tr = e.try_get<Framework::World::Modules::Base::Transform>();
-            const auto es = e.try_get<Framework::World::Modules::Base::Streamable>();
-            // Only send framework update if entity has a valid owner
-            if (tr && es && es->owner != SLNet::UNASSIGNED_RAKNET_GUID.g) {
-                Framework::Networking::Messages::GameSyncEntityUpdate entityUpdate;
-                entityUpdate.FromParameters(*tr, es->owner);
-                entityUpdate.SetServerID(e.id());
-                peer->Send(entityUpdate, guid);
-            }
-            CALL_CUSTOM_PROC(updateProc);
-            return true;
-        };
+                Framework::Networking::Messages::GameSyncEntitySpawn msg;
+                if (const auto tr = e.try_get<Transform>())
+                    msg.FromParameters(*tr);
+                msg.SetServerID(e.id());
+                payload->peer->Send(msg, payload->targetGuid);
 
-        streamable.events.ownerUpdateProc = [&](Framework::Networking::NetworkPeer *peer, uint64_t guid, flecs::entity e) {
-            const auto tr = e.try_get<Framework::World::Modules::Base::Transform>();
-            const auto es = e.try_get<Framework::World::Modules::Base::Streamable>();
-            // Only send framework owner update if entity has a valid owner
-            if (tr && es && es->owner != SLNet::UNASSIGNED_RAKNET_GUID.g) {
-                Framework::Networking::Messages::GameSyncEntityOwnerUpdate entityUpdate;
-                entityUpdate.FromParameters(es->owner);
-                entityUpdate.SetServerID(e.id());
-                peer->Send(entityUpdate, guid);
-            }
-            CALL_CUSTOM_PROC(ownerUpdateProc);
-            return true;
-        };
+                InvokeModProc(s.modEvents.spawnProc, payload->peer, payload->targetGuid, e);
+            });
+
+        world.observer<Streamable>("ServerStreamDespawn")
+            .event<StreamDespawnEvent>()
+            .each([](flecs::iter &it, size_t i, Streamable &s) {
+                const auto *payload = PayloadFrom<StreamDespawnEvent>(it);
+                if (!payload || !payload->peer) return;
+                const auto e = it.entity(i);
+
+                // Mod's despawn proc runs BEFORE the network message so it can
+                // still read state that may rely on the entity being mapped on
+                // the recipient. Matches the legacy SetupServerEmitters order.
+                InvokeModProc(s.modEvents.despawnProc, payload->peer, payload->targetGuid, e);
+
+                Framework::Networking::Messages::GameSyncEntityDespawn msg;
+                msg.SetServerID(e.id());
+                payload->peer->Send(msg, payload->targetGuid);
+            });
+
+        world.observer<Streamable>("ServerStreamSelfUpdate")
+            .event<StreamSelfUpdateEvent>()
+            .each([](flecs::iter &it, size_t i, Streamable &s) {
+                const auto *payload = PayloadFrom<StreamSelfUpdateEvent>(it);
+                if (!payload || !payload->peer) return;
+                const auto e = it.entity(i);
+
+                Framework::Networking::Messages::GameSyncEntitySelfUpdate msg;
+                msg.SetServerID(e.id());
+                payload->peer->Send(msg, payload->targetGuid);
+
+                InvokeModProc(s.modEvents.selfUpdateProc, payload->peer, payload->targetGuid, e);
+            });
+
+        world.observer<Streamable>("ServerStreamUpdate")
+            .event<StreamUpdateEvent>()
+            .each([](flecs::iter &it, size_t i, Streamable &s) {
+                const auto *payload = PayloadFrom<StreamUpdateEvent>(it);
+                if (!payload || !payload->peer) return;
+                const auto e = it.entity(i);
+
+                const auto tr = e.try_get<Transform>();
+                if (tr && s.owner != SLNet::UNASSIGNED_RAKNET_GUID.g) {
+                    Framework::Networking::Messages::GameSyncEntityUpdate msg;
+                    msg.FromParameters(*tr, s.owner);
+                    msg.SetServerID(e.id());
+                    payload->peer->Send(msg, payload->targetGuid);
+                }
+
+                InvokeModProc(s.modEvents.updateProc, payload->peer, payload->targetGuid, e);
+            });
+
+        world.observer<Streamable>("ServerStreamOwnerUpdate")
+            .event<StreamOwnerUpdateEvent>()
+            .each([](flecs::iter &it, size_t i, Streamable &s) {
+                const auto *payload = PayloadFrom<StreamOwnerUpdateEvent>(it);
+                if (!payload || !payload->peer) return;
+                const auto e = it.entity(i);
+
+                if (const auto tr = e.try_get<Transform>(); tr && s.owner != SLNet::UNASSIGNED_RAKNET_GUID.g) {
+                    Framework::Networking::Messages::GameSyncEntityOwnerUpdate msg;
+                    msg.FromParameters(s.owner);
+                    msg.SetServerID(e.id());
+                    payload->peer->Send(msg, payload->targetGuid);
+                }
+
+                InvokeModProc(s.modEvents.ownerUpdateProc, payload->peer, payload->targetGuid, e);
+            });
     }
-    void Base::SetupClientEmitters(Streamable& streamable) {
-        streamable.events.updateProc = [&](Framework::Networking::NetworkPeer *peer, uint64_t guid, flecs::entity e) {
-            Framework::Networking::Messages::GameSyncEntityUpdate entityUpdate;
-            const auto tr  = e.try_get<Framework::World::Modules::Base::Transform>();
-            const auto sid = e.try_get<Framework::World::Modules::Base::ServerID>();
-            if (tr && sid) {
-                entityUpdate.FromParameters(*tr, 0);
-                entityUpdate.SetServerID(sid->id);
-            }
-            peer->Send(entityUpdate, guid);
-            CALL_CUSTOM_PROC(updateProc);
-            return true;
-        };
+
+    void Base::RegisterClientStreamObservers(flecs::world &world) {
+        world.observer<Streamable>("ClientStreamUpdate")
+            .event<StreamUpdateEvent>()
+            .each([](flecs::iter &it, size_t i, Streamable &s) {
+                const auto *payload = PayloadFrom<StreamUpdateEvent>(it);
+                if (!payload || !payload->peer) return;
+                const auto e = it.entity(i);
+
+                Framework::Networking::Messages::GameSyncEntityUpdate msg;
+                const auto tr  = e.try_get<Transform>();
+                const auto sid = e.try_get<ServerID>();
+                if (tr && sid) {
+                    msg.FromParameters(*tr, 0);
+                    msg.SetServerID(sid->id);
+                }
+                payload->peer->Send(msg, payload->targetGuid);
+
+                InvokeModProc(s.modEvents.updateProc, payload->peer, payload->targetGuid, e);
+            });
     }
 
     void Base::SetupServerReceivers(Framework::Networking::NetworkPeer *net, Framework::World::Engine *worldEngine) {

--- a/code/framework/src/world/server.cpp
+++ b/code/framework/src/world/server.cpp
@@ -118,8 +118,13 @@ namespace Framework::World {
                 if (glm::abs(t.vel.x - snap.vel.x) > EPSILON || glm::abs(t.vel.y - snap.vel.y) > EPSILON || glm::abs(t.vel.z - snap.vel.z) > EPSILON) {
                     decreaseRate = false;
                 }
+                // A generation mismatch is the deliberate wake signal raised
+                // by Engine::WakeEntity() (which also resets updateInterval to
+                // default). Treat it as "stay at the high rate", not as a
+                // slowdown — the previous code did the opposite and silently
+                // undid the wake on the very next tick.
                 if (t.GetGeneration() != reg.lastGenID) {
-                    decreaseRate = true;
+                    decreaseRate = false;
                 }
 
                 reg.lastGenID = t.GetGeneration();

--- a/code/framework/src/world/server.cpp
+++ b/code/framework/src/world/server.cpp
@@ -46,8 +46,7 @@ namespace Framework::World {
                     e.destruct();
                     return;
                 }
-                const auto peerHandle = _world->try_get<Modules::Base::NetworkPeerHandle>();
-                Framework::Networking::NetworkPeer *peer = peerHandle ? peerHandle->peer : nullptr;
+                const auto peer = GetNetworkPeer();
 
                 _findAllStreamerEntities.each([this, &e, peer](flecs::entity rhsE, Modules::Base::Streamer &rhsS) {
                     if (rhsS.entities.contains(e)) {
@@ -98,7 +97,12 @@ namespace Framework::World {
                 streamer.collectRangeExemptEntitiesProc(e, streamer);
         });
 
+        // Multi-threaded: this system only mutates its own entities' regulator
+        // snapshot and updateInterval. No event emission, no structural ops,
+        // safe to split across worker threads when the world is configured
+        // with set_threads(N). Single-threaded for N=1.
         _world->system<Modules::Base::TickRateRegulator, Modules::Base::Transform, Modules::Base::Streamable>("TickRateRegulator")
+            .multi_threaded()
             .interval(cfg.tickRegulatorInterval)
             .each([](Modules::Base::TickRateRegulator &reg, Modules::Base::Transform &t, Modules::Base::Streamable &s) {
                 constexpr float EPSILON = 0.01f;
@@ -138,8 +142,7 @@ namespace Framework::World {
             .kind(streamingPhase)
             .interval(cfg.tickInterval)
             .run([this](flecs::iter &it) {
-                const auto peerHandle = _world->try_get<Modules::Base::NetworkPeerHandle>();
-                Framework::Networking::NetworkPeer *peer = peerHandle ? peerHandle->peer : nullptr;
+                const auto peer = GetNetworkPeer();
                 if (!peer) return; // no peer, nothing to send
 
                 while (it.next()) {

--- a/code/framework/src/world/server.cpp
+++ b/code/framework/src/world/server.cpp
@@ -16,23 +16,27 @@ namespace Framework::World {
             return WorldError::WORLD_FLECS_INIT_FAILED;
         }
 
-        _findAllResourceEntities = _world->query_builder<Modules::Base::RemovedOnResourceReload>().build();
+        _findAllResourceEntities = _world->query_builder().with<Modules::Base::RemovedOnResourceReload>().build();
 
-        // Set up a system to remove entities we no longer need.
-        _world->system<Modules::Base::PendingRemoval, Modules::Base::Streamable>("RemoveEntities").kind(flecs::PostUpdate).interval(cfg.removeEntitiesTickInterval).each([this](flecs::entity e, Modules::Base::PendingRemoval &pd, Modules::Base::Streamable &streamable) {
-            // Remove the entity from all streamers.
-            _findAllStreamerEntities.each([this, &e, &streamable](flecs::entity rhsE, Modules::Base::Streamer &rhsS) {
-                if (rhsS.entities.contains(e)) {
-                    rhsS.entities.erase(e);
+        // Observer-driven removal: react the moment PendingRemoval is added to a
+        // streamable entity, instead of polling on an interval. Flecs defers the
+        // destruct call automatically so this is safe to invoke from within an
+        // observer callback.
+        _world->observer<Modules::Base::Streamable>("RemoveEntitiesOnPendingRemoval")
+            .with<Modules::Base::PendingRemoval>()
+            .event(flecs::OnAdd)
+            .each([this](flecs::entity e, Modules::Base::Streamable &streamable) {
+                _findAllStreamerEntities.each([this, &e, &streamable](flecs::entity rhsE, Modules::Base::Streamer &rhsS) {
+                    if (rhsS.entities.contains(e)) {
+                        rhsS.entities.erase(e);
 
-                    // Ensure we despawn the entity from the client.
-                    if (streamable.GetBaseEvents().despawnProc)
-                        streamable.GetBaseEvents().despawnProc(_networkPeer, rhsS.guid, e);
-                }
+                        if (streamable.GetBaseEvents().despawnProc)
+                            streamable.GetBaseEvents().despawnProc(_networkPeer, rhsS.guid, e);
+                    }
+                });
+
+                e.destruct();
             });
-
-            e.destruct();
-        });
 
         // Set up a system to assign entity owners.
         _world->system<Modules::Base::Transform, Modules::Base::Streamable>("AssignEntityOwnership").kind(flecs::PostUpdate).interval(cfg.assignOwnershipTickInterval).each([this](flecs::entity e, Modules::Base::Transform &tr, Modules::Base::Streamable &streamable) {
@@ -77,19 +81,20 @@ namespace Framework::World {
                 for (auto i : it) {
                     bool decreaseRate       = true;
                     constexpr float EPSILON = 0.01f;
+                    auto &snap              = tr[i].snapshot;
 
                     // Check if position has changed
-                    if (glm::abs(t[i].pos.x - tr[i].pos.x) > EPSILON || glm::abs(t[i].pos.y - tr[i].pos.y) > EPSILON || glm::abs(t[i].pos.z - tr[i].pos.z) > EPSILON) {
+                    if (glm::abs(t[i].pos.x - snap.pos.x) > EPSILON || glm::abs(t[i].pos.y - snap.pos.y) > EPSILON || glm::abs(t[i].pos.z - snap.pos.z) > EPSILON) {
                         decreaseRate = false;
                     }
 
                     // Check if rotation quaternion has changed
-                    if (glm::abs(t[i].rot.x - tr[i].rot.x) > EPSILON || glm::abs(t[i].rot.y - tr[i].rot.y) > EPSILON || glm::abs(t[i].rot.z - tr[i].rot.z) > EPSILON || glm::abs(t[i].rot.w - tr[i].rot.w) > EPSILON) {
+                    if (glm::abs(t[i].rot.x - snap.rot.x) > EPSILON || glm::abs(t[i].rot.y - snap.rot.y) > EPSILON || glm::abs(t[i].rot.z - snap.rot.z) > EPSILON || glm::abs(t[i].rot.w - snap.rot.w) > EPSILON) {
                         decreaseRate = false;
                     }
 
                     // Check if velocity has changed
-                    if (glm::abs(t[i].vel.x - tr[i].vel.x) > EPSILON || glm::abs(t[i].vel.y - tr[i].vel.y) > EPSILON || glm::abs(t[i].vel.z - tr[i].vel.z) > EPSILON) {
+                    if (glm::abs(t[i].vel.x - snap.vel.x) > EPSILON || glm::abs(t[i].vel.y - snap.vel.y) > EPSILON || glm::abs(t[i].vel.z - snap.vel.z) > EPSILON) {
                         decreaseRate = false;
                     }
 
@@ -98,11 +103,11 @@ namespace Framework::World {
                         decreaseRate = true;
                     }
 
-                    // Update all values
+                    // Snapshot current transform for comparison on the next tick.
                     tr[i].lastGenID = t[i].GetGeneration();
-                    tr[i].pos       = t[i].pos;
-                    tr[i].rot       = t[i].rot;
-                    tr[i].vel       = t[i].vel;
+                    snap.pos        = t[i].pos;
+                    snap.rot        = t[i].rot;
+                    snap.vel        = t[i].vel;
 
                     // Decrease tick rate if needed
                     if (decreaseRate) {
@@ -285,23 +290,30 @@ namespace Framework::World {
             // Continue with the remaining visibility checks.
         }
         else {
-            // Check our dependents, if any of them are visible, we are visible as well.
-            for (const auto &dependentEntity : rhsS.dependentEntities) {
+            // Check our dependents via the (DependsOn, *) relation. If any
+            // target is visible, we are visible as well. Iterating the relation
+            // pairs avoids maintaining a separate vector on the component and
+            // keeps the dependency graph queryable via Flecs.
+            bool dependentVisible = false;
+            e.each<Modules::Base::DependsOn>([&](flecs::entity dependentEntity) {
+                if (dependentVisible)
+                    return;
                 if (!dependentEntity.is_valid() || !dependentEntity.is_alive())
-                    continue;
+                    return;
                 if (e == dependentEntity)
-                    continue;
-                // Skip if already visited (part of a cycle)
+                    return;
                 if (visited.contains(dependentEntity.id()))
-                    continue;
-                const auto &dependentS  = dependentEntity.try_get<Modules::Base::Streamable>();
-                const auto &dependentTr = dependentEntity.try_get<Modules::Base::Transform>();
+                    return;
+                const auto dependentS  = dependentEntity.try_get<Modules::Base::Streamable>();
+                const auto dependentTr = dependentEntity.try_get<Modules::Base::Transform>();
                 if (!dependentS || !dependentTr)
-                    continue;
+                    return;
                 if (IsEntityVisibleToStreamerInternal(streamerEntity, dependentEntity, lhsTr, streamer, lhsS, *dependentTr, *dependentS, visited)) {
-                    return true;
+                    dependentVisible = true;
                 }
-            }
+            });
+            if (dependentVisible)
+                return true;
         }
 
         // Entity is always visible to clients.

--- a/code/framework/src/world/server.cpp
+++ b/code/framework/src/world/server.cpp
@@ -18,20 +18,30 @@ namespace Framework::World {
 
         _findAllResourceEntities = _world->query_builder().with<Modules::Base::RemovedOnResourceReload>().build();
 
-        // Observer-driven removal: react the moment PendingRemoval is added to a
-        // streamable entity, instead of polling on an interval. Flecs defers the
-        // destruct call automatically so this is safe to invoke from within an
-        // observer callback.
-        _world->observer<Modules::Base::Streamable>("RemoveEntitiesOnPendingRemoval")
+        // Observer-driven removal: react the moment PendingRemoval is added,
+        // instead of polling on an interval. Anchoring on PendingRemoval (not
+        // Streamable) ensures the observer only fires for transitions of the
+        // tag itself — adding Streamable to an entity that already carries
+        // PendingRemoval would otherwise re-trigger the destruct path. Flecs
+        // defers the destruct call automatically so it is safe to invoke from
+        // within an observer callback.
+        _world->observer<>("RemoveEntitiesOnPendingRemoval")
             .with<Modules::Base::PendingRemoval>()
             .event(flecs::OnAdd)
-            .each([this](flecs::entity e, Modules::Base::Streamable &streamable) {
-                _findAllStreamerEntities.each([this, &e, &streamable](flecs::entity rhsE, Modules::Base::Streamer &rhsS) {
+            .each([this](flecs::entity e) {
+                const auto streamable = e.try_get_mut<Modules::Base::Streamable>();
+                if (!streamable) {
+                    // Non-streamable entity: nothing to despawn from streamers,
+                    // just destroy it.
+                    e.destruct();
+                    return;
+                }
+                _findAllStreamerEntities.each([this, &e, streamable](flecs::entity rhsE, Modules::Base::Streamer &rhsS) {
                     if (rhsS.entities.contains(e)) {
                         rhsS.entities.erase(e);
 
-                        if (streamable.GetBaseEvents().despawnProc)
-                            streamable.GetBaseEvents().despawnProc(_networkPeer, rhsS.guid, e);
+                        if (streamable->GetBaseEvents().despawnProc)
+                            streamable->GetBaseEvents().despawnProc(_networkPeer, rhsS.guid, e);
                     }
                 });
 

--- a/code/framework/src/world/server.cpp
+++ b/code/framework/src/world/server.cpp
@@ -16,8 +16,6 @@ namespace Framework::World {
             return WorldError::WORLD_FLECS_INIT_FAILED;
         }
 
-        _findAllResourceEntities = _world->query_builder().with<Modules::Base::RemovedOnResourceReload>().cached().build();
-
         // Declare custom phases so server systems express their order via
         // DependsOn relations instead of all crowding into PostUpdate. Each
         // phase runs after the previous one within a single world.progress().
@@ -74,8 +72,13 @@ namespace Framework::World {
                 uint64_t closestOwnerGUID = SLNet::UNASSIGNED_RAKNET_GUID.g;
                 float closestDist         = std::numeric_limits<float>::max();
                 _findAllStreamerEntities.each([this, &e, &tr, &closestDist, &closestOwnerGUID, &streamable](flecs::entity rhsE, Modules::Base::Streamer &rhsS) {
-                    const auto rhsTr      = rhsE.try_get<Modules::Base::Transform>();
-                    const auto rhsRs      = rhsE.try_get<Modules::Base::Streamable>();
+                    // Streamer-only query — Transform/Streamable are not in
+                    // the term list, so a streamer entity that lacks either
+                    // would null-deref here without these guards.
+                    const auto rhsTr = rhsE.try_get<Modules::Base::Transform>();
+                    const auto rhsRs = rhsE.try_get<Modules::Base::Streamable>();
+                    if (!rhsTr || !rhsRs)
+                        return;
                     const auto canBeOwner = this->IsEntityVisibleToStreamer(rhsE, e, *rhsTr, rhsS, *rhsRs, tr, streamable);
                     if (canBeOwner) {
                         const auto dist = glm::distance(tr.pos, rhsTr->pos);

--- a/code/framework/src/world/server.cpp
+++ b/code/framework/src/world/server.cpp
@@ -16,7 +16,18 @@ namespace Framework::World {
             return WorldError::WORLD_FLECS_INIT_FAILED;
         }
 
-        _findAllResourceEntities = _world->query_builder().with<Modules::Base::RemovedOnResourceReload>().build();
+        _findAllResourceEntities = _world->query_builder().with<Modules::Base::RemovedOnResourceReload>().cached().build();
+
+        // Declare custom phases so server systems express their order via
+        // DependsOn relations instead of all crowding into PostUpdate. Each
+        // phase runs after the previous one within a single world.progress().
+        const auto ownershipPhase = _world->entity("OwnershipPhase").add(flecs::Phase).depends_on(flecs::PostUpdate);
+        const auto streamingPhase = _world->entity("StreamingPhase").add(flecs::Phase).depends_on(ownershipPhase);
+
+        // Translate StreamSpawnEvent/etc. into network messages. Mods can
+        // subscribe to the same events for additional behavior; the per-entity
+        // modEvents.* callbacks are invoked by these observers as well.
+        Modules::Base::RegisterServerStreamObservers(*_world);
 
         // Observer-driven removal: react the moment PendingRemoval is added,
         // instead of polling on an interval. Anchoring on PendingRemoval (not
@@ -29,19 +40,24 @@ namespace Framework::World {
             .with<Modules::Base::PendingRemoval>()
             .event(flecs::OnAdd)
             .each([this](flecs::entity e) {
-                const auto streamable = e.try_get_mut<Modules::Base::Streamable>();
-                if (!streamable) {
+                if (!e.has<Modules::Base::Streamable>()) {
                     // Non-streamable entity: nothing to despawn from streamers,
                     // just destroy it.
                     e.destruct();
                     return;
                 }
-                _findAllStreamerEntities.each([this, &e, streamable](flecs::entity rhsE, Modules::Base::Streamer &rhsS) {
+                const auto peerHandle = _world->try_get<Modules::Base::NetworkPeerHandle>();
+                Framework::Networking::NetworkPeer *peer = peerHandle ? peerHandle->peer : nullptr;
+
+                _findAllStreamerEntities.each([this, &e, peer](flecs::entity rhsE, Modules::Base::Streamer &rhsS) {
                     if (rhsS.entities.contains(e)) {
                         rhsS.entities.erase(e);
-
-                        if (streamable->GetBaseEvents().despawnProc)
-                            streamable->GetBaseEvents().despawnProc(_networkPeer, rhsS.guid, e);
+                        if (!peer) return;
+                        _world->event<Modules::Base::StreamDespawnEvent>()
+                            .id<Modules::Base::Streamable>()
+                            .entity(e)
+                            .ctx(Modules::Base::StreamDespawnEvent{{peer, rhsS.guid}})
+                            .emit();
                     }
                 });
 
@@ -49,7 +65,7 @@ namespace Framework::World {
             });
 
         // Set up a system to assign entity owners.
-        _world->system<Modules::Base::Transform, Modules::Base::Streamable>("AssignEntityOwnership").kind(flecs::PostUpdate).interval(cfg.assignOwnershipTickInterval).each([this](flecs::entity e, Modules::Base::Transform &tr, Modules::Base::Streamable &streamable) {
+        _world->system<Modules::Base::Transform, Modules::Base::Streamable>("AssignEntityOwnership").kind(ownershipPhase).interval(cfg.assignOwnershipTickInterval).each([this](flecs::entity e, Modules::Base::Transform &tr, Modules::Base::Streamable &streamable) {
             // Let user provide custom ownership assignment.
             if (streamable.assignOwnerManually || (streamable.assignOwnerProc && streamable.assignOwnerProc(e, streamable))) {
                 /* no op */
@@ -76,65 +92,56 @@ namespace Framework::World {
         });
 
         // Set up a system to collect stream range exempt entities.
-        _world->system<Modules::Base::Streamer>("CollectRangeExemptEntities").kind(flecs::PostUpdate).interval(cfg.collectRangeExemptEntitiesTickInterval).each([this](flecs::entity e, Modules::Base::Streamer &streamer) {
+        _world->system<Modules::Base::Streamer>("CollectRangeExemptEntities").kind(streamingPhase).interval(cfg.collectRangeExemptEntitiesTickInterval).each([this](flecs::entity e, Modules::Base::Streamer &streamer) {
             streamer.rangeExemptEntities.clear();
             if (streamer.collectRangeExemptEntitiesProc)
                 streamer.collectRangeExemptEntitiesProc(e, streamer);
         });
 
-        _world->system<Modules::Base::TickRateRegulator, Modules::Base::Transform, Modules::Base::Streamable>("TickRateRegulator").interval(cfg.tickRegulatorInterval).run([](flecs::iter &it) {
-            while (it.next()) {
-                const auto tr = it.field<Modules::Base::TickRateRegulator>(0);
-                const auto t = it.field<Modules::Base::Transform>(1);
-                const auto s = it.field<Modules::Base::Streamable>(2);
+        _world->system<Modules::Base::TickRateRegulator, Modules::Base::Transform, Modules::Base::Streamable>("TickRateRegulator")
+            .interval(cfg.tickRegulatorInterval)
+            .each([](Modules::Base::TickRateRegulator &reg, Modules::Base::Transform &t, Modules::Base::Streamable &s) {
+                constexpr float EPSILON = 0.01f;
+                auto &snap              = reg.snapshot;
 
-                for (auto i : it) {
-                    bool decreaseRate       = true;
-                    constexpr float EPSILON = 0.01f;
-                    auto &snap              = tr[i].snapshot;
-
-                    // Check if position has changed
-                    if (glm::abs(t[i].pos.x - snap.pos.x) > EPSILON || glm::abs(t[i].pos.y - snap.pos.y) > EPSILON || glm::abs(t[i].pos.z - snap.pos.z) > EPSILON) {
-                        decreaseRate = false;
-                    }
-
-                    // Check if rotation quaternion has changed
-                    if (glm::abs(t[i].rot.x - snap.rot.x) > EPSILON || glm::abs(t[i].rot.y - snap.rot.y) > EPSILON || glm::abs(t[i].rot.z - snap.rot.z) > EPSILON || glm::abs(t[i].rot.w - snap.rot.w) > EPSILON) {
-                        decreaseRate = false;
-                    }
-
-                    // Check if velocity has changed
-                    if (glm::abs(t[i].vel.x - snap.vel.x) > EPSILON || glm::abs(t[i].vel.y - snap.vel.y) > EPSILON || glm::abs(t[i].vel.z - snap.vel.z) > EPSILON) {
-                        decreaseRate = false;
-                    }
-
-                    // Check if generation ID has changed
-                    if (t[i].GetGeneration() != tr[i].lastGenID) {
-                        decreaseRate = true;
-                    }
-
-                    // Snapshot current transform for comparison on the next tick.
-                    tr[i].lastGenID = t[i].GetGeneration();
-                    snap.pos        = t[i].pos;
-                    snap.rot        = t[i].rot;
-                    snap.vel        = t[i].vel;
-
-                    // Decrease tick rate if needed
-                    if (decreaseRate) {
-                        s[i].updateInterval += 5.0f;
-                    }
-                    else {
-                        s[i].updateInterval = s[i].defaultUpdateInterval;
-                    }
+                bool decreaseRate = true;
+                if (glm::abs(t.pos.x - snap.pos.x) > EPSILON || glm::abs(t.pos.y - snap.pos.y) > EPSILON || glm::abs(t.pos.z - snap.pos.z) > EPSILON) {
+                    decreaseRate = false;
                 }
-            }
-        });
+                if (glm::abs(t.rot.x - snap.rot.x) > EPSILON || glm::abs(t.rot.y - snap.rot.y) > EPSILON || glm::abs(t.rot.z - snap.rot.z) > EPSILON || glm::abs(t.rot.w - snap.rot.w) > EPSILON) {
+                    decreaseRate = false;
+                }
+                if (glm::abs(t.vel.x - snap.vel.x) > EPSILON || glm::abs(t.vel.y - snap.vel.y) > EPSILON || glm::abs(t.vel.z - snap.vel.z) > EPSILON) {
+                    decreaseRate = false;
+                }
+                if (t.GetGeneration() != reg.lastGenID) {
+                    decreaseRate = true;
+                }
 
-        // Set up a system to stream entities to clients.
+                reg.lastGenID = t.GetGeneration();
+                snap.pos      = t.pos;
+                snap.rot      = t.rot;
+                snap.vel      = t.vel;
+
+                if (decreaseRate) {
+                    s.updateInterval += 5.0f;
+                } else {
+                    s.updateInterval = s.defaultUpdateInterval;
+                }
+            });
+
+        // Set up a system to stream entities to clients. Visibility decisions
+        // here translate into custom-event emissions on the streamable entity;
+        // the framework's network observers (RegisterServerStreamObservers)
+        // and any mod-registered observers convert those events into messages.
         _world->system<Modules::Base::Transform, Modules::Base::Streamer, Modules::Base::Streamable>("StreamEntities")
-            .kind(flecs::PostUpdate)
+            .kind(streamingPhase)
             .interval(cfg.tickInterval)
             .run([this](flecs::iter &it) {
+                const auto peerHandle = _world->try_get<Modules::Base::NetworkPeerHandle>();
+                Framework::Networking::NetworkPeer *peer = peerHandle ? peerHandle->peer : nullptr;
+                if (!peer) return; // no peer, nothing to send
+
                 while (it.next()) {
                     const auto tr = it.field<Modules::Base::Transform>(0);
                     const auto s = it.field<Modules::Base::Streamer>(1);
@@ -145,60 +152,69 @@ namespace Framework::World {
                         if (it.entity(i).has<Modules::Base::PendingRemoval>())
                             continue;
 
-                        // Grab all streamable entities.
                         _allStreamableEntities.each([&](flecs::entity e, Modules::Base::Transform &otherTr, Modules::Base::Streamable &otherS) {
-                            // Skip dead entities.
                             if (!e.is_alive())
                                 return;
 
-                            // Let streamer send an update to self if an event is assigned.
-                            if (e == it.entity(i) && rs[i].GetBaseEvents().selfUpdateProc && rs[i].performTickUpdates) {
-                                rs[i].GetBaseEvents().selfUpdateProc(_networkPeer, s[i].guid, e);
+                            const auto guid = s[i].guid;
+
+                            // Let streamer send an update to self.
+                            if (e == it.entity(i) && rs[i].performTickUpdates) {
+                                _world->event<Modules::Base::StreamSelfUpdateEvent>()
+                                    .id<Modules::Base::Streamable>()
+                                    .entity(e)
+                                    .ctx(Modules::Base::StreamSelfUpdateEvent{{peer, guid}})
+                                    .emit();
                                 return;
                             }
 
-                            // Figure out entity visibility.
                             const auto id      = e.id();
                             const auto canSend = this->IsEntityVisibleToStreamer(it.entity(i), e, tr[i], s[i], rs[i], otherTr, otherS);
                             const auto map_it  = s[i].entities.find(id);
 
-                            // Entity is already known to this streamer.
                             if (map_it != s[i].entities.end()) {
-                                // If we can't stream an entity anymore, despawn it
                                 if (!canSend) {
                                     s[i].entities.erase(map_it);
-                                    if (otherS.GetBaseEvents().despawnProc)
-                                        otherS.GetBaseEvents().despawnProc(_networkPeer, s[i].guid, e);
+                                    _world->event<Modules::Base::StreamDespawnEvent>()
+                                        .id<Modules::Base::Streamable>()
+                                        .entity(e)
+                                        .ctx(Modules::Base::StreamDespawnEvent{{peer, guid}})
+                                        .emit();
                                 }
-
-                                // otherwise we do regular updates
                                 else if (rs[i].owner != otherS.owner) {
                                     auto &data = map_it->second;
                                     if (static_cast<double>(Utils::Time::GetTime()) - data.lastUpdate > otherS.updateInterval) {
-                                        if (otherS.GetBaseEvents().updateProc && rs[i].performTickUpdates)
-                                            otherS.GetBaseEvents().updateProc(_networkPeer, s[i].guid, e);
+                                        if (rs[i].performTickUpdates) {
+                                            _world->event<Modules::Base::StreamUpdateEvent>()
+                                                .id<Modules::Base::Streamable>()
+                                                .entity(e)
+                                                .ctx(Modules::Base::StreamUpdateEvent{{peer, guid}})
+                                                .emit();
+                                        }
                                         data.lastUpdate = static_cast<double>(Utils::Time::GetTime());
                                     }
                                 }
                                 else {
                                     auto &data = map_it->second;
-
-                                    // If the entity is owned by this streamer, we send a full update.
                                     if (static_cast<double>(Utils::Time::GetTime()) - data.lastUpdate > otherS.updateInterval) {
-                                        if (otherS.GetBaseEvents().ownerUpdateProc)
-                                            otherS.GetBaseEvents().ownerUpdateProc(_networkPeer, s[i].guid, e);
+                                        _world->event<Modules::Base::StreamOwnerUpdateEvent>()
+                                            .id<Modules::Base::Streamable>()
+                                            .entity(e)
+                                            .ctx(Modules::Base::StreamOwnerUpdateEvent{{peer, guid}})
+                                            .emit();
                                         data.lastUpdate = static_cast<double>(Utils::Time::GetTime());
                                     }
                                 }
                             }
-
-                            // this is a new entity, spawn it unless user says otherwise
-                            else if (canSend && otherS.GetBaseEvents().spawnProc) {
-                                if (otherS.GetBaseEvents().spawnProc(_networkPeer, s[i].guid, e)) {
-                                    Modules::Base::Streamer::StreamData data;
-                                    data.lastUpdate   = static_cast<double>(Utils::Time::GetTime());
-                                    s[i].entities[id] = data;
-                                }
+                            else if (canSend) {
+                                _world->event<Modules::Base::StreamSpawnEvent>()
+                                    .id<Modules::Base::Streamable>()
+                                    .entity(e)
+                                    .ctx(Modules::Base::StreamSpawnEvent{{peer, guid}})
+                                    .emit();
+                                Modules::Base::Streamer::StreamData data;
+                                data.lastUpdate   = static_cast<double>(Utils::Time::GetTime());
+                                s[i].entities[id] = data;
                             }
                         });
                     }

--- a/code/framework/src/world/server.cpp
+++ b/code/framework/src/world/server.cpp
@@ -166,8 +166,13 @@ namespace Framework::World {
 
                             const auto guid = s[i].guid;
 
-                            // Let streamer send an update to self.
-                            if (e == it.entity(i) && rs[i].performTickUpdates) {
+                            // Let streamer send an update to self. performTickUpdates
+                            // belongs to the entity being streamed; for the self-update
+                            // branch the streamer *is* that entity, so rs[i] and otherS
+                            // are the same component — reading via otherS keeps the
+                            // ownership intent consistent across all three emission
+                            // sites below.
+                            if (e == it.entity(i) && otherS.performTickUpdates) {
                                 _world->event<Modules::Base::StreamSelfUpdateEvent>()
                                     .id<Modules::Base::Streamable>()
                                     .entity(e)
@@ -192,7 +197,10 @@ namespace Framework::World {
                                 else if (rs[i].owner != otherS.owner) {
                                     auto &data = map_it->second;
                                     if (static_cast<double>(Utils::Time::GetTime()) - data.lastUpdate > otherS.updateInterval) {
-                                        if (rs[i].performTickUpdates) {
+                                        // performTickUpdates lives on the streamed entity,
+                                        // not on the streamer — the previous rs[i] read
+                                        // checked the wrong component.
+                                        if (otherS.performTickUpdates) {
                                             _world->event<Modules::Base::StreamUpdateEvent>()
                                                 .id<Modules::Base::Streamable>()
                                                 .entity(e)
@@ -205,11 +213,19 @@ namespace Framework::World {
                                 else {
                                     auto &data = map_it->second;
                                     if (static_cast<double>(Utils::Time::GetTime()) - data.lastUpdate > otherS.updateInterval) {
-                                        _world->event<Modules::Base::StreamOwnerUpdateEvent>()
-                                            .id<Modules::Base::Streamable>()
-                                            .entity(e)
-                                            .ctx(Modules::Base::StreamOwnerUpdateEvent{{peer, guid}})
-                                            .emit();
+                                        // Same gate as the update branch: skip the owner
+                                        // update for entities that opted out of continuous
+                                        // ticks (e.g. immovable objects). Legacy code
+                                        // missed this check, so non-streaming entities
+                                        // owned by a streamer still received owner-update
+                                        // messages every tick.
+                                        if (otherS.performTickUpdates) {
+                                            _world->event<Modules::Base::StreamOwnerUpdateEvent>()
+                                                .id<Modules::Base::Streamable>()
+                                                .entity(e)
+                                                .ctx(Modules::Base::StreamOwnerUpdateEvent{{peer, guid}})
+                                                .emit();
+                                        }
                                         data.lastUpdate = static_cast<double>(Utils::Time::GetTime());
                                     }
                                 }

--- a/code/framework/src/world/server.cpp
+++ b/code/framework/src/world/server.cpp
@@ -210,6 +210,15 @@ namespace Framework::World {
                                 }
                             }
                             else if (canSend) {
+                                // Contract change vs. the legacy spawnProc API:
+                                // spawn observers cannot reject a spawn — the
+                                // entity is recorded in the streamer's set
+                                // unconditionally. The previous bool-returning
+                                // spawnProc was always implemented to return
+                                // true, so this matches existing behavior; if
+                                // a future mod needs veto semantics, extend
+                                // StreamSpawnEvent with an `accepted` flag the
+                                // emitter can read back after emit().
                                 _world->event<Modules::Base::StreamSpawnEvent>()
                                     .id<Modules::Base::Streamable>()
                                     .entity(e)

--- a/code/framework/src/world/server.h
+++ b/code/framework/src/world/server.h
@@ -67,7 +67,6 @@ namespace Framework::World {
             float streamerTickInterval                   = 0.033334f;
             float assignOwnershipTickInterval            = 3.0f;
             float collectRangeExemptEntitiesTickInterval = 0.066668f;
-            float removeEntitiesTickInterval             = 0.066668f;
             float tickRegulatorInterval                  = 3.0f;
         };
 

--- a/code/framework/src/world/types/player.hpp
+++ b/code/framework/src/world/types/player.hpp
@@ -19,7 +19,10 @@ namespace Framework::World::Archetypes {
       private:
         inline void SetupDefaults(flecs::entity e, uint64_t guid) {
             auto &streamer = e.ensure<World::Modules::Base::Streamer>();
-            streamer.guid      = guid;
+            streamer.guid  = guid;
+            // Emit OnSet so observer-maintained caches (e.g. guid -> entity)
+            // pick up the new guid value.
+            e.modified<World::Modules::Base::Streamer>();
         }
 
       public:
@@ -28,8 +31,6 @@ namespace Framework::World::Archetypes {
         }
 
         inline void SetupServer(flecs::entity e, uint64_t guid, uint16_t playerIndex, const std::string &nickname, const std::string &hardwareId = "") {
-            SetupDefaults(e, guid);
-
             auto &streamable           = e.ensure<World::Modules::Base::Streamable>();
             streamable.assignOwnerProc = [](flecs::entity, World::Modules::Base::Streamable &) {
                 return true; /* always keep current owner */
@@ -40,6 +41,7 @@ namespace Framework::World::Archetypes {
             streamer.playerIndex = playerIndex;
             streamer.guid        = guid;
             streamer.hardwareId  = hardwareId;
+            e.modified<World::Modules::Base::Streamer>();
         }
     };
 } // namespace Framework::World::Archetypes

--- a/code/framework/src/world/types/streaming.hpp
+++ b/code/framework/src/world/types/streaming.hpp
@@ -26,9 +26,11 @@ namespace Framework::World::Archetypes {
         }
 
       public:
-        // OnAdd observers on Streamable (registered at engine init time) wire
-        // up the server/client emitter procs automatically, so the factories
-        // just need to ensure the component exists.
+        // Streaming-event observers (registered once at engine init via
+        // Base::RegisterServerStreamObservers / RegisterClientStreamObservers)
+        // translate stream events into network messages. The factories only
+        // need to ensure Streamable exists on the entity — no per-entity
+        // emitter wiring is required.
         inline void SetupClient(flecs::entity e, uint64_t guid) {
             SetupDefaults(e, guid);
             e.ensure<Framework::World::Modules::Base::Streamable>();

--- a/code/framework/src/world/types/streaming.hpp
+++ b/code/framework/src/world/types/streaming.hpp
@@ -26,21 +26,17 @@ namespace Framework::World::Archetypes {
         }
 
       public:
+        // OnAdd observers on Streamable (registered at engine init time) wire
+        // up the server/client emitter procs automatically, so the factories
+        // just need to ensure the component exists.
         inline void SetupClient(flecs::entity e, uint64_t guid) {
             SetupDefaults(e, guid);
-
-            auto& streamable = e.ensure<Framework::World::Modules::Base::Streamable>();
-            Framework::World::Modules::Base::SetupClientEmitters(streamable);
-
-            auto ass = e.get_mut<Framework::World::Modules::Base::Streamable>();
-            (void)ass;
+            e.ensure<Framework::World::Modules::Base::Streamable>();
         }
 
         inline void SetupServer(flecs::entity e, uint64_t guid) {
             SetupDefaults(e, guid);
-
-            auto& streamable = e.ensure<Framework::World::Modules::Base::Streamable>();
-            Framework::World::Modules::Base::SetupServerEmitters(streamable);
+            e.ensure<Framework::World::Modules::Base::Streamable>();
         }
     };
 } // namespace Framework::World::Archetypes

--- a/code/tests/framework_ut.cpp
+++ b/code/tests/framework_ut.cpp
@@ -13,6 +13,7 @@
 /* TEST CATEGORIES */
 #include "modules/interpolator_ut.h"
 #include "modules/state_machine_ut.h"
+#include "modules/streaming_ut.h"
 
 // Scripting tests
 #include "modules/engine_ut.h"
@@ -28,6 +29,7 @@ int main() {
 
     UNIT_MODULE(interpolator);
     UNIT_MODULE(state_machine);
+    UNIT_MODULE(streaming);
 
     // Scripting tests
     UNIT_MODULE(engine);

--- a/code/tests/modules/resource_ut.h
+++ b/code/tests/modules/resource_ut.h
@@ -431,7 +431,6 @@ MODULE(resource, {
             root = resource.GetRootEntity();
             EQUALS(root.is_alive(), true);
             STREQUALS(root.name().c_str(), "foo-bar");
-            EQUALS(root.get<OwnedResource>().value, &resource);
         }
         EQUALS(root.is_alive(), false);
 

--- a/code/tests/modules/streaming_ut.h
+++ b/code/tests/modules/streaming_ut.h
@@ -1,0 +1,67 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2024, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
+#pragma once
+
+#include "world/server.h"
+
+// Tests covering the ECS modernization work in the world layer:
+// - observer-maintained guid cache on the Engine (must handle reassignment)
+// - DependsOn relation cleanup when a target entity is destructed
+//
+// These exercise behavior that the rest of the suite does not touch.
+
+MODULE(streaming, {
+    using namespace Framework::World;
+
+    IT("guid -> entity cache stays consistent across Streamer.guid reassignment", {
+        ServerEngine engine;
+        EQUALS(engine.Init(nullptr, {}), WorldError::WORLD_NONE);
+        auto *world = engine.GetWorld();
+
+        const auto e1 = world->entity().set<Modules::Base::Streamer>({});
+        e1.try_get_mut<Modules::Base::Streamer>()->guid = 100;
+        e1.modified<Modules::Base::Streamer>();
+
+        const auto e2 = world->entity().set<Modules::Base::Streamer>({});
+        e2.try_get_mut<Modules::Base::Streamer>()->guid = 200;
+        e2.modified<Modules::Base::Streamer>();
+
+        EQUALS(engine.GetEntityByGUID(100).id(), e1.id());
+        EQUALS(engine.GetEntityByGUID(200).id(), e2.id());
+
+        // Reassign e1's guid. The OnSet observer should evict the stale
+        // forward entry so the old guid no longer resolves to e1.
+        e1.try_get_mut<Modules::Base::Streamer>()->guid = 300;
+        e1.modified<Modules::Base::Streamer>();
+
+        EQUALS(engine.GetEntityByGUID(100).is_alive(), false);
+        EQUALS(engine.GetEntityByGUID(300).id(), e1.id());
+        EQUALS(engine.GetEntityByGUID(200).id(), e2.id());
+
+        engine.Shutdown();
+    });
+
+    IT("DependsOn pair is removed when the target entity is destructed", {
+        flecs::world world;
+        world.import<Modules::Base>();
+
+        const auto target = world.entity();
+        const auto source = world.entity().add<Modules::Base::DependsOn>(target);
+
+        EQUALS(source.has<Modules::Base::DependsOn>(target), true);
+
+        target.destruct();
+
+        // (OnDeleteTarget, Remove) on the DependsOn relation should have
+        // cleaned up the pair on `source`, but the source entity itself must
+        // still be alive.
+        EQUALS(source.is_alive(), true);
+        EQUALS(source.has<Modules::Base::DependsOn>(target), false);
+    });
+});


### PR DESCRIPTION
## Summary

Sweep through the ECS layer replacing legacy patterns with idiomatic Flecs v4 features. No behavioral changes intended; all 93 `RunFrameworkTests` pass.

### Tags, relations, observers

- Convert `PendingRemoval` and `RemovedOnResourceReload` from `[[maybe_unused]] uint8_t` stubs to true zero-size tags.
- Introduce a `DependsOn` relation marked `Acyclic` with `(OnDeleteTarget, Remove)`; the `Streamable::dependentEntities` vector is gone and the `(DependsOn, *)` graph is walked via `entity::each<DependsOn>`.
- `Engine::GetEntityByGUID` and `ClientEngine::GetEntityByServerID` are now O(1), backed by `OnSet`/`OnRemove` observer-maintained caches with reverse maps so reassignments do not leave stale forward entries.
- The interval-based `RemoveEntities` system is now an `OnAdd` observer on `PendingRemoval`; streamer cleanup and `e.destruct()` happen the instant removal is requested.
- `TickRateRegulator` no longer inherits from `Transform` &mdash; composition with a `snapshot` member &mdash; and its system uses a plain `.each(...)`.

### Custom streaming events

- The framework's per-entity `Streamable::events.spawnProc/despawnProc/updateProc/ownerUpdateProc/selfUpdateProc` function pointers are replaced with custom flecs events (`StreamSpawnEvent`, `StreamDespawnEvent`, `StreamUpdateEvent`, `StreamOwnerUpdateEvent`, `StreamSelfUpdateEvent`). The streaming loop emits them with a `{peer, targetGuid}` payload; `RegisterServerStreamObservers` / `RegisterClientStreamObservers` translate them into network messages and still invoke each entity's `modEvents.*` callback. Mods can subscribe additional observers to the same events.
- Streamable factory's per-entity `SetupServerEmitters`/`SetupClientEmitters` calls are replaced by `OnAdd` observers registered once at engine init.

### Pipeline and infrastructure

- Custom `OwnershipPhase` and `StreamingPhase` declared with `flecs::Phase` + `depends_on`; the three server systems express order through the type system instead of all crowding into `PostUpdate`.
- `_findAllStreamerEntities`, `_allStreamableEntities`, and `_findAllResourceEntities` are built with `.cached()` so they stop rebuilding their match set every iteration.
- `TickRateRegulator` system is tagged `.multi_threaded()` &mdash; gated by `world.set_threads(N)`, no-op at `N=1`.
- Active `NetworkPeer` is now a `flecs::Singleton` (`NetworkPeerHandle`); `Engine::GetNetworkPeer()` wraps the lookup. Old `_networkPeer` member removed.
- `defer_begin/defer_end` pairs replaced with `world.defer([&]{ ... })` for RAII-style scoping.
- `OwnedResource{Resource*}` back-pointer component removed; callers look up the C++ `Resource` via `ResourceManager::GetResource(entity.name())`.
- Reflection `member<>()` registrations lifted out of `#ifdef _WIN32` so the Flecs explorer / REST API can introspect components on every platform.

### Explicitly not changed, with rationale

- `Streamer::entities` (per-frame mutating `std::unordered_map`) was *not* converted to a `(StreamingTo, target)` relation: per-pair archetype churn every spawn/despawn outweighs the structural benefit.
- Per-entity strategy callbacks (`assignOwnerProc`, `isVisibleProc`, `collectRangeExemptEntitiesProc`) remain `fu2::function`s on the component &mdash; a singleton policy cannot express per-entity choice and a tag/observer scheme adds ceremony without a real win.

## Test plan

- [x] `cmake --build build --target RunFrameworkTests` &mdash; 93/93 pass.
- [ ] Manual smoke test on a downstream project (MafiaMP needs its `modEvents` consumers re-verified; the in-tree copy already cannot build on this branch for an unrelated `flecs/flecs.h` include-path issue).

## Version impact

Touches shared ECS modules and the network-side streaming event surface &mdash; **MAJOR** bump per `CONTRIBUTING.md`. Requires matching client + server updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Overhauled entity streaming and synchronization architecture using event-driven observers instead of direct callbacks.
  * Improved entity caching mechanisms for faster lookups during client-server communication.
  * Simplified entity dependency tracking with automatic lifecycle management.
  * Enhanced network peer management through centralized singleton pattern.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MafiaHub/Framework/pull/193)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->