### PR TITLE
GUI: gate CEF external begin frames to the GPU path

### DIFF
--- a/code/framework/src/gui/view.cpp
+++ b/code/framework/src/gui/view.cpp
@@ -111,9 +111,15 @@ namespace Framework::GUI {
     }
 
     void View::RequestBeginFrame() {
-        if (_browser) {
-            _browser->GetHost()->SendExternalBeginFrame();
+        if (!_browser) {
+            return;
         }
+        // Software OSR emits OnPaint only when the view has damage, so force a repaint each cycle;
+        // the begin frame then drives the compositor to hand us that frame. Both must run on the
+        // CEF UI thread — this is called from Manager::Update, which also pumps the message loop.
+        const auto host = _browser->GetHost();
+        host->Invalidate(PET_VIEW);
+        host->SendExternalBeginFrame();
     }
 
     void View::LockToOrigin(const std::string &url) {


### PR DESCRIPTION
Software OSR emits no OnPaint under external begin frames, leaving every web view a blank texture. Use CEF's internal paint timer on the CPU path.

In the Hogwarts Legacy mod, this prevented the chat from loading. I was also seeing issues of a permanent black screen on game launch which this seems to also resolve, but I'm not 100%. Launched and exited the game 5x consecutively and worked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering behavior by applying the appropriate frame timing for GPU-accelerated and software rendering modes.
  * Prevented unnecessary external frame requests when GPU acceleration is disabled or no browser is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->