### PR TITLE
Networking: hash RPCs by compiler-independent type name

### DIFF
--- a/code/framework/src/networking/rpc/game_rpc.h
+++ b/code/framework/src/networking/rpc/game_rpc.h
@@ -12,9 +12,8 @@
 #include <mafianet/MessageIdentifiers.h>
 #include <mafianet/types.h>
 #include <string>
-#include <utils/hashing.h>
 
-#include <typeinfo>
+#include "rpc_identity.h"
 
 #include "world/modules/base.hpp"
 
@@ -24,13 +23,15 @@ namespace Framework::Networking::RPC {
       private:
         MafiaNet::Packet *packet {};
         uint32_t _hashName = 0;
-        std::string _rpcName;
 
       protected:
         flecs::entity_t _serverID = 0;
 
       public:
-        IGameRPC(): _rpcName(typeid(T).name()), _hashName(Utils::Hashing::CalculateCRC32(typeid(T).name())) {};
+        // Identity comes from a compiler-independent type name (NOT typeid().name(),
+        // which differs MSVC vs GCC and breaks cross-platform RPC routing); cached
+        // per type in RPCHash/RPCName.
+        IGameRPC(): _hashName(RPCHash<T>()) {};
         void SetServerID(flecs::entity_t serverID) {
             _serverID = serverID;
         }
@@ -40,7 +41,7 @@ namespace Framework::Networking::RPC {
         }
 
         const std::string& GetName() const {
-            return _rpcName;
+            return RPCName<T>();
         }
 
         virtual void Serialize(MafiaNet::BitStream *bs, bool write) = 0;

--- a/code/framework/src/networking/rpc/rpc.h
+++ b/code/framework/src/networking/rpc/rpc.h
@@ -12,9 +12,8 @@
 #include <mafianet/MessageIdentifiers.h>
 #include <mafianet/types.h>
 #include <string>
-#include <utils/hashing.h>
 
-#include <typeinfo>
+#include "rpc_identity.h"
 
 namespace Framework::Networking::RPC {
     template <class T>
@@ -22,11 +21,13 @@ namespace Framework::Networking::RPC {
       private:
         MafiaNet::Packet *packet {};
         uint32_t _hashName = 0;
-        std::string _rpcName;
 
       public:
         virtual ~IRPC() = default;
-        IRPC(): _rpcName(typeid(T).name()), _hashName(Utils::Hashing::CalculateCRC32(typeid(T).name())) {};
+        // Identity comes from a compiler-independent type name (NOT typeid().name(),
+        // which differs MSVC vs GCC and breaks cross-platform RPC routing); cached
+        // per type in RPCHash/RPCName.
+        IRPC(): _hashName(RPCHash<T>()) {};
 
         virtual void Serialize(MafiaNet::BitStream *bs, bool write) = 0;
         virtual bool Valid() const                               = 0;
@@ -36,7 +37,7 @@ namespace Framework::Networking::RPC {
         }
 
         const std::string &GetName() const {
-            return _rpcName;
+            return RPCName<T>();
         }
 
         void SetPacket(MafiaNet::Packet *p) {

--- a/code/framework/src/networking/rpc/rpc_identity.h
+++ b/code/framework/src/networking/rpc/rpc_identity.h
@@ -1,0 +1,35 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2023, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+#include <utils/hashing.h>
+#include <utils/type_name.h>
+
+namespace Framework::Networking::RPC {
+    // Per-type RPC identity derived from a compiler-independent type name (see
+    // Utils::TypeName — NOT typeid().name(), which differs MSVC vs GCC and breaks
+    // cross-platform RPC routing). Both values are cached in function-local
+    // statics so the name string and its CRC32 are computed once per type rather
+    // than on every RPC construction, and the logic lives in one place shared by
+    // IRPC and IGameRPC.
+    template <typename T>
+    inline uint32_t RPCHash() {
+        static const uint32_t hash = Utils::Hashing::CalculateCRC32(Utils::TypeName<T>().data(), Utils::TypeName<T>().size());
+        return hash;
+    }
+
+    template <typename T>
+    inline const std::string &RPCName() {
+        static const std::string name {Utils::TypeName<T>()};
+        return name;
+    }
+} // namespace Framework::Networking::RPC

--- a/code/framework/src/utils/type_name.h
+++ b/code/framework/src/utils/type_name.h
@@ -1,0 +1,65 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2023, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
+#pragma once
+
+#include <string_view>
+
+namespace Framework::Utils {
+    // Stable, compiler-independent fully-qualified type name.
+    //
+    // typeid(T).name() is NOT portable across compilers: MSVC returns a readable
+    // decorated name ("class Foo::Bar") while the Itanium ABI (GCC/Clang) returns
+    // a mangled name ("N3Foo3BarE"). Anything that uses typeid().name() as a
+    // network identity therefore disagrees between, e.g., an MSVC Windows client
+    // and a GCC Linux server, so their RPC hashes never match.
+    //
+    // This derives the name from the compiler's own function signature and
+    // normalizes it so MSVC, GCC, and Clang all yield the SAME string for a given
+    // type, making it safe to hash as a cross-platform wire identifier.
+    template <typename T>
+    constexpr std::string_view TypeName() {
+#if defined(_MSC_VER)
+        // e.g. "...Framework::Utils::TypeName<class Foo::Bar>(void)"
+        constexpr std::string_view sig    = __FUNCSIG__;
+        constexpr std::string_view prefix = "TypeName<";
+        constexpr std::string_view suffix = ">(void)";
+#elif defined(__GNUC__) || defined(__clang__)
+        // GCC:   "...TypeName() [with T = Foo::Bar; std::string_view = ...]"
+        // Clang: "...TypeName() [T = Foo::Bar]"
+        constexpr std::string_view sig    = __PRETTY_FUNCTION__;
+        constexpr std::string_view prefix = "T = ";
+        constexpr std::string_view suffix = "]";
+#else
+#error "Framework::Utils::TypeName: unsupported compiler (needs __FUNCSIG__ or __PRETTY_FUNCTION__)"
+#endif
+        const auto begin = sig.find(prefix);
+        if (begin == std::string_view::npos)
+            return sig; // unknown compiler format — degrade rather than crash
+        const auto start = begin + prefix.size();
+        auto end         = sig.find(suffix, start);
+        if (end == std::string_view::npos)
+            end = sig.size();
+        // GCC lists further template params after a ';'; cut at the first one.
+        const auto semi = sig.find(';', start);
+        if (semi != std::string_view::npos && semi < end)
+            end = semi;
+
+        std::string_view name = sig.substr(start, end - start);
+
+        // MSVC prefixes class/struct/enum types with an elaborated-type keyword
+        // that GCC/Clang omit — strip it so the names match across compilers.
+        for (const std::string_view kw : {std::string_view {"class "}, std::string_view {"struct "}, std::string_view {"enum "}}) {
+            if (name.size() >= kw.size() && name.substr(0, kw.size()) == kw) {
+                name.remove_prefix(kw.size());
+                break;
+            }
+        }
+        return name;
+    }
+} // namespace Framework::Utils

--- a/code/tests/framework_ut.cpp
+++ b/code/tests/framework_ut.cpp
@@ -13,6 +13,7 @@
 /* TEST CATEGORIES */
 #include "modules/interpolator_ut.h"
 #include "modules/state_machine_ut.h"
+#include "modules/type_name_ut.h"
 
 // Scripting tests
 #include "modules/engine_ut.h"
@@ -28,6 +29,7 @@ int main() {
 
     UNIT_MODULE(interpolator);
     UNIT_MODULE(state_machine);
+    UNIT_MODULE(type_name);
 
     // Scripting tests
     UNIT_MODULE(engine);

--- a/code/tests/modules/type_name_ut.h
+++ b/code/tests/modules/type_name_ut.h
@@ -1,0 +1,66 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2024, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
+#pragma once
+
+#include "utils/hashing.h"
+#include "utils/type_name.h"
+
+#include <string_view>
+
+// Fixture types at namespace scope so their names are predictable. The exact
+// expected strings below are the cross-compiler contract: MSVC, GCC, and Clang
+// must all produce the SAME name for a given type (this is what makes the RPC
+// hash portable). If a compiler ever diverges, the equality checks fail on that
+// platform's CI build.
+namespace Framework::Tests::TypeNameFixture {
+    struct Alpha {};
+    class Beta {};
+    enum Gamma { GammaValue };
+    namespace Inner {
+        struct Delta {};
+    }
+} // namespace Framework::Tests::TypeNameFixture
+
+MODULE(type_name, {
+    using Framework::Utils::TypeName;
+    namespace Fx = Framework::Tests::TypeNameFixture;
+
+    IT("returns the fully-qualified name, identical across compilers", {
+        EQUALS(TypeName<Fx::Alpha>() == std::string_view("Framework::Tests::TypeNameFixture::Alpha"), true);
+        EQUALS(TypeName<Fx::Beta>() == std::string_view("Framework::Tests::TypeNameFixture::Beta"), true);
+    });
+
+    IT("resolves nested namespaces", {
+        EQUALS(TypeName<Fx::Inner::Delta>() == std::string_view("Framework::Tests::TypeNameFixture::Inner::Delta"), true);
+    });
+
+    IT("strips the class/struct/enum keyword MSVC prepends", {
+        // GCC/Clang never emit these; MSVC does, and TypeName must remove them
+        // so all three agree.
+        EQUALS(TypeName<Fx::Alpha>().rfind("struct ", 0) == 0, false);
+        EQUALS(TypeName<Fx::Beta>().rfind("class ", 0) == 0, false);
+        EQUALS(TypeName<Fx::Gamma>().rfind("enum ", 0) == 0, false);
+    });
+
+    IT("handles primitive types", {
+        EQUALS(TypeName<int>() == std::string_view("int"), true);
+    });
+
+    IT("is stable across repeated calls", {
+        EQUALS(TypeName<Fx::Alpha>() == TypeName<Fx::Alpha>(), true);
+    });
+
+    IT("gives distinct types distinct names and CRC32 hashes", {
+        EQUALS(TypeName<Fx::Alpha>() == TypeName<Fx::Beta>(), false);
+
+        const auto ha = Framework::Utils::Hashing::CalculateCRC32(std::string(TypeName<Fx::Alpha>()));
+        const auto hb = Framework::Utils::Hashing::CalculateCRC32(std::string(TypeName<Fx::Beta>()));
+        EQUALS(ha == hb, false);
+    });
+});


### PR DESCRIPTION
Came across this issue when attempting to chat from a client running `hogwarts-mp` on Windows against a Ubuntu 24.04 Linux VM.

typeid(T).name() is not portable across compilers (MSVC emits a readable decorated name, the Itanium ABI a mangled one), so an MSVC client and a GCC server computed different CRC32 hashes for the same RPC type and silently dropped each other's RPCs (chat, weather, SetTransform game RPC).

Add Utils::TypeName<T>(), which normalizes __FUNCSIG__/__PRETTY_FUNCTION__ to an identical string across MSVC/GCC/Clang, plus a per-type RPC identity cache (RPCHash/RPCName) shared by IRPC and IGameRPC. Covered by unit tests in tests/modules/type_name_ut.h.

Question: Does this require a version change?

Also verified to work with Windows client against Linux server.

GHA checks will still fail until #203 is merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored RPC identity resolution mechanisms to provide consistent and reliable behavior across different compiler platforms, improving system portability and stability.

* **Tests**
  * Added comprehensive unit tests to verify type name resolution and RPC identity verification across multiple scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->