### PR TITLE
Networking: optional broadcast-exclude GUID on BroadcastRPC

### DIFF
--- a/code/framework/src/networking/network_peer.h
+++ b/code/framework/src/networking/network_peer.h
@@ -105,12 +105,13 @@ namespace Framework::Networking {
             });
         }
 
-        // Send an RPC payload to every connected system.
+        // Send an RPC payload to every connected system, optionally excluding one (in broadcast mode
+        // RakNet treats the guid as the system to SKIP — e.g. don't echo a client's own update back).
         template <RPC::Payload T>
-        void BroadcastRPC(T &payload, MafiaNet::Priority priority = MafiaNet::Priority::High, MafiaNet::Reliability reliability = MafiaNet::Reliability::ReliableOrdered) {
+        void BroadcastRPC(T &payload, MafiaNet::Priority priority = MafiaNet::Priority::High, MafiaNet::Reliability reliability = MafiaNet::Reliability::ReliableOrdered, MafiaNet::RakNetGUID except = MafiaNet::UNASSIGNED_RAKNET_GUID) {
             MafiaNet::BitStream bs;
             payload.Serialize(&bs, true);
-            _rpc.Signal(T::kIdentifier, &bs, priority, reliability, 0, MafiaNet::UNASSIGNED_RAKNET_GUID, true, false);
+            _rpc.Signal(T::kIdentifier, &bs, priority, reliability, 0, except, true, false);
         }
 
         // Send an RPC payload to a single system.


### PR DESCRIPTION
In broadcast mode RakNet treats the guid as the system to skip; expose it so a server can relay a client's update without echoing it to the sender. Defaulted — existing callers unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for broadcasting network RPCs while excluding a specific recipient, giving multiplayer systems more control over who receives updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->