### PR TITLE
fix(cef): build cef_subprocess as a windowed app (no per-child console window)

### DIFF
--- a/code/framework/CMakeLists.txt
+++ b/code/framework/CMakeLists.txt
@@ -407,6 +407,8 @@ if(WIN32)
     target_compile_definitions(cef_subprocess PRIVATE _USE_MATH_DEFINES NOMINMAX)
     set_target_properties(cef_subprocess PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+        # Windowed subsystem (no black console window per CEF child) while keeping the int main() entry.
+        LINK_FLAGS "/SUBSYSTEM:WINDOWS /ENTRY:mainCRTStartup"
     )
     if(TARGET CEFCopyDlls)
         add_dependencies(FrameworkClient CEFCopyDlls)


### PR DESCRIPTION
## Problem
On Windows, launching a `FrameworkClient` pops **several black console windows** — one per CEF child process (renderer, GPU, utility, …). `cef_subprocess` is defined with `add_executable(...)` without a windowed subsystem, so every CEF subprocess spawns with a console window.

## Fix
Link `cef_subprocess` with `/SUBSYSTEM:WINDOWS` while keeping its `int main()` entry point via `/ENTRY:mainCRTStartup`. One line in `code/framework/CMakeLists.txt` — the subprocess runs identically, just without a console window. Consistent with the surrounding MSVC-only client block.

## Testing
Built on Windows (MSVC 14.44, RelWithDebInfo) — the CEF children no longer open console windows; the client and CEF views work as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows application startup behavior for the CEF subprocess.
  * Prevented an unwanted console window from appearing when launching the subprocess.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->