### PR TITLE
CI: Bump actions versions to fix Node 20 deprecation warning

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -31,7 +31,7 @@ jobs:
             build_type: "Debug"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: ${{ secrets.FW_SERVICES_PAT != '' && 'recursive' || 'false' }}
           token: ${{ secrets.FW_SERVICES_PAT || github.token }}

--- a/.github/workflows/check_style.yml
+++ b/.github/workflows/check_style.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         # The style check only inspects this repo's own tracked files
         # (check_style.sh excludes vendors and submodules), so there is

--- a/.github/workflows/issue_hooks.yml
+++ b/.github/workflows/issue_hooks.yml
@@ -10,7 +10,7 @@ jobs:
     name: Add issue to project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v0.5.0
+      - uses: actions/add-to-project@v2
         with:
           project-url: https://github.com/orgs/MafiaHub/projects/1
           github-token: ${{ secrets.ISSUE_PAT }}

--- a/.github/workflows/pr_hooks.yml
+++ b/.github/workflows/pr_hooks.yml
@@ -11,7 +11,7 @@ jobs:
     name: Add pull request to project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v0.5.0
+      - uses: actions/add-to-project@v2
         with:
           project-url: https://github.com/orgs/MafiaHub/projects/1
           github-token: ${{ secrets.ISSUE_PAT }}

--- a/.github/workflows/pr_tag_commit.yml
+++ b/.github/workflows/pr_tag_commit.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: develop
           fetch-depth: 0  # Ensure full history for diff comparisons
@@ -33,7 +33,7 @@ jobs:
     needs: bump-semver
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: develop
           fetch-depth: 0  # Get full history for tag comparison
@@ -68,10 +68,10 @@ jobs:
 
       - name: Create semver tag and release
         if: env.RELEASE_NEEDED == 'true'
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ env.new_tag }}
-          release_name: ${{ env.new_tag }}
+          name: ${{ env.new_tag }}
           draft: false
           prerelease: false
           generate_release_notes: true

--- a/.github/workflows/publish_types.yml
+++ b/.github/workflows/publish_types.yml
@@ -15,13 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: develop
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/update_services.yml
+++ b/.github/workflows/update_services.yml
@@ -14,7 +14,7 @@ jobs:
       should_build: ${{ steps.check_changes.outputs.changed }}
     steps:
       - name: Checkout services-adapter repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: MafiaHub/services-adapter
           path: services-adapter-repo
@@ -101,7 +101,7 @@ jobs:
             build_type: "Release"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           token: ${{ secrets.FW_SERVICES_PAT }}
@@ -133,7 +133,7 @@ jobs:
         run: |
           cmake --build build --target MafiaHubServices --config ${{ matrix.build_type }}
       - name: Upload MafiaHub Services
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: mafiahub-services-${{ matrix.os }}
           path: |
@@ -149,10 +149,10 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: temp-artifacts
           
@@ -202,7 +202,7 @@ jobs:
       
       - name: Create or update release
         id: create_release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: MafiaHub-Services
           name: MafiaHub Services


### PR DESCRIPTION
Node 20 deprecated on github actions runners, and we've been seeing this warning on our logs for a while.

https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

Bumping all actions versions to the version that supports Node 24.

One thing to note is that there's an action that was using the no-longer-maintained `actions/create-release@v1`. Switched that to use `softprops/action-gh-release`, which seems fine since it's already used in this repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated GitHub Actions versions across continuous integration and deployment workflows to latest stable releases, improving compatibility and pipeline stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->