### PR TITLE
Integrations: rename EmitLuaEvent RPC to EmitScriptEvent

### DIFF
--- a/code/framework/src/integrations/client/instance.cpp
+++ b/code/framework/src/integrations/client/instance.cpp
@@ -8,7 +8,7 @@
 
 #include "instance.h"
 
-#include "integrations/shared/rpc/emit_lua_event.h"
+#include "integrations/shared/rpc/emit_script_event.h"
 
 #include "networking/rpc/rpc.h"
 #include "networking/rpc/chat_message.h"
@@ -50,7 +50,7 @@ namespace Framework::Integrations::Client {
     namespace {
         // Handler for server-emitted scripting events; reaches the scripting engine through the
         // CoreModules singleton.
-        void OnEmitLuaEvent(const Shared::RPC::EmitLuaEvent &rpc, MafiaNet::Packet *packet) {
+        void OnEmitScriptEvent(const Shared::RPC::EmitScriptEvent &rpc, MafiaNet::Packet *packet) {
             (void)packet;
             const auto eventName = rpc.GetEventName();
             if (eventName.empty()) {
@@ -518,7 +518,7 @@ namespace Framework::Integrations::Client {
             }
         });
 
-        net->RegisterRPC<Shared::RPC::EmitLuaEvent>(&OnEmitLuaEvent);
+        net->RegisterRPC<Shared::RPC::EmitScriptEvent>(&OnEmitScriptEvent);
 
         // Chat lines from the server are forwarded to the mod's UI via the received callback.
         net->RegisterRPC<Framework::Networking::RPC::ChatMessage>([this](const Framework::Networking::RPC::ChatMessage &payload, MafiaNet::Packet *) {

--- a/code/framework/src/integrations/server/instance.cpp
+++ b/code/framework/src/integrations/server/instance.cpp
@@ -15,7 +15,7 @@
 
 #include "core_modules.h"
 
-#include "integrations/shared/rpc/emit_lua_event.h"
+#include "integrations/shared/rpc/emit_script_event.h"
 #include "networking/replication/network_entity.h"
 #include "networking/replication/replication_manager.h"
 #include "networking/rpc/chat_message.h"
@@ -400,7 +400,7 @@ namespace Framework::Integrations::Server {
         // its viewer entity, then hand off to OnClientEvent, which routes into the dedicated
         // client-event table (Events.onClient) — never the global bus a client could otherwise
         // collide with.
-        net->RegisterRPC<Framework::Integrations::Shared::RPC::EmitLuaEvent>([this](const Framework::Integrations::Shared::RPC::EmitLuaEvent &payload, MafiaNet::Packet *packet) {
+        net->RegisterRPC<Framework::Integrations::Shared::RPC::EmitScriptEvent>([this](const Framework::Integrations::Shared::RPC::EmitScriptEvent &payload, MafiaNet::Packet *packet) {
             const std::string name = payload.GetEventName();
             if (name.empty()) {
                 return;

--- a/code/framework/src/integrations/shared/rpc/emit_script_event.h
+++ b/code/framework/src/integrations/shared/rpc/emit_script_event.h
@@ -16,8 +16,8 @@
 namespace Framework::Integrations::Shared::RPC {
     // RPC payload forwarding a named scripting event (with a JSON payload) to the other peer's
     // resource layer. See networking/rpc/rpc.h for the dispatch model.
-    struct EmitLuaEvent {
-        static constexpr const char *kIdentifier = "Framework::EmitLuaEvent";
+    struct EmitScriptEvent {
+        static constexpr const char *kIdentifier = "Framework::EmitScriptEvent";
 
         MafiaNet::RakString eventName;
         MafiaNet::RakString payload;

--- a/code/framework/src/scripting/builtins/events.cpp
+++ b/code/framework/src/scripting/builtins/events.cpp
@@ -11,7 +11,7 @@
 #include "../resource/resource_manager.h"
 
 #include <core_modules.h>
-#include <integrations/shared/rpc/emit_lua_event.h>
+#include <integrations/shared/rpc/emit_script_event.h>
 #include <logging/logger.h>
 #include <networking/network_peer.h>
 
@@ -184,7 +184,7 @@ namespace Framework::Scripting {
         if (!peer) {
             return;
         }
-        Framework::Integrations::Shared::RPC::EmitLuaEvent ev;
+        Framework::Integrations::Shared::RPC::EmitScriptEvent ev;
         ev.FromParameters(eventName, payload);
         peer->BroadcastRPC(ev);
     }

--- a/code/framework/src/scripting/builtins/player.h
+++ b/code/framework/src/scripting/builtins/player.h
@@ -12,7 +12,7 @@
 #include "property.h"
 
 #include <core_modules.h>
-#include <integrations/shared/rpc/emit_lua_event.h>
+#include <integrations/shared/rpc/emit_script_event.h>
 #include <networking/network_peer.h>
 #include <networking/rpc/client_identity.h>
 
@@ -62,7 +62,7 @@ namespace Framework::Scripting::Builtins {
             if (!peer) {
                 return;
             }
-            Framework::Integrations::Shared::RPC::EmitLuaEvent ev;
+            Framework::Integrations::Shared::RPC::EmitScriptEvent ev;
             ev.FromParameters(eventName, payloadJson);
             peer->SendRPC(ev, MafiaNet::ToGuid(entity->ownerGUID));
         }


### PR DESCRIPTION
The scripted-event RPC was misnamed after the Lua->JS scripting switch; rename to a language-neutral name (struct, header, handler, and wire identifier).

Note: this changes `kIdentifier`, do I need to manually bump the version or does the CI take care of that?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Server-emitted scripting events are now delivered via the dedicated script-event RPC channel (replacing the Lua-specific path), improving reliability and consistency in scripting.
  * Event payloads are forwarded as structured JSON into the scripting engine’s reserved event stream more consistently.
  * Client-to-server event handling and in-app broadcasting/emit flows were updated to use the script-event mechanism.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->