### PR TITLE
Networking: fix ID_TIMESTAMP packet-id offset (skip Time not TimeMS)

### DIFF
--- a/code/framework/src/networking/network_peer.cpp
+++ b/code/framework/src/networking/network_peer.cpp
@@ -71,20 +71,14 @@ namespace Framework::Networking {
         }
 
         for (_packet = _peer->Receive(); _packet; _peer->DeallocatePacket(_packet), _packet = _peer->Receive()) {
-            _packetDataOffset = 0;
             if (_packet->length == 0) {
                 continue;
             }
-            MafiaNet::TimeMS TS  = 0;
-            if (_packet->length > 1 + sizeof(MafiaNet::TimeMS) && _packet->data[0] == ID_TIMESTAMP) {
-                MafiaNet::BitStream timestamp(_packet->data + 1, sizeof(MafiaNet::TimeMS) + 1, false);
-                timestamp.Read(TS);
-                _packetDataOffset = 1 + sizeof(MafiaNet::TimeMS);
-            }
-
-            if (static_cast<uint32_t>(_packetDataOffset) >= _packet->length) {
+            const int offset = ResolvePacketDataOffset(_packet->data, _packet->length);
+            if (offset < 0) {
                 continue;
             }
+            _packetDataOffset = offset;
             uint8_t packetID = _packet->data[_packetDataOffset];
 
             if (!HandlePacket(packetID, _packet)) {
@@ -94,6 +88,21 @@ namespace Framework::Networking {
                 }
             }
         }
+    }
+
+    int NetworkPeer::ResolvePacketDataOffset(const uint8_t *data, uint32_t length) {
+        if (length == 0) {
+            return -1;
+        }
+        if (data[0] != ID_TIMESTAMP) {
+            return 0;
+        }
+        // ID_TIMESTAMP is followed by a MafiaNet::Time (8 bytes); a frame too short to also hold a
+        // real id is malformed — drop it rather than dispatching ID_TIMESTAMP as the id.
+        if (length <= 1 + sizeof(MafiaNet::Time)) {
+            return -1;
+        }
+        return 1 + static_cast<int>(sizeof(MafiaNet::Time));
     }
 
     const char *NetworkPeer::GetStartupResultString(uint8_t id) {

--- a/code/framework/src/networking/network_peer.h
+++ b/code/framework/src/networking/network_peer.h
@@ -137,6 +137,11 @@ namespace Framework::Networking {
         void Update() override;
         virtual bool HandlePacket(uint8_t packetID, MafiaNet::Packet *packet) = 0;
 
+        // Byte offset of the packet id in a datagram, skipping an optional ID_TIMESTAMP + 8-byte
+        // MafiaNet::Time prefix. Returns -1 if too short. Pure + tested so the skip width can't drift
+        // from what RakNet writes (a wrong width reads the id mid-timestamp — phantom control packets).
+        static int ResolvePacketDataOffset(const uint8_t *data, uint32_t length);
+
         // Server-only; base no-op lets shared code kick through a NetworkPeer* without a cast.
         virtual void KickPlayer(MafiaNet::RakNetGUID, DisconnectionReason, const std::string & = "") {}
 

--- a/code/tests/framework_ut.cpp
+++ b/code/tests/framework_ut.cpp
@@ -13,6 +13,7 @@
 /* TEST CATEGORIES */
 #include "modules/interpolator_ut.h"
 #include "modules/result_ut.h"
+#include "modules/network_packets_ut.h"
 #include "modules/state_machine_ut.h"
 
 // Scripting tests
@@ -29,6 +30,7 @@ int main() {
 
     UNIT_MODULE(interpolator);
     UNIT_MODULE(result);
+    UNIT_MODULE(network_packets);
     UNIT_MODULE(state_machine);
 
     // Scripting tests

--- a/code/tests/modules/network_packets_ut.h
+++ b/code/tests/modules/network_packets_ut.h
@@ -1,0 +1,94 @@
+#pragma once
+
+#include "networking/network_peer.h"
+#include "networking/rpc/chat_message.h"
+#include "networking/rpc/client_identity.h"
+#include "networking/rpc/server_resources.h"
+
+#include <mafianet/BitStream.h>
+
+#include <cstdint>
+#include <vector>
+
+// Networking wire-format tests: the ID_TIMESTAMP packet-id offset (a wrong skip width once read the
+// id mid-timestamp and faked an ID_CONNECTION_LOST), plus serialize/deserialize round-trips of the
+// RPC payloads so a write/read asymmetry can't slip through.
+MODULE(network_packets, {
+    using Framework::Networking::NetworkPeer;
+    namespace RPC = Framework::Networking::RPC;
+
+    IT("resolves the packet id after a full ID_TIMESTAMP + Time prefix", {
+        std::vector<uint8_t> buf;
+        buf.push_back(ID_TIMESTAMP);
+        for (size_t i = 0; i < sizeof(MafiaNet::Time); i++) {
+            buf.push_back(static_cast<uint8_t>(0x80 + i)); // arbitrary timestamp bytes
+        }
+        buf.push_back(static_cast<uint8_t>(ID_REPLICA_MANAGER_SERIALIZE));
+        buf.push_back(0x42);
+
+        const int offset = NetworkPeer::ResolvePacketDataOffset(buf.data(), static_cast<uint32_t>(buf.size()));
+        EQUALS(offset, 1 + static_cast<int>(sizeof(MafiaNet::Time)));
+        // The decisive check: the byte at the offset is the real id, not a timestamp byte.
+        EQUALS(buf[static_cast<size_t>(offset)], static_cast<uint8_t>(ID_REPLICA_MANAGER_SERIALIZE));
+    });
+
+    IT("returns offset 0 for a packet without a timestamp", {
+        std::vector<uint8_t> buf = {static_cast<uint8_t>(ID_CONNECTION_REQUEST_ACCEPTED), 0x01, 0x02};
+        EQUALS(NetworkPeer::ResolvePacketDataOffset(buf.data(), static_cast<uint32_t>(buf.size())), 0);
+    });
+
+    IT("rejects a truncated ID_TIMESTAMP frame", {
+        // Starts with ID_TIMESTAMP but can't hold the 8-byte Time plus a real id: malformed -> -1.
+        std::vector<uint8_t> buf = {static_cast<uint8_t>(ID_TIMESTAMP), 0x00, 0x01};
+        EQUALS(NetworkPeer::ResolvePacketDataOffset(buf.data(), static_cast<uint32_t>(buf.size())), -1);
+    });
+
+    IT("rejects an empty datagram", {
+        EQUALS(NetworkPeer::ResolvePacketDataOffset(nullptr, 0), -1);
+    });
+
+    IT("round-trips a ChatMessage payload", {
+        RPC::ChatMessage out {};
+        out.text = "Expecto Patronum!";
+
+        MafiaNet::BitStream bs;
+        out.Serialize(&bs, true);
+        const RPC::ChatMessage in = RPC::Read<RPC::ChatMessage>(&bs);
+        STREQUALS(in.text.c_str(), "Expecto Patronum!");
+    });
+
+    IT("round-trips a ClientIdentity payload", {
+        RPC::ClientIdentity out {};
+        out.name       = "kheartz";
+        out.steamId    = "steam-1";
+        out.discordId  = "discord-2";
+        out.hardwareId = "hw-3";
+
+        MafiaNet::BitStream bs;
+        out.Serialize(&bs, true);
+        const RPC::ClientIdentity in = RPC::Read<RPC::ClientIdentity>(&bs);
+        STREQUALS(in.name.c_str(), "kheartz");
+        STREQUALS(in.steamId.c_str(), "steam-1");
+        STREQUALS(in.discordId.c_str(), "discord-2");
+        STREQUALS(in.hardwareId.c_str(), "hw-3");
+    });
+
+    IT("round-trips a ServerResources payload with a resource list", {
+        RPC::ServerResources out {};
+        out.readyEventId = 7;
+        out.tickRate     = 0.0166f;
+        out.resources.push_back({"gamemode", "1.0.0"});
+        out.resources.push_back({"wizard-test", "0.0.1"});
+
+        MafiaNet::BitStream bs;
+        out.Serialize(&bs, true);
+        const RPC::ServerResources in = RPC::Read<RPC::ServerResources>(&bs);
+        EQUALS(in.readyEventId, 7);
+        EQUALS(in.tickRate, 0.0166f);
+        EQUALS(in.resources.size(), static_cast<size_t>(2));
+        STREQUALS(in.resources[0].name.c_str(), "gamemode");
+        STREQUALS(in.resources[0].version.c_str(), "1.0.0");
+        STREQUALS(in.resources[1].name.c_str(), "wizard-test");
+        STREQUALS(in.resources[1].version.c_str(), "0.0.1");
+    });
+});


### PR DESCRIPTION
NetworkPeer::Update skipped sizeof(TimeMS) (4 bytes) after ID_TIMESTAMP, but RakNet writes the prefix as an 8-byte MafiaNet::Time. A timestamped packet reaching the loop (e.g. a leaked ReplicaManager3 SERIALIZE) had its id read mid-timestamp and was intermittently dispatched as a phantom ID_CONNECTION_LOST, faking a disconnect right after entity replication began. (This caused a quick disconnect for the hogwarts legacy mp mod)

Extract the offset arithmetic into NetworkPeer::ResolvePacketDataOffset and cover it (plus RPC payload round-trips) in a new network_packets test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved network packet parsing to ignore empty datagrams and avoid misreading malformed payloads.
  * Refined packet ID detection to correctly handle an optional timestamp prefix and safely skip packets when the packet layout can’t be validated.

* **Tests**
  * Added unit tests covering packet ID offset detection, including edge cases (no timestamp, truncated frames, empty datagrams).
  * Added round-trip serialization/deserialization tests for selected network messages and server resource entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->