### PR TITLE
Update transform member structure in base.hpp

### DIFF
--- a/code/framework/src/world/modules/base.hpp
+++ b/code/framework/src/world/modules/base.hpp
@@ -181,7 +181,7 @@ namespace Framework::World::Modules {
                 auto _quat = world.component<glm::quat>();
                 _vec3.member<float>("x").member<float>("y").member<float>("z");
                 _quat.member<float>("w").member<float>("x").member<float>("y").member<float>("z");
-                _transform.member<glm::vec3>("pos").member<glm::quat>("rot").member<glm::vec3>("vel");
+                _transform.member<uint16_t>("generation").member<glm::vec3>("pos").member<glm::quat>("rot").member<glm::vec3>("vel");
                 _frame.member<uint64_t>("modelHash").member<glm::vec3>("scale");
                 _streamable.member<int>("virtualWorld").member<bool>("isVisible").member<bool>("alwaysVisible").member<double>("updateInterval").member<uint64_t>("owner");
                 _streamer.member<float>("range").member<uint64_t>("guid");

--- a/code/framework/src/world/modules/base.hpp
+++ b/code/framework/src/world/modules/base.hpp
@@ -181,7 +181,7 @@ namespace Framework::World::Modules {
                 auto _quat = world.component<glm::quat>();
                 _vec3.member<float>("x").member<float>("y").member<float>("z");
                 _quat.member<float>("w").member<float>("x").member<float>("y").member<float>("z");
-                _transform.member<uint16_t>("generation").member<glm::vec3>("pos").member<glm::quat>("rot").member<glm::vec3>("vel");
+                _transform.member<uint16_t>("generation").member<glm::vec3>("pos").member<glm::vec3>("vel").member<glm::quat>("rot");
                 _frame.member<uint64_t>("modelHash").member<glm::vec3>("scale");
                 _streamable.member<int>("virtualWorld").member<bool>("isVisible").member<bool>("alwaysVisible").member<double>("updateInterval").member<uint64_t>("owner");
                 _streamer.member<float>("range").member<uint64_t>("guid");


### PR DESCRIPTION
Fixes issue where flecs-explorer inproperly displays transform component.
With this change it displays everything properly, otherwise "glm::vec3::z" would be displayed as "w" component in rotation

<img width="587" height="524" alt="image" src="https://github.com/user-attachments/assets/99bf94a8-ce8c-40c5-a171-ce49cef94822" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved component metadata on Windows so the transform component now exposes a "generation" field alongside position, rotation, and velocity.
  * This enhances tooling and platform compatibility when inspecting or synchronizing component state on Windows builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MafiaHub/Framework/pull/194?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->