### PR TITLE
CI: Fix Test Build and style checks on fork PRs

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -32,8 +32,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          submodules: recursive
-          token: ${{ secrets.FW_SERVICES_PAT }}
+          # The private services-adapter submodule is not fetched: fork PRs
+          # have no access to FW_SERVICES_PAT, and the build falls back to the
+          # public prebuilt MafiaHubServices release when it is absent.
+          submodules: false
                               
       - uses: maxim-lobanov/setup-xcode@v1
         with:

--- a/code/framework/src/external/discord/wrapper.h
+++ b/code/framework/src/external/discord/wrapper.h
@@ -7,6 +7,7 @@
  */
 
 #pragma once
+
 #include <utils/safe_win32.h>
 #include <utils/lifecycle.h>
 

--- a/code/framework/src/graphics/types.cpp
+++ b/code/framework/src/graphics/types.cpp
@@ -1,3 +1,11 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2024, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
 #include "types.h"
 
 namespace Framework::Graphics {

--- a/code/framework/src/integrations/client/scripting/module.cpp
+++ b/code/framework/src/integrations/client/scripting/module.cpp
@@ -1,3 +1,11 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2024, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
 #include "module.h"
 
 #include <logging/logger.h>

--- a/code/framework/src/integrations/client/scripting/module.h
+++ b/code/framework/src/integrations/client/scripting/module.h
@@ -1,3 +1,11 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2024, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
 #pragma once
 
 #include <function2.hpp>

--- a/code/framework/src/integrations/server/scripting/module.cpp
+++ b/code/framework/src/integrations/server/scripting/module.cpp
@@ -1,3 +1,11 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2024, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
 #include "module.h"
 
 #include <logging/logger.h>

--- a/code/framework/src/integrations/server/scripting/module.h
+++ b/code/framework/src/integrations/server/scripting/module.h
@@ -1,3 +1,11 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2024, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
 #pragma once
 
 #include <memory>

--- a/code/framework/src/logging/formatters.h
+++ b/code/framework/src/logging/formatters.h
@@ -1,3 +1,11 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2024, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
 #pragma once
 
 #include "src/world/modules/base.hpp"

--- a/code/framework/src/scripting/builtins/builtins.h
+++ b/code/framework/src/scripting/builtins/builtins.h
@@ -1,3 +1,11 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2024, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
 #pragma once
 
 #include "vector2.h"

--- a/code/framework/src/scripting/builtins/color.cpp
+++ b/code/framework/src/scripting/builtins/color.cpp
@@ -1,3 +1,11 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2024, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
 #include "color.h"
 
 #include <algorithm>

--- a/code/framework/src/scripting/builtins/color.h
+++ b/code/framework/src/scripting/builtins/color.h
@@ -1,3 +1,11 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2024, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
 #pragma once
 
 #include <v8pp/class.hpp>

--- a/code/framework/src/scripting/builtins/console.cpp
+++ b/code/framework/src/scripting/builtins/console.cpp
@@ -1,3 +1,11 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2024, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
 #include "console.h"
 #include "../resource/resource_manager.h"
 

--- a/code/framework/src/scripting/builtins/console.h
+++ b/code/framework/src/scripting/builtins/console.h
@@ -1,3 +1,11 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2024, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
 #pragma once
 
 #include <v8pp/convert.hpp>

--- a/code/framework/src/scripting/builtins/environment.cpp
+++ b/code/framework/src/scripting/builtins/environment.cpp
@@ -1,3 +1,11 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2024, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
 #include "environment.h"
 
 #include <v8pp/convert.hpp>

--- a/code/framework/src/scripting/builtins/environment.h
+++ b/code/framework/src/scripting/builtins/environment.h
@@ -1,3 +1,11 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2024, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
 #pragma once
 
 #include <v8pp/module.hpp>

--- a/code/framework/src/scripting/builtins/events.cpp
+++ b/code/framework/src/scripting/builtins/events.cpp
@@ -1,3 +1,11 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2024, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
 #include "events.h"
 #include "../engine_helpers.h"
 #include "../resource/resource_manager.h"

--- a/code/framework/src/scripting/builtins/events.h
+++ b/code/framework/src/scripting/builtins/events.h
@@ -1,3 +1,11 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2024, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
 #pragma once
 
 #include <v8pp/convert.hpp>

--- a/code/framework/src/scripting/builtins/exports.cpp
+++ b/code/framework/src/scripting/builtins/exports.cpp
@@ -1,3 +1,11 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2024, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
 #include "exports.h"
 #include "../resource/resource_manager.h"
 #include "../resource/resource.h"

--- a/code/framework/src/scripting/builtins/exports.h
+++ b/code/framework/src/scripting/builtins/exports.h
@@ -1,3 +1,11 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2024, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
 #pragma once
 
 #include <v8.h>

--- a/code/framework/src/scripting/builtins/imports.cpp
+++ b/code/framework/src/scripting/builtins/imports.cpp
@@ -1,3 +1,11 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2024, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
 #include "imports.h"
 #include "../resource/resource_manager.h"
 #include "../resource/resource.h"

--- a/code/framework/src/scripting/builtins/imports.h
+++ b/code/framework/src/scripting/builtins/imports.h
@@ -1,3 +1,11 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2024, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
 #pragma once
 
 #include <v8pp/convert.hpp>

--- a/code/framework/src/scripting/builtins/messages.cpp
+++ b/code/framework/src/scripting/builtins/messages.cpp
@@ -1,3 +1,11 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2024, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
 #include "messages.h"
 #include "../resource/resource_manager.h"
 

--- a/code/framework/src/scripting/builtins/messages.h
+++ b/code/framework/src/scripting/builtins/messages.h
@@ -1,3 +1,11 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2024, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
 #pragma once
 
 #include <v8pp/convert.hpp>

--- a/code/framework/src/scripting/builtins/quaternion.cpp
+++ b/code/framework/src/scripting/builtins/quaternion.cpp
@@ -1,3 +1,11 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2024, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
 #include "quaternion.h"
 #include "vector3.h"
 

--- a/code/framework/src/scripting/builtins/quaternion.h
+++ b/code/framework/src/scripting/builtins/quaternion.h
@@ -1,3 +1,11 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2024, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
 #pragma once
 
 #include <v8pp/class.hpp>

--- a/code/framework/src/scripting/builtins/vector2.cpp
+++ b/code/framework/src/scripting/builtins/vector2.cpp
@@ -1,3 +1,11 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2024, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
 #include "vector2.h"
 
 #include <sstream>

--- a/code/framework/src/scripting/builtins/vector2.h
+++ b/code/framework/src/scripting/builtins/vector2.h
@@ -1,3 +1,11 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2024, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
 #pragma once
 
 #include <v8pp/class.hpp>

--- a/code/framework/src/scripting/builtins/vector3.cpp
+++ b/code/framework/src/scripting/builtins/vector3.cpp
@@ -1,3 +1,11 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2024, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
 #include "vector3.h"
 
 #include <sstream>

--- a/code/framework/src/scripting/builtins/vector3.h
+++ b/code/framework/src/scripting/builtins/vector3.h
@@ -1,3 +1,11 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2024, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
 #pragma once
 
 #include <v8pp/class.hpp>

--- a/code/framework/src/scripting/builtins/vector4.cpp
+++ b/code/framework/src/scripting/builtins/vector4.cpp
@@ -1,3 +1,11 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2024, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
 #include "vector4.h"
 
 #include <sstream>

--- a/code/framework/src/scripting/builtins/vector4.h
+++ b/code/framework/src/scripting/builtins/vector4.h
@@ -1,3 +1,11 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2024, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
 #pragma once
 
 #include <v8pp/class.hpp>

--- a/code/framework/src/scripting/engine.cpp
+++ b/code/framework/src/scripting/engine.cpp
@@ -1,3 +1,11 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2024, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
 #include "engine.h"
 #include "engine_helpers.h"
 

--- a/code/framework/src/scripting/engine.h
+++ b/code/framework/src/scripting/engine.h
@@ -1,3 +1,11 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2024, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
 #pragma once
 
 // CRITICAL: Include <cerrno> BEFORE V8 headers on Windows.

--- a/code/framework/src/scripting/engine_helpers.h
+++ b/code/framework/src/scripting/engine_helpers.h
@@ -1,3 +1,11 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2024, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
 #pragma once
 
 #include <cerrno>

--- a/code/framework/src/scripting/module.h
+++ b/code/framework/src/scripting/module.h
@@ -1,3 +1,11 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2024, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
 #pragma once
 
 namespace Framework::Scripting {

--- a/code/framework/src/scripting/node_engine.cpp
+++ b/code/framework/src/scripting/node_engine.cpp
@@ -1,3 +1,11 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2024, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
 #include "node_engine.h"
 #include "engine_helpers.h"
 #include "builtins/messages.h"

--- a/code/framework/src/scripting/node_engine.h
+++ b/code/framework/src/scripting/node_engine.h
@@ -1,3 +1,11 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2024, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
 #pragma once
 
 // CRITICAL: Include <cerrno> BEFORE any Node.js/libuv headers on Windows.

--- a/code/framework/src/scripting/resource/package_manifest.cpp
+++ b/code/framework/src/scripting/resource/package_manifest.cpp
@@ -1,3 +1,11 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2024, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
 #include "package_manifest.h"
 
 #include <fstream>

--- a/code/framework/src/scripting/resource/package_manifest.h
+++ b/code/framework/src/scripting/resource/package_manifest.h
@@ -1,3 +1,11 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2024, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
 #pragma once
 
 #include <string>

--- a/code/framework/src/scripting/resource/resource.cpp
+++ b/code/framework/src/scripting/resource/resource.cpp
@@ -1,3 +1,11 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2024, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
 #include "resource.h"
 #include "world/engine.h"
 #include <filesystem>

--- a/code/framework/src/scripting/resource/resource.h
+++ b/code/framework/src/scripting/resource/resource.h
@@ -1,3 +1,11 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2024, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
 #pragma once
 
 #include "package_manifest.h"

--- a/code/framework/src/scripting/resource/resource_manager.cpp
+++ b/code/framework/src/scripting/resource/resource_manager.cpp
@@ -1,3 +1,11 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2024, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
 #include "resource_manager.h"
 
 #include "../builtins/events.h"

--- a/code/framework/src/scripting/resource/resource_manager.h
+++ b/code/framework/src/scripting/resource/resource_manager.h
@@ -1,3 +1,11 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2024, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
 #pragma once
 
 #include "resource.h"

--- a/code/framework/src/scripting/v8_engine.cpp
+++ b/code/framework/src/scripting/v8_engine.cpp
@@ -1,3 +1,11 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2024, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
 #include "v8_engine.h"
 #include "v8_engine_callbacks.h"
 #include "engine_helpers.h"

--- a/code/framework/src/scripting/v8_engine.h
+++ b/code/framework/src/scripting/v8_engine.h
@@ -1,3 +1,11 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2024, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
 #pragma once
 
 // CRITICAL: Include <cerrno> BEFORE V8 headers on Windows.

--- a/code/framework/src/scripting/v8_engine_callbacks.h
+++ b/code/framework/src/scripting/v8_engine_callbacks.h
@@ -1,3 +1,11 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2024, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
 #pragma once
 
 // V8 callbacks for V8Engine global APIs (require, timers, microtasks).

--- a/code/framework/src/scripting/v8pp_types.h
+++ b/code/framework/src/scripting/v8pp_types.h
@@ -1,3 +1,11 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2024, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
 #pragma once
 
 #include <v8pp/convert.hpp>

--- a/scripts/check_style.sh
+++ b/scripts/check_style.sh
@@ -46,6 +46,7 @@ done < <(git ls-files -- \
 	':!:vendors' \
 	':!:code/tests/unit.h' \
 	':!:code/framework/utils/hooks' \
+	':!:code/framework/src/graphics/shaders' \
 )
 
 exit_status=0

--- a/scripts/check_style_ci.sh
+++ b/scripts/check_style_ci.sh
@@ -17,10 +17,14 @@ EOF
 
   PAYLOAD="$(gen_data)"
   echo "$PAYLOAD"
-  curl \
-    -H "Accept: application/json" \
-    -H "Content-Type: application/json" \
-    --data-binary "$PAYLOAD" \
-    "$1"
+  # The webhook URL is unavailable on fork PRs (secrets are not exposed); only
+  # notify Discord when it is actually set, but always fail the job.
+  if [ -n "$1" ]; then
+    curl \
+      -H "Accept: application/json" \
+      -H "Content-Type: application/json" \
+      --data-binary "$PAYLOAD" \
+      "$1"
+  fi
   exit 1
 fi


### PR DESCRIPTION
## Problem

CI was red on fork PRs (e.g. #198) and `check_style` has been red on every `develop` commit since the check was re-enabled. Fork PRs don't receive repo secrets, which surfaced two pre-existing issues:

- **Test Build** — `build-test.yml` passed `token: ${{ secrets.FW_SERVICES_PAT }}` to `actions/checkout` to fetch the private `services-adapter` submodule. On forks the secret is empty, so checkout failed with `Input required and not supplied: token`. The submodule is optional — `services/CMakeLists.txt` downloads the prebuilt `MafiaHubServices` release when it's absent.
- **check_style** — genuine debt: 45 first-party sources missing the MafiaHub license header, generated `graphics/shaders/**` headers flagged, and a missing blank line after `#pragma once` in `discord/wrapper.h`. The empty `DISCORD_WEBHOOK` secret was also piped to `curl`, producing a malformed-URL error.

## Changes

- `build-test.yml`: drop the PAT, `submodules: false` (mirrors `check_style.yml`); build uses the public prebuilt services lib.
- `check_style.sh`: exclude generated `graphics/shaders/**`.
- `check_style_ci.sh`: only POST to the webhook when it's set; still fail the job on violations.
- `discord/wrapper.h`: blank line after `#pragma once`.
- Added the canonical license header to the 45 missing scripting/integration/logging/graphics sources.

## Verification

- `scripts/check_style.sh` → exit 0
- `scripts/check_style_ci.sh ""` (empty webhook, fork case) → exit 0, no curl error
- Test Build verified via the CMake public-release fallback; the CI on this PR exercises it for real.

Once merged, #198's checks re-run against the merge with current `develop` and go green with no action from the PR author.