### PR TITLE
Fix, ids in view manager are not stable

### DIFF
--- a/code/framework/src/gui/backend/view_d3d11.cpp
+++ b/code/framework/src/gui/backend/view_d3d11.cpp
@@ -12,7 +12,7 @@
 #include "graphics/backend/d3d11.h"
 
 namespace Framework::GUI {
-    ViewD3D11::ViewD3D11(Graphics::Renderer *graphicsRenderer, Manager *manager): View(graphicsRenderer, manager) {
+    ViewD3D11::ViewD3D11(int id, Graphics::Renderer *graphicsRenderer, Manager *manager): View(id, graphicsRenderer, manager) {
     }
 
     GUIError ViewD3D11::Init(const std::string &url, int width, int height, int offsetX, int offsetY, bool gpuAccelerated) {

--- a/code/framework/src/gui/backend/view_d3d11.h
+++ b/code/framework/src/gui/backend/view_d3d11.h
@@ -29,7 +29,7 @@ namespace Framework::GUI {
         uint32_t _cpuTextureID = 0;
 
       public:
-        ViewD3D11(Graphics::Renderer *graphicsRenderer, Manager *manager);
+        ViewD3D11(int id, Graphics::Renderer *graphicsRenderer, Manager *manager);
 
         [[nodiscard]] GUIError Init(const std::string &url, int width, int height, int offsetX, int offsetY, bool gpuAccelerated = false) override;
 

--- a/code/framework/src/gui/manager.cpp
+++ b/code/framework/src/gui/manager.cpp
@@ -241,4 +241,13 @@ namespace Framework::GUI {
         }
         return views;
     }
+
+    View *Manager::GetView(int id) const {
+        for (auto it = _views.begin(); it != _views.end(); ++it) {
+            if ((*it)->GetId() == id) {
+                return it->get();
+            }
+        }
+        return nullptr;
+    }
 } // namespace Framework::GUI

--- a/code/framework/src/gui/manager.cpp
+++ b/code/framework/src/gui/manager.cpp
@@ -145,7 +145,7 @@ namespace Framework::GUI {
         std::unique_ptr<View> view;
         switch (_graphicsRenderer->GetBackendType()) {
         case Graphics::RendererBackend::BACKEND_D3D_11:
-            view = std::make_unique<ViewD3D11>(_graphicsRenderer, this);
+            view = std::make_unique<ViewD3D11>(++_id, _graphicsRenderer, this);
             break;
         default:
             Framework::Logging::GetLogger("Web")->error("Failed to create view: Unsupported renderer backend");
@@ -163,9 +163,8 @@ namespace Framework::GUI {
 
         _views.push_back(std::move(view));
 
-        const auto viewId = _views.size() - 1;
-        Framework::Logging::GetLogger("Web")->debug("Created view with id {}", viewId);
-        return static_cast<int>(viewId);
+        Framework::Logging::GetLogger("Web")->debug("Created view with id {}", _id);
+        return _id;
     }
 
     bool Manager::DestroyView(int id) {
@@ -174,13 +173,23 @@ namespace Framework::GUI {
             return false;
         }
 
-        if (id < 0 || id >= static_cast<int>(_views.size())) {
+        int index = -1;
+        int i     = 0;
+
+        for (auto it = _views.begin(); it != _views.end(); ++it, ++i) {
+            if ((*it)->GetId() == id) {
+                index = i;
+                break;
+            }
+        }
+
+        if (index == -1) {
             Framework::Logging::GetLogger("Web")->error("Failed to destroy view: View does not exist");
             return false;
         }
 
-        _views[id].reset();
-        _views.erase(_views.begin() + id);
+        _views[index].reset();
+        _views.erase(_views.begin() + index);
 
         Framework::Logging::GetLogger("Web")->debug("Destroyed view with id {}", id);
         return true;

--- a/code/framework/src/gui/manager.h
+++ b/code/framework/src/gui/manager.h
@@ -75,8 +75,6 @@ namespace Framework::GUI {
             return _viewportConfiguration;
         }
 
-        View *GetView(int id) const {
-            return _views[id].get();
-        }
+        View *GetView(int id) const;
     };
 } // namespace Framework::GUI

--- a/code/framework/src/gui/manager.h
+++ b/code/framework/src/gui/manager.h
@@ -42,6 +42,7 @@ namespace Framework::GUI {
         std::unique_ptr<SystemClipboard> _clipboard;
         Graphics::Renderer *_graphicsRenderer {};
         bool _gpuAccelerated = false;
+        int _id              = 0;
 
       public:
         Manager();

--- a/code/framework/src/gui/view.cpp
+++ b/code/framework/src/gui/view.cpp
@@ -15,8 +15,9 @@
 #include "graphics/backend/d3d11.h"
 
 namespace Framework::GUI {
-    View::View(Graphics::Renderer *graphicsRenderer, Manager *manager)
-        : _graphicsRenderer(graphicsRenderer)
+    View::View(int id, Graphics::Renderer *graphicsRenderer, Manager *manager)
+        : _id(id)
+        , _graphicsRenderer(graphicsRenderer)
         , _manager(manager)
         , _width(0)
         , _height(0)

--- a/code/framework/src/gui/view.h
+++ b/code/framework/src/gui/view.h
@@ -74,9 +74,10 @@ namespace Framework::GUI {
         std::recursive_mutex _renderMutex;
         glm::vec2 _cursorPos {};
         bool _isMouseDown = false;
+        int _id;
 
       public:
-        View(Graphics::Renderer *graphicsRenderer, Manager *manager);
+        View(int id, Graphics::Renderer *graphicsRenderer, Manager *manager);
         virtual ~View();
 
         [[nodiscard]] virtual GUIError Init(const std::string &url, int width, int height, int offsetX, int offsetY, bool gpuAccelerated = false);
@@ -86,6 +87,10 @@ namespace Framework::GUI {
 
         void ProcessMouseEvent(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
         void ProcessKeyboardEvent(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
+
+        int GetId() const {
+            return _id;
+        }
 
         void Focus(bool enable) {
             _hasFocus = enable;


### PR DESCRIPTION
Fixes issue where you create multiple views and destroy them in different order

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Views now receive explicit, unique numeric identifiers to improve tracking.
  * Creation flow updated to assign and return stable IDs when new views are made.
  * Destruction now removes views by their ID rather than by list index.
  * Added a public accessor to retrieve a view's ID.
  * Internal view construction updated to require an ID at initialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MafiaHub/Framework/pull/196?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->