### PR TITLE
Graphics: (d3d12 pt I) report configured backend and unify D3D12 device

### DIFF
--- a/code/framework/src/graphics/backend/backend.h
+++ b/code/framework/src/graphics/backend/backend.h
@@ -15,8 +15,8 @@ namespace Framework::Graphics {
     template <typename TDevice, typename TContext, typename TSwapChain, typename TCommandQueue>
     class Backend {
       protected:
-        TDevice _device;
-        TContext _context;
+        TDevice _device {};
+        TContext _context {};
         uint32_t _nextTextureID       = 1;
         uint32_t _nextRenderBufferID = 1; // render buffer id 0 is reserved for default render target view.
         uint32_t _nextGeometryID      = 1;

--- a/code/framework/src/graphics/backend/d3d12.cpp
+++ b/code/framework/src/graphics/backend/d3d12.cpp
@@ -10,17 +10,19 @@
 
 #include <logging/logger.h>
 
+#include <wrl/client.h>
+
 namespace Framework::Graphics {
     bool D3D12Backend::Init(const Framework::Graphics::RendererConfiguration &opts) {
         const auto swapChain = opts.d3d12.swapchain;
         const auto commandQueue = opts.d3d12.commandQueue;
-        _device  = opts.d3d12.device;
         _context = opts.d3d12.deviceContext;
         // #1 get device from swapchain (maybe different device)
-        ID3D12Device *pD3DDevice;
-        if (FAILED(swapChain->GetDevice(__uuidof(ID3D12Device), (void **)&pD3DDevice))) {
+        Microsoft::WRL::ComPtr<ID3D12Device> deviceGuard;
+        if (FAILED(swapChain->GetDevice(IID_PPV_ARGS(&deviceGuard)))) {
             return false;
         }
+        ID3D12Device *pD3DDevice = deviceGuard.Get();
 
         _swapChain    = swapChain;
         _commandQueue = commandQueue;
@@ -87,6 +89,8 @@ namespace Framework::Graphics {
             }
         }
 
+        _device = deviceGuard.Detach();
+
         Framework::Logging::GetLogger(FRAMEWORK_INNER_GRAPHICS)->info("D3D12 device {}", fmt::ptr(_device));
         return true;
     }
@@ -99,6 +103,10 @@ namespace Framework::Graphics {
         for (const auto &frameContext : _frameContext) {
             frameContext._commandAllocator->Release();
             frameContext._mainRenderTargetResource->Release();
+        }
+        if (_device) {
+            _device->Release();
+            _device = nullptr;
         }
     }
 

--- a/code/framework/src/graphics/renderer.cpp
+++ b/code/framework/src/graphics/renderer.cpp
@@ -21,7 +21,8 @@ namespace Framework::Graphics {
             return Error("Renderer is already initialized");
         }
 
-        _config = config;
+        _config  = config;
+        _backend = config.backend;
 
         if (_config.backend == RendererBackend::BACKEND_D3D_11) {
             _d3d11Backend = std::make_unique<D3D11Backend>();


### PR DESCRIPTION
Part 1/N: 

The renderer never set `_backend`, so `GetBackendType()` always returned the D3D11 default and D3D12 consumers silently built no-op views. Set it from the configuration at Init.

The D3D12 backend created its descriptor heaps and RTVs from the swapchain's device but stored opts.d3d12.device, so resources later created through `GetDevice()` could come from a different device and be rejected by D3D12. Use the swapchain device as the single device.

With a device, the next PR will propose to allocate an additional pool D3D12 descriptors for our CEF webview textures (max 64)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved D3D12 backend initialization to derive the device from the swap chain and initialize graphics resources from that source.
  * Updated D3D12 shutdown to conditionally release the device and clear it after cleanup.
  * Renderer now caches the selected graphics backend along with the full configuration.

* **Bug Fixes**
  * Backend now starts with deterministic default values for device and context to avoid uninitialized-state behavior before configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->