### PR TITLE
Scripting: reuse Events callback context across Register

### DIFF
--- a/code/framework/src/scripting/builtins/events.cpp
+++ b/code/framework/src/scripting/builtins/events.cpp
@@ -47,10 +47,15 @@ namespace Framework::Scripting {
     }
 
     void Events::Register(v8::Isolate *isolate, v8::Local<v8::Context> context, v8::Local<v8::Object> target, ResourceManager *resourceManager, bool isClient) {
-        // Create callback context that will be passed to all V8 callbacks
-        _callbackContext                  = std::make_unique<CallbackContext>();
+        // Reuse the context across repeated Register() calls; never reallocate. Its address is
+        // baked into non-owning v8::Externals (template data and on() unsubscribe closures) that
+        // outlive this call, so replacing it would dangle them. Contents are invariant anyway.
+        if (!_callbackContext) {
+            _callbackContext = std::make_unique<CallbackContext>();
+        }
         _callbackContext->events          = this;
         _callbackContext->resourceManager = resourceManager;
+        _callbackContext->valid.store(true, std::memory_order_release);
 
         v8::Local<v8::Object> eventsObj     = v8::Object::New(isolate);
         v8::Local<v8::External> contextData = v8::External::New(isolate, _callbackContext.get());

--- a/code/framework/src/scripting/builtins/events.h
+++ b/code/framework/src/scripting/builtins/events.h
@@ -211,7 +211,8 @@ namespace Framework::Scripting {
 
         mutable std::mutex _handlersMutex;
 
-        // Stored callback context (lifetime tied to this Events instance)
+        // Callback context passed to V8 via Externals. Allocated once and reused, never
+        // reallocated — its address outlives individual Register() calls. See Events::Register.
         std::unique_ptr<CallbackContext> _callbackContext;
 
         // Track pending AllSettled callbacks for cleanup on destruction

--- a/code/tests/modules/js_features_ut.h
+++ b/code/tests/modules/js_features_ut.h
@@ -552,6 +552,69 @@ MODULE(js_features, {
     });
 
     // ========================================
+    // RE-REGISTER SAFETY (callback-context reuse)
+    // ========================================
+    // A second Register() must not dangle the v8::Externals baked during the first one. Regression
+    // guard for the double-Register use-after-free: externals captured before the second call must
+    // still resolve to live memory afterwards.
+
+    // An unsubscribe closure from the first Register() must still remove its handler after a second.
+    IT("Second Register keeps a prior unsubscribe closure valid", {
+        EventsTestHelper::Setup();
+        NodeEngine engine({});
+        EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
+        ResourceManagerConfig config;
+        config.resourcesPath = EventsTestHelper::GetTestPath();
+        ResourceManager manager(&engine, config);
+
+        // Stash the unsubscribe closure from the first Register().
+        registerEvents(engine, manager);
+        RunJS(engine, "globalThis.oldUnsub = Core.Events.on('persist', () => {}); 0");
+        EQUALS(manager.GetEvents().GetListenerCount("persist"), (size_t)1);
+
+        // Re-register on the same Events instance (the path that previously freed the context
+        // out from under oldUnsub). Handler tables are untouched.
+        registerEvents(engine, manager);
+        EQUALS(manager.GetEvents().GetListenerCount("persist"), (size_t)1);
+
+        // The old closure still reaches the live context and removes its handler.
+        RunJS(engine, "globalThis.oldUnsub(); 0");
+        EQUALS(manager.GetEvents().GetListenerCount("persist"), (size_t)0);
+
+        cleanupResource(engine, manager);
+        engine.Shutdown();
+        EventsTestHelper::Cleanup();
+    });
+
+    // The old Core.Events.on function (its template data holds the context) must still dispatch
+    // into the same Events after a second Register(), and the new Core.Events must work too.
+    IT("Second Register keeps prior function-template externals valid", {
+        EventsTestHelper::Setup();
+        NodeEngine engine({});
+        EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
+        ResourceManagerConfig config;
+        config.resourcesPath = EventsTestHelper::GetTestPath();
+        ResourceManager manager(&engine, config);
+
+        // Capture the on() function from the first Register(), then re-register over it.
+        registerEvents(engine, manager);
+        RunJS(engine, "globalThis.oldOn = Core.Events.on; 0");
+        registerEvents(engine, manager);
+
+        // The captured function still registers into the same Events instance.
+        RunJS(engine, "globalThis.oldOn('again', () => {}); 0");
+        EQUALS(manager.GetEvents().GetListenerCount("again"), (size_t)1);
+
+        // And the freshly-installed Core.Events works too.
+        RunJS(engine, "Core.Events.on('fresh', () => {}); 0");
+        EQUALS(manager.GetEvents().GetListenerCount("fresh"), (size_t)1);
+
+        cleanupResource(engine, manager);
+        engine.Shutdown();
+        EventsTestHelper::Cleanup();
+    });
+
+    // ========================================
     // CONSOLE BUILTIN TESTS
     // ========================================
 


### PR DESCRIPTION
## Problem

A second `Events::Register()` call replaced `_callbackContext`, freeing the old one — while the `v8::External`s baked during the first registration still pointed at it. Those externals live in two places that can outlive a single `Register()` call:

- the data of every Events function template (`on`, `emit`, `off`, …) set on `Core.Events`
- the data of each unsubscribe closure returned by `on()`, which script code may capture and hold

Since a `v8::External` is a non-owning `void*` wrapper (confirmed against the vendored V8 headers) and the `valid=false` guard only fires in `~Events()`, a second `Register()` left those stale externals dereferencing freed memory — a use-after-free. The client reconnect/reset path reuses the isolate/context while rebuilding bindings, so this is reachable, not merely theoretical.

## Fix

Reuse the callback context in place instead of reallocating it. Keeping the same address means every previously-baked external stays pointed at live, valid memory. The contents are invariant anyway: `events` is always `this`, and `resourceManager` is the manager that owns this `Events`.

Considered but rejected: eagerly freeing on re-register (still dangles surviving unsubscribe closures) and retiring old contexts into a vector (leaks, and doesn't actually remove the dangle). Reuse-in-place is the minimal correct fix — no dangle, no leak.

## Tests

Two regression tests in `js_features_ut.h`, one per external site:
- a prior `on()` unsubscribe closure must still remove its handler after a second `Register()`
- the prior `Core.Events.on` function must still dispatch into the same `Events`, and the freshly-installed `Core.Events` must work too

Verified locally: full suite **144/144 passing**. Confirmed the tests have teeth — reverting to the old replace-and-free behavior makes them fail deterministically (and the UAF aborts the process).

## Versioning

PATCH — internal lifetime fix, no peer-sync or scripting-API surface change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when registering the Events system multiple times.
  * Existing event handlers, unsubscribe actions, and event functions now remain valid after re-registration.

* **Tests**
  * Added coverage to verify callbacks and event registrations continue working across repeated registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->