### PR TITLE
Add lic header to network_packets_ut.h

### DIFF
--- a/code/tests/modules/network_packets_ut.h
+++ b/code/tests/modules/network_packets_ut.h
@@ -1,3 +1,11 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2026, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
 #pragma once
 
 #include "networking/network_peer.h"


### PR DESCRIPTION
I hope this addresses the `check_style_ci` check (can't verify from my end since it requires a webhook for a token I do not have).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for network packet handling, including validation of data offset resolution and timestamp handling
  * Added serialization/deserialization tests for RPC payload functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->