### PR TITLE
Launcher: keep PhysX runtime reachable under restricted DLL search

### DIFF
--- a/code/framework/src/launcher/project.cpp
+++ b/code/framework/src/launcher/project.cpp
@@ -17,6 +17,7 @@
 #include <Psapi.h>
 #include <ShellScalingApi.h>
 #include <Windows.h>
+#include <winreg.h>
 #include <cppfs/FileHandle.h>
 #include <cppfs/fs.h>
 #include <fstream>
@@ -255,6 +256,26 @@ namespace Framework::Launcher {
             // add our own paths now
             addDllDirectory(gProjectDllPath);
             addDllDirectory((std::wstring(gProjectDllPath) + L"\\bin").c_str());
+
+            // Keep the system PhysX runtime reachable under the restricted DLL search:
+            // SetDefaultDllDirectories drops PATH, but legacy NVIDIA/AGEIA PhysX resolves its
+            // cudart dependency (in ...\PhysX\Common) by name via PATH, so games like Mafia II
+            // would fail NxCreatePhysicsSDK. Re-add the PhysX dirs from the AGEIA registry.
+            HKEY physXKey {};
+            if (RegOpenKeyExW(HKEY_LOCAL_MACHINE, L"SOFTWARE\\AGEIA Technologies", 0, KEY_READ, &physXKey) == ERROR_SUCCESS) {
+                wchar_t enginePath[MAX_PATH] {};
+                DWORD enginePathSize = sizeof(enginePath);
+                if (RegQueryValueExW(physXKey, L"PhysXCore Path", nullptr, nullptr, reinterpret_cast<LPBYTE>(enginePath), &enginePathSize) == ERROR_SUCCESS) {
+                    addDllDirectory(enginePath);
+
+                    // PhysXCore.dll's cudart lives in the sibling Common dir; canonicalize (no "..").
+                    wchar_t commonPath[MAX_PATH] {};
+                    if (GetFullPathNameW((std::wstring(enginePath) + L"\\..\\Common").c_str(), MAX_PATH, commonPath, nullptr)) {
+                        addDllDirectory(commonPath);
+                    }
+                }
+                RegCloseKey(physXKey);
+            }
 
             if (_config.useAlternativeWorkDir) {
                 _gamePath += L"/" + _config.alternativeWorkDir;


### PR DESCRIPTION
## Summary

When a game is launched through the framework's PE-mapping launcher, Mafia II
(and any title whose runtime relies on `PATH` to locate a dependency) fails to
initialize PhysX, showing **"PhysX SDK not initialized. PhysX System Software
will be installed."** and exiting. The same game launched normally works fine.

## Root cause

`Project::Launch()` calls:

```cpp
setDefaultDllDirectories(LOAD_LIBRARY_SEARCH_DEFAULT_DIRS | LOAD_LIBRARY_SEARCH_USER_DIRS);
```

which removes `PATH` (and the CWD) from the process-wide DLL search order. Mafia
II's `PhysXLoader.dll` then loads the system `PhysXCore.dll` by full path (from
the AGEIA registry `PhysXCore Path`), but that core resolves its dependency
**`cudart32_30_9.dll` by name** — and the legacy NVIDIA/AGEIA PhysX installer
makes that DLL reachable only by appending `...\NVIDIA Corporation\PhysX\Common\`
to the system `PATH`. With `PATH` stripped from the search the dependency can't
be found → `LoadLibraryA` returns `NULL` → `NxCreatePhysicsSDK` returns
`NXCE_PHYSX_NOT_FOUND` → the dialog. A normal launch never restricts the search,
which is why single-player works.

## Fix

After restricting the search, re-add the PhysX runtime directories (read from
`HKLM\SOFTWARE\AGEIA Technologies\PhysXCore Path`) via `AddDllDirectory`. It is a
no-op when PhysX isn't installed (key absent) and keeps the
`SetDefaultDllDirectories` hardening intact.

## Verification

Reproduced and fixed in isolation with a 32-bit harness that calls the real
`PhysXLoader.dll` using the exact `NxPhysicsSDKDesc` the game passes (captured
from the live process under a debugger):

- `SetDefaultDllDirectories(...DEFAULT_DIRS|USER_DIRS)` → `NxCreatePhysicsSDK`
  returns `NXCE_PHYSX_NOT_FOUND`, `PhysXCore.dll` not loaded.
- `+ AddDllDirectory(...\PhysX\Common)` → `NXCE_NO_ERROR`, SDK created,
  `cudart32_30_9.dll` loaded.

Confirmed end-to-end on the real launcher (live trace): `PhysXCore` loads,
`NxCreatePhysicsSDK` returns a valid SDK, no dialog, the game reaches the menu.
The only strictly-required directory is the PhysX `Common` dir; `Engine` is added
as a harmless extra in case a title loads the core by name.

## Notes

- `project.cpp` is Windows-only (unguarded Win32), so this does not affect the
  Linux/macOS build legs.
- No new dependencies; uses only Win32 (`RegOpenKeyExW` / `RegQueryValueExW` /
  `GetFullPathNameW` / `AddDllDirectory`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app launch reliability on Windows for setups that rely on legacy PhysX components.
  * Added support for locating required graphics-related libraries even when standard environment paths are restricted, reducing launch failures and missing-DLL errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->