### PR TITLE
CommandListener: stop busy-spinning on stdin EOF

### DIFF
--- a/code/framework/src/utils/command_listener.cpp
+++ b/code/framework/src/utils/command_listener.cpp
@@ -8,6 +8,7 @@
 
 #include "command_listener.h"
 
+#include <chrono>
 #include <iostream>
 #include <mutex>
 #include <thread>
@@ -18,7 +19,16 @@ namespace Framework::Utils {
         std::thread([this]() {
             while (_running) {
                 std::string commandString;
-                std::getline(std::cin, commandString);
+                if (!std::getline(std::cin, commandString)) {
+                    // Non-interactive stdin (e.g. Docker, no TTY) is at EOF and getline
+                    // returns instantly; break on EOF, back off otherwise, to avoid a busy-spin.
+                    if (std::cin.eof()) {
+                        break;
+                    }
+                    std::cin.clear();
+                    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+                    continue;
+                }
 
                 if (commandString.empty())
                     continue;


### PR DESCRIPTION
The console reader thread looped on std::getline(std::cin, ...) and `continue`d on empty lines. With a non-interactive stdin (a dedicated server in a Docker container with no TTY), std::cin is at EOF and getline returns immediately without blocking, so the loop pegs a full CPU core. Interactive runs block in getline and are unaffected, which is why this only showed up on the Linux/Docker server, not Windows.

Break out of the loop when stdin is permanently closed (EOF); on any other transient stream failure, clear and back off instead of spinning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved command-line input handling in non-interactive environments.
  - Prevented excessive CPU usage when standard input encounters temporary failures.
  - Ensured input processing stops cleanly when the input stream reaches end-of-file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->