### PR TITLE
Scripting: builtins fixes, conventions sweep, and value-type parity

### DIFF
--- a/code/framework/CMakeLists.txt
+++ b/code/framework/CMakeLists.txt
@@ -47,7 +47,7 @@ set(FRAMEWORK_SRC
     src/scripting/builtins/console.cpp
     src/scripting/builtins/imports.cpp
     src/scripting/builtins/exports.cpp
-    src/scripting/builtins/environment.cpp
+    src/scripting/builtins/execution_environment.cpp
     src/scripting/resource/package_manifest.cpp
     src/scripting/resource/resource.cpp
     src/scripting/resource/resource_manager.cpp

--- a/code/framework/src/integrations/client/scripting/module.cpp
+++ b/code/framework/src/integrations/client/scripting/module.cpp
@@ -140,8 +140,8 @@ namespace Framework::Integrations::Client::Scripting {
 
         Framework::Scripting::SetScriptingCatalog(isolate, "framework-client");
 
-        // Register math type builtins on Core object
-        Framework::Scripting::Builtins::RegisterAll(isolate, coreObj);
+        // Register value-type builtins on Core object
+        Framework::Scripting::Builtins::RegisterValueTypes(isolate, coreObj);
 
         // Register communication APIs
         _resourceManager->GetEvents().Register(isolate, context, coreObj, _resourceManager.get(), /*isClient*/ true);

--- a/code/framework/src/integrations/client/scripting/module.cpp
+++ b/code/framework/src/integrations/client/scripting/module.cpp
@@ -134,17 +134,17 @@ namespace Framework::Integrations::Client::Scripting {
         v8::Local<v8::Context> context = _engine->GetContext();
         v8::Context::Scope contextScope(context);
 
-        // Get Framework and Core global objects (created by V8Engine)
+        // Framework global object (created by V8Engine); builtins register at the global root.
         v8::Local<v8::Object> frameworkObj = _engine->GetFrameworkObject();
-        v8::Local<v8::Object> coreObj      = _engine->GetCoreObject();
+        v8::Local<v8::Object> global       = context->Global();
 
         Framework::Scripting::SetScriptingCatalog(isolate, "framework-client");
 
-        // Register value-type builtins on Core object
-        Framework::Scripting::Builtins::RegisterValueTypes(isolate, coreObj);
+        // Register value-type builtins at the global root (new Vector3, not new Core.Vector3)
+        Framework::Scripting::Builtins::RegisterValueTypes(isolate, global);
 
         // Register communication APIs
-        _resourceManager->GetEvents().Register(isolate, context, coreObj, _resourceManager.get(), /*isClient*/ true);
+        _resourceManager->GetEvents().Register(isolate, context, global, _resourceManager.get(), /*isClient*/ true);
         Framework::Scripting::Builtins::Messages::Register(isolate, context, frameworkObj, _resourceManager.get());
         Framework::Scripting::Builtins::Exports::Register(isolate, context, frameworkObj, _resourceManager.get());
         Framework::Scripting::Builtins::Imports::Register(isolate, context, frameworkObj, _resourceManager.get());
@@ -152,8 +152,8 @@ namespace Framework::Integrations::Client::Scripting {
         // Register console override
         Framework::Scripting::Builtins::Console::Register(isolate, context, _resourceManager.get());
 
-        // Register environment info
-        Framework::Scripting::Builtins::Environment::Register(isolate, context, coreObj, true);
+        // Register environment info at the global root
+        Framework::Scripting::Builtins::Environment::Register(isolate, context, global, true);
 
         // Register web views API (client only)
         Builtins::Web::Register(isolate, context, frameworkObj, _resourceManager.get());

--- a/code/framework/src/integrations/client/scripting/module.cpp
+++ b/code/framework/src/integrations/client/scripting/module.cpp
@@ -145,15 +145,15 @@ namespace Framework::Integrations::Client::Scripting {
 
         // Register communication APIs
         _resourceManager->GetEvents().Register(isolate, context, coreObj, _resourceManager.get(), /*isClient*/ true);
-        Framework::Scripting::Messages::Register(isolate, context, frameworkObj, _resourceManager.get());
-        Framework::Scripting::Exports::Register(isolate, context, frameworkObj, _resourceManager.get());
-        Framework::Scripting::Imports::Register(isolate, context, frameworkObj, _resourceManager.get());
+        Framework::Scripting::Builtins::Messages::Register(isolate, context, frameworkObj, _resourceManager.get());
+        Framework::Scripting::Builtins::Exports::Register(isolate, context, frameworkObj, _resourceManager.get());
+        Framework::Scripting::Builtins::Imports::Register(isolate, context, frameworkObj, _resourceManager.get());
 
         // Register console override
-        Framework::Scripting::Console::Register(isolate, context, _resourceManager.get());
+        Framework::Scripting::Builtins::Console::Register(isolate, context, _resourceManager.get());
 
         // Register environment info
-        Framework::Scripting::Environment::Register(isolate, context, coreObj, true);
+        Framework::Scripting::Builtins::Environment::Register(isolate, context, coreObj, true);
 
         // Register web views API (client only)
         Builtins::Web::Register(isolate, context, frameworkObj, _resourceManager.get());
@@ -229,7 +229,7 @@ namespace Framework::Integrations::Client::Scripting {
                 v8::Local<v8::Context> context = _engine->GetContext();
                 v8::Context::Scope contextScope(context);
 
-                Framework::Scripting::Messages::ProcessPendingResponses(isolate, context);
+                Framework::Scripting::Builtins::Messages::ProcessPendingResponses(isolate, context);
             }
 
             // Poll keys and dispatch key binds (self-scopes the isolate).

--- a/code/framework/src/integrations/client/scripting/module.cpp
+++ b/code/framework/src/integrations/client/scripting/module.cpp
@@ -12,7 +12,7 @@
 
 #include <scripting/builtins/builtins.h>
 #include <scripting/builtins/console.h>
-#include <scripting/builtins/environment.h>
+#include <scripting/builtins/execution_environment.h>
 #include <scripting/builtins/events.h>
 #include <scripting/builtins/exports.h>
 #include <scripting/builtins/imports.h>
@@ -153,7 +153,7 @@ namespace Framework::Integrations::Client::Scripting {
         Framework::Scripting::Builtins::Console::Register(isolate, context, _resourceManager.get());
 
         // Register environment info at the global root
-        Framework::Scripting::Builtins::Environment::Register(isolate, context, global, true);
+        Framework::Scripting::Builtins::ExecutionEnvironment::Register(isolate, context, global, true);
 
         // Register web views API (client only)
         Builtins::Web::Register(isolate, context, frameworkObj, _resourceManager.get());

--- a/code/framework/src/integrations/server/scripting/module.cpp
+++ b/code/framework/src/integrations/server/scripting/module.cpp
@@ -134,15 +134,15 @@ namespace Framework::Integrations::Server::Scripting {
 
         // Register communication APIs
         _resourceManager->GetEvents().Register(isolate, context, coreObj, _resourceManager.get());
-        Framework::Scripting::Messages::Register(isolate, context, frameworkObj, _resourceManager.get());
-        Framework::Scripting::Imports::Register(isolate, context, frameworkObj, _resourceManager.get());
-        Framework::Scripting::Exports::Register(isolate, context, frameworkObj, _resourceManager.get());
+        Framework::Scripting::Builtins::Messages::Register(isolate, context, frameworkObj, _resourceManager.get());
+        Framework::Scripting::Builtins::Imports::Register(isolate, context, frameworkObj, _resourceManager.get());
+        Framework::Scripting::Builtins::Exports::Register(isolate, context, frameworkObj, _resourceManager.get());
 
         // Register console override
-        Framework::Scripting::Console::Register(isolate, context, _resourceManager.get());
+        Framework::Scripting::Builtins::Console::Register(isolate, context, _resourceManager.get());
 
         // Register environment info
-        Framework::Scripting::Environment::Register(isolate, context, coreObj, false);
+        Framework::Scripting::Builtins::Environment::Register(isolate, context, coreObj, false);
 
         // Register the chat API on the global object (Chat.sendToAll / Chat.sendToPlayer)
         Framework::Scripting::Builtins::Chat::Register(isolate, global);
@@ -201,7 +201,7 @@ namespace Framework::Integrations::Server::Scripting {
             v8::Local<v8::Context> context = _nodeEngine->GetContext();
             v8::Context::Scope contextScope(context);
 
-            Framework::Scripting::Messages::ProcessPendingResponses(isolate, context);
+            Framework::Scripting::Builtins::Messages::ProcessPendingResponses(isolate, context);
         }
     }
 

--- a/code/framework/src/integrations/server/scripting/module.cpp
+++ b/code/framework/src/integrations/server/scripting/module.cpp
@@ -13,7 +13,7 @@
 #include <scripting/builtins/builtins.h>
 #include <scripting/builtins/chat.h>
 #include <scripting/builtins/console.h>
-#include <scripting/builtins/environment.h>
+#include <scripting/builtins/execution_environment.h>
 #include <scripting/builtins/events.h>
 #include <scripting/builtins/exports.h>
 #include <scripting/builtins/imports.h>
@@ -142,7 +142,7 @@ namespace Framework::Integrations::Server::Scripting {
         Framework::Scripting::Builtins::Console::Register(isolate, context, _resourceManager.get());
 
         // Register environment info at the global root
-        Framework::Scripting::Builtins::Environment::Register(isolate, context, global, false);
+        Framework::Scripting::Builtins::ExecutionEnvironment::Register(isolate, context, global, false);
 
         // Register the chat API on the global object (Chat.sendToAll / Chat.sendToPlayer)
         Framework::Scripting::Builtins::Chat::Register(isolate, global);

--- a/code/framework/src/integrations/server/scripting/module.cpp
+++ b/code/framework/src/integrations/server/scripting/module.cpp
@@ -129,8 +129,8 @@ namespace Framework::Integrations::Server::Scripting {
             global->Set(context, coreKey, coreObj).Check();
         }
 
-        // Register math type builtins on Core object
-        Framework::Scripting::Builtins::RegisterAll(isolate, coreObj);
+        // Register value-type builtins on Core object
+        Framework::Scripting::Builtins::RegisterValueTypes(isolate, coreObj);
 
         // Register communication APIs
         _resourceManager->GetEvents().Register(isolate, context, coreObj, _resourceManager.get());

--- a/code/framework/src/integrations/server/scripting/module.cpp
+++ b/code/framework/src/integrations/server/scripting/module.cpp
@@ -129,11 +129,11 @@ namespace Framework::Integrations::Server::Scripting {
             global->Set(context, coreKey, coreObj).Check();
         }
 
-        // Register value-type builtins on Core object
-        Framework::Scripting::Builtins::RegisterValueTypes(isolate, coreObj);
+        // Register value-type builtins at the global root (new Vector3, not new Core.Vector3)
+        Framework::Scripting::Builtins::RegisterValueTypes(isolate, global);
 
         // Register communication APIs
-        _resourceManager->GetEvents().Register(isolate, context, coreObj, _resourceManager.get());
+        _resourceManager->GetEvents().Register(isolate, context, global, _resourceManager.get());
         Framework::Scripting::Builtins::Messages::Register(isolate, context, frameworkObj, _resourceManager.get());
         Framework::Scripting::Builtins::Imports::Register(isolate, context, frameworkObj, _resourceManager.get());
         Framework::Scripting::Builtins::Exports::Register(isolate, context, frameworkObj, _resourceManager.get());
@@ -141,8 +141,8 @@ namespace Framework::Integrations::Server::Scripting {
         // Register console override
         Framework::Scripting::Builtins::Console::Register(isolate, context, _resourceManager.get());
 
-        // Register environment info
-        Framework::Scripting::Builtins::Environment::Register(isolate, context, coreObj, false);
+        // Register environment info at the global root
+        Framework::Scripting::Builtins::Environment::Register(isolate, context, global, false);
 
         // Register the chat API on the global object (Chat.sendToAll / Chat.sendToPlayer)
         Framework::Scripting::Builtins::Chat::Register(isolate, global);

--- a/code/framework/src/scripting/builtins/README.md
+++ b/code/framework/src/scripting/builtins/README.md
@@ -1,0 +1,73 @@
+# Scripting builtins — conventions
+
+Every builtin under `scripting/builtins/` follows the rules below. They exist so
+that scripts see one consistent surface: the same failure always fails the same
+way, and the same kind of builtin always registers the same way. When you add or
+edit a builtin, match these. When something here is wrong, fix the rule and sweep
+the code — don't let the code drift silently.
+
+## Namespace
+
+All builtins live in `Framework::Scripting::Builtins`. No exceptions — value
+types (`Vector3`, `Color`, …), handle types (`Entity`, `Player`, `TextLabel`),
+and service APIs (`Console`, `Environment`, `Events`, `Exports`, `Imports`,
+`Messages`, `Chat`) all share the namespace. A builtin that needs a type from
+another subsystem forward-declares it in its own namespace; it does not move
+itself out of `Builtins` to be near that type.
+
+## Throwing
+
+Pick the failure mode by *what kind* of thing went wrong — not by which file you
+happen to be in:
+
+| Situation | Idiom |
+|---|---|
+| Wrong argument count, type, or shape | `isolate->ThrowException(v8::Exception::TypeError(...))` |
+| Valid call, but the world can't satisfy it (subsystem missing, resource not running, limit reached, no handler, cross-isolate) | `isolate->ThrowException(v8::Exception::Error(...))` |
+| A stale handle to a destroyed/absent object | silent no-op (return without throwing) |
+
+Rules:
+
+- **Never** use `isolate->ThrowError(...)`. It is equivalent to
+  `ThrowException(Exception::Error(...))` but hides the Error-vs-TypeError choice
+  above. Always spell out `ThrowException(Exception::Error/TypeError(...))`.
+- **Silent no-op is only for stale handles.** A bad argument is a programming
+  error and must throw; swallowing it hides the caller's bug. If two builtins
+  face the same bad-argument case, they must both throw (e.g. `Chat.sendToPlayer`
+  and `Entity.setVisibleTo` both reject a non-player argument).
+- **A missing subsystem is a state error, not a stale handle** — throw. Do not
+  silently drop the call (e.g. `Chat.send` with no network peer throws, matching
+  `TextLabel.create`).
+- Message format: `"<Api>.<method>: <what was expected / what went wrong>"`.
+
+## Registration
+
+There are two legitimate `Register` shapes; a builtin uses the one that matches
+what it needs, and nothing else diverges:
+
+- **Value / handle types** — pure v8pp classes attached to a target object:
+
+  ```cpp
+  static void Register(v8::Isolate *isolate, v8::Local<v8::Object> target);
+  ```
+
+  These need nothing from the runtime. The pure value types
+  (`Vector2/3/4`, `Quaternion`, `Color`) are registered together by
+  `Builtins::RegisterValueTypes`. Handle types (`Entity`, `Player`, `TextLabel`)
+  register individually because they pull in networking/replication and are
+  wired up by the integration layer, not by the value-type helper.
+
+- **Service APIs** — need the context and the `ResourceManager`:
+
+  ```cpp
+  static void Register(v8::Isolate *isolate, v8::Local<v8::Context> context,
+                       v8::Local<v8::Object> target, ResourceManager *manager);
+  ```
+
+  `Events` is the one deliberate variation: it is a non-static member of
+  `ResourceManager` (which owns the handler tables), so it is called as
+  `manager.GetEvents().Register(...)` with the same argument list.
+
+`RegisterValueTypes` registers **only** the pure value types — its name says so.
+It is the counterpart to `UnregisterAll`, which additionally drops the handle
+types' cached class wrappers on isolate disposal.

--- a/code/framework/src/scripting/builtins/README.md
+++ b/code/framework/src/scripting/builtins/README.md
@@ -83,7 +83,7 @@ they feed, which we don't get to renumber freely. Know which one an API wants:
 
 | Where | Representation |
 |---|---|
-| `Core.Color` internal (`r`/`g`/`b`/`a`, `vec()`) | floats in `[0, 1]` |
+| `Color` internal (`r`/`g`/`b`/`a`, `vec()`) | floats in `[0, 1]` |
 | `Color.fromRGB(r, g, b, a?)` | byte components `0–255` |
 | `Chat` message `color` option | packed `0xRRGGBBAA` (uint32) |
 | `TextLabel` `color` / `setColor` | packed **ARGB** `0xAARRGGBB` (uint32) |
@@ -93,7 +93,7 @@ different existing payloads; unifying them is a wire-format change, out of scope
 for a scripting-layer bump.
 
 To spare scripts from packing bytes in the right order, **the packed-int APIs
-also accept a `Core.Color`**: `Chat.send(text, { color: new Core.Color(...) })`
-and `label.setColor(new Core.Color(...))` each convert the Color into that API's
+also accept a `Color`**: `Chat.send(text, { color: new Color(...) })`
+and `label.setColor(new Color(...))` each convert the Color into that API's
 own packed layout. Prefer passing a `Color`; reach for the raw packed int only
 when you already have one.

--- a/code/framework/src/scripting/builtins/README.md
+++ b/code/framework/src/scripting/builtins/README.md
@@ -23,18 +23,21 @@ happen to be in:
 | Situation | Idiom |
 |---|---|
 | Wrong argument count, type, or shape | `isolate->ThrowException(v8::Exception::TypeError(...))` |
-| Valid call, but the world can't satisfy it (subsystem missing, resource not running, limit reached, no handler, cross-isolate) | `isolate->ThrowException(v8::Exception::Error(...))` |
-| A stale handle to a destroyed/absent object | silent no-op (return without throwing) |
+| Valid call, but the world can't satisfy it (subsystem missing, resource not running, limit reached, no handler, cross-isolate, argument's object has no live connection) | `isolate->ThrowException(v8::Exception::Error(...))` |
+| A method called on a stale **receiver** (`this` whose object is gone) | silent no-op (return without throwing) |
 
 Rules:
 
 - **Never** use `isolate->ThrowError(...)`. It is equivalent to
   `ThrowException(Exception::Error(...))` but hides the Error-vs-TypeError choice
   above. Always spell out `ThrowException(Exception::Error/TypeError(...))`.
-- **Silent no-op is only for stale handles.** A bad argument is a programming
-  error and must throw; swallowing it hides the caller's bug. If two builtins
-  face the same bad-argument case, they must both throw (e.g. `Chat.sendToPlayer`
-  and `Entity.setVisibleTo` both reject a non-player argument).
+- **Silent no-op is only for a stale receiver.** A method invoked on a handle
+  whose entity was destroyed returns quietly (common during async teardown; don't
+  crash the caller). Everything the *caller passes in* is different: a bad or
+  stale **argument** is the caller's bug and must throw. If two builtins face the
+  same bad-argument case, they must both throw — e.g. `Chat.sendToPlayer` and
+  `Entity.setVisibleTo` both reject a non-player argument (`TypeError`) and a
+  player with no owning connection (`Error`).
 - **A missing subsystem is a state error, not a stale handle** — throw. Do not
   silently drop the call (e.g. `Chat.send` with no network peer throws, matching
   `TextLabel.create`).

--- a/code/framework/src/scripting/builtins/README.md
+++ b/code/framework/src/scripting/builtins/README.md
@@ -74,3 +74,26 @@ what it needs, and nothing else diverges:
 `RegisterValueTypes` registers **only** the pure value types — its name says so.
 It is the counterpart to `UnregisterAll`, which additionally drops the handle
 types' cached class wrappers on isolate disposal.
+
+## Color representations
+
+Color is not stored one way across the surface — there are four representations,
+because the packed integer forms are dictated by the wire/replication payloads
+they feed, which we don't get to renumber freely. Know which one an API wants:
+
+| Where | Representation |
+|---|---|
+| `Core.Color` internal (`r`/`g`/`b`/`a`, `vec()`) | floats in `[0, 1]` |
+| `Color.fromRGB(r, g, b, a?)` | byte components `0–255` |
+| `Chat` message `color` option | packed `0xRRGGBBAA` (uint32) |
+| `TextLabel` `color` / `setColor` | packed **ARGB** `0xAARRGGBB` (uint32) |
+
+The two packed orders differ (`RRGGBBAA` vs `AARRGGBB`) because they mirror
+different existing payloads; unifying them is a wire-format change, out of scope
+for a scripting-layer bump.
+
+To spare scripts from packing bytes in the right order, **the packed-int APIs
+also accept a `Core.Color`**: `Chat.send(text, { color: new Core.Color(...) })`
+and `label.setColor(new Core.Color(...))` each convert the Color into that API's
+own packed layout. Prefer passing a `Color`; reach for the raw packed int only
+when you already have one.

--- a/code/framework/src/scripting/builtins/builtins.h
+++ b/code/framework/src/scripting/builtins/builtins.h
@@ -23,9 +23,11 @@
 namespace Framework::Scripting::Builtins {
 
     /**
-     * Register all builtin types on the target object.
+     * Register the pure value types (Vector2/3/4, Quaternion, Color) on the target
+     * object. Handle types (Entity, Player, TextLabel) and service APIs register
+     * themselves — see README.md. Counterpart to UnregisterAll.
      */
-    inline void RegisterAll(v8::Isolate *isolate, v8::Local<v8::Object> target) {
+    inline void RegisterValueTypes(v8::Isolate *isolate, v8::Local<v8::Object> target) {
         Vector2::Register(isolate, target);
         Vector3::Register(isolate, target);
         Vector4::Register(isolate, target);

--- a/code/framework/src/scripting/builtins/builtins.h
+++ b/code/framework/src/scripting/builtins/builtins.h
@@ -16,6 +16,10 @@
 
 #include <v8.h>
 
+// Conventions every builtin here follows — namespace, throw idiom, registration
+// shape — are documented in README.md next to this file. Match them when adding
+// or editing a builtin.
+
 namespace Framework::Scripting::Builtins {
 
     /**

--- a/code/framework/src/scripting/builtins/chat.cpp
+++ b/code/framework/src/scripting/builtins/chat.cpp
@@ -9,6 +9,7 @@
 #include "chat.h"
 
 #include "../scripting_catalog.h"
+#include "color.h"
 #include "entity.h"
 
 #include <core_modules.h>
@@ -38,8 +39,14 @@ namespace Framework::Scripting::Builtins {
                 author = v8pp::from_v8<std::string>(isolate, a);
             }
             v8::Local<v8::Value> c;
-            if (opts->Get(ctx, v8pp::to_v8(isolate, "color")).ToLocal(&c) && c->IsNumber()) {
-                color = c->Uint32Value(ctx).FromMaybe(0u);
+            if (opts->Get(ctx, v8pp::to_v8(isolate, "color")).ToLocal(&c)) {
+                if (c->IsNumber()) {
+                    color = c->Uint32Value(ctx).FromMaybe(0u);
+                }
+                else if (auto *col = v8pp::class_<Color>::unwrap_object(isolate, c)) {
+                    // Pack a Core.Color into Chat's 0xRRGGBBAA layout.
+                    color = col->toRGBA();
+                }
             }
         }
 
@@ -81,14 +88,14 @@ namespace Framework::Scripting::Builtins {
         metadata.record(v8pp::metadata::function_of<v8::FunctionCallback>("sendToAll", v8pp::metadata::docs("void",
                                                                                            {
                                                                                                v8pp::metadata::param("text", "string", false, "Message body broadcast to every connected client."),
-                                                                                               v8pp::metadata::param("options", "{ author?: string; color?: number }", true, "Optional author label and packed 0xRRGGBBAA color."),
+                                                                                               v8pp::metadata::param("options", "{ author?: string; color?: number | Color }", true, "Optional author label and color: a Core.Color or a packed 0xRRGGBBAA integer."),
                                                                                            },
                                                                                            "Broadcasts a structured chat message to all clients.")));
         metadata.record(v8pp::metadata::function_of<v8::FunctionCallback>("sendToPlayer", v8pp::metadata::docs("void",
                                                                                               {
                                                                                                   v8pp::metadata::param("player", "Entity", false, "Player-owned entity identifying the destination connection."),
                                                                                                   v8pp::metadata::param("text", "string", false, "Message body sent to the player."),
-                                                                                                  v8pp::metadata::param("options", "{ author?: string; color?: number }", true, "Optional author label and packed 0xRRGGBBAA color."),
+                                                                                                  v8pp::metadata::param("options", "{ author?: string; color?: number | Color }", true, "Optional author label and color: a Core.Color or a packed 0xRRGGBBAA integer."),
                                                                                               },
                                                                                               "Sends a structured chat message to one player's owning connection.")));
     }

--- a/code/framework/src/scripting/builtins/chat.cpp
+++ b/code/framework/src/scripting/builtins/chat.cpp
@@ -43,10 +43,11 @@ namespace Framework::Scripting::Builtins {
             }
         }
 
-        void Send(const std::string &text, const std::string &author, uint32_t color, MafiaNet::RakNetGUID target, bool broadcast) {
+        // Returns false when the network peer is unavailable so the caller can throw a state error.
+        bool Send(const std::string &text, const std::string &author, uint32_t color, MafiaNet::RakNetGUID target, bool broadcast) {
             auto *net = CoreModules::GetNetworkPeer();
             if (!net) {
-                return;
+                return false;
             }
             Networking::RPC::ChatMessage payload;
             payload.text   = text;
@@ -58,6 +59,7 @@ namespace Framework::Scripting::Builtins {
             else {
                 net->SendRPC(payload, target);
             }
+            return true;
         }
     } // namespace
 
@@ -95,7 +97,7 @@ namespace Framework::Scripting::Builtins {
         v8::Isolate *isolate = info.GetIsolate();
         v8::HandleScope hs(isolate);
         if (info.Length() < 1 || !info[0]->IsString()) {
-            isolate->ThrowError(v8pp::to_v8(isolate, "Chat.sendToAll: expected (text, opts?)"));
+            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "Chat.sendToAll: expected (text, opts?)")));
             return;
         }
         std::string author;
@@ -103,22 +105,27 @@ namespace Framework::Scripting::Builtins {
         if (info.Length() >= 2) {
             ReadOptions(isolate, info[1], author, color);
         }
-        Send(v8pp::from_v8<std::string>(isolate, info[0]), author, color, MafiaNet::UNASSIGNED_RAKNET_GUID, true);
+        if (!Send(v8pp::from_v8<std::string>(isolate, info[0]), author, color, MafiaNet::UNASSIGNED_RAKNET_GUID, true)) {
+            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "Chat.sendToAll: network peer unavailable")));
+        }
     }
 
     void Chat::JS_SendToPlayer(const v8::FunctionCallbackInfo<v8::Value> &info) {
         v8::Isolate *isolate = info.GetIsolate();
         v8::HandleScope hs(isolate);
         if (info.Length() < 2 || !info[1]->IsString()) {
-            isolate->ThrowError(v8pp::to_v8(isolate, "Chat.sendToPlayer: expected (player, text, opts?)"));
+            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "Chat.sendToPlayer: expected (player, text, opts?)")));
             return;
         }
+        // Bad argument (not a player) is the caller's bug — throw, mirroring Entity.setVisibleTo.
         auto *entity = v8pp::class_<Entity>::unwrap_object(isolate, info[0]);
         if (!entity) {
+            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "Chat.sendToPlayer: expected a Player")));
             return;
         }
         auto *handle = entity->GetHandle();
         if (!handle) {
+            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "Chat.sendToPlayer: player has no owning connection")));
             return;
         }
         std::string author;
@@ -126,6 +133,8 @@ namespace Framework::Scripting::Builtins {
         if (info.Length() >= 3) {
             ReadOptions(isolate, info[2], author, color);
         }
-        Send(v8pp::from_v8<std::string>(isolate, info[1]), author, color, MafiaNet::ToGuid(handle->ownerGUID), false);
+        if (!Send(v8pp::from_v8<std::string>(isolate, info[1]), author, color, MafiaNet::ToGuid(handle->ownerGUID), false)) {
+            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "Chat.sendToPlayer: network peer unavailable")));
+        }
     }
 } // namespace Framework::Scripting::Builtins

--- a/code/framework/src/scripting/builtins/color.cpp
+++ b/code/framework/src/scripting/builtins/color.cpp
@@ -118,7 +118,7 @@ namespace Framework::Scripting::Builtins {
                     "Replaces this color's normalized components in place.", "This mutated color for chaining."))
             .function("clone", &Color::clone, v8pp::metadata::docs("Color", {}, "Creates an independent copy of this color.", "New color with the same components."))
             .function("toHex", &Color::toHex,
-                v8pp::metadata::docs("string", {v8pp::metadata::param("includeAlpha", "boolean", true, "Whether to append the alpha byte; defaults to false.")}, "Converts normalized components to a hexadecimal CSS-style string.", "Uppercase #RRGGBB or #RRGGBBAA string."))
+                v8pp::metadata::docs("string", {v8pp::metadata::param("includeAlpha", "boolean", true, "Whether to append the alpha byte; defaults to false.")}, "Converts normalized components to a hexadecimal CSS-style string.", "Lowercase #rrggbb or #rrggbbaa string."))
             .function("toString", &Color::toString, v8pp::metadata::docs("string", {}, "Formats this color for logging and debugging.", "Text in Color(r, g, b, a) form."));
 
         // Add properties manually using v8's SetNativeDataProperty with correct signature
@@ -221,7 +221,7 @@ namespace Framework::Scripting::Builtins {
         auto &metadata = GetScriptingCatalog(isolate).constructor("Color");
         metadata.record(v8pp::metadata::function_of<v8::FunctionCallback>("toJSON", v8pp::metadata::docs("{ r: number; g: number; b: number; a: number }", {}, "Converts this color to a plain object for JSON.stringify.", "Object containing the current normalized components.")));
         metadata.record(v8pp::metadata::function_of<decltype(&Color::fromHex)>("fromHex",
-            v8pp::metadata::docs("Color", {v8pp::metadata::param("hex", "string", false, "Hexadecimal color in #RGB, #RGBA, #RRGGBB, or #RRGGBBAA form.")}, "Parses a hexadecimal color string.", "Parsed color, or opaque white when the input is invalid."), true));
+            v8pp::metadata::docs("Color", {v8pp::metadata::param("hex", "string", false, "Hexadecimal color in #RRGGBB or #RRGGBBAA form; the leading # is optional. Three- and four-digit shorthands are not supported.")}, "Parses a hexadecimal color string.", "Parsed color, or opaque white when the input is invalid."), true));
         metadata.record(v8pp::metadata::function_of<decltype(&Color::fromRGB)>("fromRGB",
             v8pp::metadata::docs("Color",
                 {v8pp::metadata::param("r", "number", false, "Red byte from 0 to 255."), v8pp::metadata::param("g", "number", false, "Green byte from 0 to 255."), v8pp::metadata::param("b", "number", false, "Blue byte from 0 to 255."),

--- a/code/framework/src/scripting/builtins/color.cpp
+++ b/code/framework/src/scripting/builtins/color.cpp
@@ -99,14 +99,26 @@ namespace Framework::Scripting::Builtins {
         auto &cls = _classes[isolate];
         cls       = std::make_unique<v8pp::class_<Color>>(isolate, GetScriptingCatalog(isolate), "Color", "Mutable RGBA color exposed as Core.Color, with components stored from 0 to 1.");
         cls->auto_wrap_objects(true); // Enable auto-wrapping for return values
-        cls->ctor<float, float, float, std::optional<float>>(v8pp::metadata::docs("void",
-                                                                 {
-                                                                     v8pp::metadata::param("r", "number", false, "Initial red component from 0 to 1."),
-                                                                     v8pp::metadata::param("g", "number", false, "Initial green component from 0 to 1."),
-                                                                     v8pp::metadata::param("b", "number", false, "Initial blue component from 0 to 1."),
-                                                                     v8pp::metadata::param("a", "number", true, "Optional alpha component from 0 to 1; defaults to 1."),
-                                                                 },
-                                                                 "Creates a color from normalized RGBA components."))
+        // Custom constructor callback rather than the default ctor<...> factory: v8pp's factory
+        // forwards args as std::optional<float>&&, which its is_optional trait doesn't recognize, so
+        // the default path would wrongly require all four arguments. This makes alpha truly optional
+        // (defaults to 1) while keeping the documented metadata below.
+        cls->ctor<float, float, float, std::optional<float>>(
+            v8pp::metadata::docs("void",
+                {
+                    v8pp::metadata::param("r", "number", false, "Initial red component from 0 to 1."),
+                    v8pp::metadata::param("g", "number", false, "Initial green component from 0 to 1."),
+                    v8pp::metadata::param("b", "number", false, "Initial blue component from 0 to 1."),
+                    v8pp::metadata::param("a", "number", true, "Optional alpha component from 0 to 1; defaults to 1."),
+                },
+                "Creates a color from normalized RGBA components."),
+            [](const v8::FunctionCallbackInfo<v8::Value> &args) -> Color * {
+                v8::Local<v8::Context> ctx = args.GetIsolate()->GetCurrentContext();
+                const auto num             = [&](int i, double fallback) {
+                    return (args.Length() > i && args[i]->IsNumber()) ? args[i]->NumberValue(ctx).FromMaybe(fallback) : fallback;
+                };
+                return new Color(static_cast<float>(num(0, 0.0)), static_cast<float>(num(1, 0.0)), static_cast<float>(num(2, 0.0)), static_cast<float>(num(3, 1.0)));
+            })
             // Instance methods
             .function("lerp", &Color::lerp,
                 v8pp::metadata::docs("this", {v8pp::metadata::param("target", "Color", false, "Destination color."), v8pp::metadata::param("t", "number", false, "Interpolation factor; 0 keeps this color and 1 reaches target.")},

--- a/code/framework/src/scripting/builtins/color.cpp
+++ b/code/framework/src/scripting/builtins/color.cpp
@@ -233,6 +233,11 @@ namespace Framework::Scripting::Builtins {
         global->Set(ctx, v8pp::to_v8(isolate, "Color"), cls.js_function_template()->GetFunction(ctx).ToLocalChecked()).Check();
     }
 
+    v8::Local<v8::Object> Color::NewInstance(v8::Isolate *isolate, const glm::vec4 &value) {
+        v8pp::class_<Color> &cls = GetClass(isolate);
+        return cls.import_external(isolate, new Color(value));
+    }
+
     void Color::UnregisterIsolate(v8::Isolate *isolate) {
         _classes.erase(isolate);
     }

--- a/code/framework/src/scripting/builtins/color.cpp
+++ b/code/framework/src/scripting/builtins/color.cpp
@@ -38,6 +38,20 @@ namespace Framework::Scripting::Builtins {
         return ss.str();
     }
 
+    namespace {
+        uint32_t colorByte(float v) {
+            return static_cast<uint32_t>(std::lround(std::clamp(v, 0.0f, 1.0f) * 255.0f));
+        }
+    } // namespace
+
+    uint32_t Color::toRGBA() const {
+        return (colorByte(_color.r) << 24) | (colorByte(_color.g) << 16) | (colorByte(_color.b) << 8) | colorByte(_color.a);
+    }
+
+    uint32_t Color::toARGB() const {
+        return (colorByte(_color.a) << 24) | (colorByte(_color.r) << 16) | (colorByte(_color.g) << 8) | colorByte(_color.b);
+    }
+
     std::string Color::toString() const {
         std::ostringstream ss;
         ss << "Color(" << _color.r << ", " << _color.g << ", " << _color.b << ", " << _color.a << ")";

--- a/code/framework/src/scripting/builtins/color.h
+++ b/code/framework/src/scripting/builtins/color.h
@@ -8,87 +8,131 @@
 
 #pragma once
 
-#include <v8pp/class.hpp>
-#include <v8pp/property.hpp>
-#include <glm/glm.hpp>
 #include <cstdint>
-#include <string>
-#include <string_view>
+#include <glm/glm.hpp>
 #include <memory>
 #include <optional>
+#include <string>
+#include <string_view>
 #include <unordered_map>
+#include <v8pp/class.hpp>
+#include <v8pp/property.hpp>
 
 namespace Framework::Scripting::Builtins {
 
-/**
- * Color wrapper class for V8 bindings using v8pp.
- * Provides a clean C++ interface that wraps glm::vec4 for RGBA colors.
- * Components are stored as floats in range [0, 1].
- */
-class Color final {
-  public:
-    Color() : _color(1.0f) {}
-    // v8pp treats std::optional parameters as JS-optional. Keep the C++
-    // default (std::nullopt -> 1.0f) so existing callers writing
-    // Color(r,g,b) and Color(r,g,b,a) both compile unchanged.
-    Color(float r, float g, float b, std::optional<float> a = std::nullopt)
-        : _color(r, g, b, a.value_or(1.0f)) {}
-    Color(const glm::vec4& c) : _color(c) {}
+    /**
+     * Color wrapper class for V8 bindings using v8pp.
+     * Provides a clean C++ interface that wraps glm::vec4 for RGBA colors.
+     * Components are stored as floats in range [0, 1].
+     */
+    class Color final {
+      public:
+        Color(): _color(1.0f) {}
+        // v8pp treats std::optional parameters as JS-optional. Keep the C++
+        // default (std::nullopt -> 1.0f) so existing callers writing
+        // Color(r,g,b) and Color(r,g,b,a) both compile unchanged.
+        Color(float r, float g, float b, std::optional<float> a = std::nullopt): _color(r, g, b, a.value_or(1.0f)) {}
+        Color(const glm::vec4 &c): _color(c) {}
 
-    // Property accessors
-    float getR() const { return _color.r; }
-    void setR(float v) { _color.r = v; }
-    float getG() const { return _color.g; }
-    void setG(float v) { _color.g = v; }
-    float getB() const { return _color.b; }
-    void setB(float v) { _color.b = v; }
-    float getA() const { return _color.a; }
-    void setA(float v) { _color.a = v; }
+        // Property accessors
+        float getR() const {
+            return _color.r;
+        }
+        void setR(float v) {
+            _color.r = v;
+        }
+        float getG() const {
+            return _color.g;
+        }
+        void setG(float v) {
+            _color.g = v;
+        }
+        float getB() const {
+            return _color.b;
+        }
+        void setB(float v) {
+            _color.b = v;
+        }
+        float getA() const {
+            return _color.a;
+        }
+        void setA(float v) {
+            _color.a = v;
+        }
 
-    // Mutable methods (modify in place, return this for chaining)
-    Color& lerp(const Color& target, float t) { _color = glm::mix(_color, target._color, t); return *this; }
-    Color& set(float r, float g, float b, std::optional<float> a = std::nullopt) {
-        _color.r = r; _color.g = g; _color.b = b; _color.a = a.value_or(1.0f); return *this;
-    }
+        // Mutable methods (modify in place, return this for chaining)
+        Color &lerp(const Color &target, float t) {
+            _color = glm::mix(_color, target._color, t);
+            return *this;
+        }
+        Color &set(float r, float g, float b, std::optional<float> a = std::nullopt) {
+            _color.r = r;
+            _color.g = g;
+            _color.b = b;
+            _color.a = a.value_or(1.0f);
+            return *this;
+        }
 
-    // Non-mutating methods
-    Color clone() const { return Color(_color); }
-    std::string toHex(std::optional<bool> includeAlpha = std::nullopt) const;
-    std::string toString() const;
+        // Non-mutating methods
+        Color clone() const {
+            return Color(_color);
+        }
+        std::string toHex(std::optional<bool> includeAlpha = std::nullopt) const;
+        std::string toString() const;
 
-    // Static factory methods
-    static Color fromHex(std::string_view hex);
-    static Color fromRGB(float r, float g, float b, std::optional<float> a = std::nullopt);
-    static Color white() { return Color(1.0f, 1.0f, 1.0f, 1.0f); }
-    static Color black() { return Color(0.0f, 0.0f, 0.0f, 1.0f); }
-    static Color red() { return Color(1.0f, 0.0f, 0.0f, 1.0f); }
-    static Color green() { return Color(0.0f, 1.0f, 0.0f, 1.0f); }
-    static Color blue() { return Color(0.0f, 0.0f, 1.0f, 1.0f); }
-    static Color yellow() { return Color(1.0f, 1.0f, 0.0f, 1.0f); }
-    static Color cyan() { return Color(0.0f, 1.0f, 1.0f, 1.0f); }
-    static Color magenta() { return Color(1.0f, 0.0f, 1.0f, 1.0f); }
-    static Color transparent() { return Color(0.0f, 0.0f, 0.0f, 0.0f); }
+        // Static factory methods
+        static Color fromHex(std::string_view hex);
+        static Color fromRGB(float r, float g, float b, std::optional<float> a = std::nullopt);
+        static Color white() {
+            return Color(1.0f, 1.0f, 1.0f, 1.0f);
+        }
+        static Color black() {
+            return Color(0.0f, 0.0f, 0.0f, 1.0f);
+        }
+        static Color red() {
+            return Color(1.0f, 0.0f, 0.0f, 1.0f);
+        }
+        static Color green() {
+            return Color(0.0f, 1.0f, 0.0f, 1.0f);
+        }
+        static Color blue() {
+            return Color(0.0f, 0.0f, 1.0f, 1.0f);
+        }
+        static Color yellow() {
+            return Color(1.0f, 1.0f, 0.0f, 1.0f);
+        }
+        static Color cyan() {
+            return Color(0.0f, 1.0f, 1.0f, 1.0f);
+        }
+        static Color magenta() {
+            return Color(1.0f, 0.0f, 1.0f, 1.0f);
+        }
+        static Color transparent() {
+            return Color(0.0f, 0.0f, 0.0f, 0.0f);
+        }
 
-    // Access underlying GLM type
-    const glm::vec4& vec() const { return _color; }
+        // Access underlying GLM type
+        const glm::vec4 &vec() const {
+            return _color;
+        }
 
-    // Pack into the two integer layouts the packed-int APIs use (bytes clamped
-    // to 0-255). Chat wants RGBA; TextLabel wants ARGB. See README "Color
-    // representations".
-    uint32_t toRGBA() const; // 0xRRGGBBAA
-    uint32_t toARGB() const; // 0xAARRGGBB
+        // Pack into the two integer layouts the packed-int APIs use (bytes clamped
+        // to 0-255). Chat wants RGBA; TextLabel wants ARGB. See README "Color
+        // representations".
+        uint32_t toRGBA() const; // 0xRRGGBBAA
+        uint32_t toARGB() const; // 0xAARRGGBB
 
-    // V8 Registration
-    static void Register(v8::Isolate* isolate, v8::Local<v8::Object> global);
-    static v8pp::class_<Color>& GetClass(v8::Isolate* isolate);
-    // Wrap a native color as a JS Color, so C++ (e.g. the native SDK) can return
-    // one to script. Mirrors Vector3/Quaternion::NewInstance.
-    static v8::Local<v8::Object> NewInstance(v8::Isolate* isolate, const glm::vec4& value);
-    static void UnregisterIsolate(v8::Isolate* isolate);
+        // V8 Registration
+        static void Register(v8::Isolate *isolate, v8::Local<v8::Object> global);
+        static v8pp::class_<Color> &GetClass(v8::Isolate *isolate);
+        // Wrap a native color as a JS Color, so C++ (e.g. the native SDK) can return
+        // one to script. Mirrors Vector3/Quaternion::NewInstance.
+        static v8::Local<v8::Object> NewInstance(v8::Isolate *isolate, const glm::vec4 &value);
+        static void UnregisterIsolate(v8::Isolate *isolate);
 
-  private:
-    glm::vec4 _color;
-    static std::unordered_map<v8::Isolate*, std::unique_ptr<v8pp::class_<Color>>> _classes;
-};
+      private:
+        glm::vec4 _color;
+        static std::unordered_map<v8::Isolate *, std::unique_ptr<v8pp::class_<Color>>> _classes;
+    };
 
 } // namespace Framework::Scripting::Builtins

--- a/code/framework/src/scripting/builtins/color.h
+++ b/code/framework/src/scripting/builtins/color.h
@@ -74,6 +74,9 @@ class Color final {
     // V8 Registration
     static void Register(v8::Isolate* isolate, v8::Local<v8::Object> global);
     static v8pp::class_<Color>& GetClass(v8::Isolate* isolate);
+    // Wrap a native color as a JS Color, so C++ (e.g. the native SDK) can return
+    // one to script. Mirrors Vector3/Quaternion::NewInstance.
+    static v8::Local<v8::Object> NewInstance(v8::Isolate* isolate, const glm::vec4& value);
     static void UnregisterIsolate(v8::Isolate* isolate);
 
   private:

--- a/code/framework/src/scripting/builtins/color.h
+++ b/code/framework/src/scripting/builtins/color.h
@@ -11,6 +11,7 @@
 #include <v8pp/class.hpp>
 #include <v8pp/property.hpp>
 #include <glm/glm.hpp>
+#include <cstdint>
 #include <string>
 #include <string_view>
 #include <memory>
@@ -70,6 +71,12 @@ class Color final {
 
     // Access underlying GLM type
     const glm::vec4& vec() const { return _color; }
+
+    // Pack into the two integer layouts the packed-int APIs use (bytes clamped
+    // to 0-255). Chat wants RGBA; TextLabel wants ARGB. See README "Color
+    // representations".
+    uint32_t toRGBA() const; // 0xRRGGBBAA
+    uint32_t toARGB() const; // 0xAARRGGBB
 
     // V8 Registration
     static void Register(v8::Isolate* isolate, v8::Local<v8::Object> global);

--- a/code/framework/src/scripting/builtins/console.cpp
+++ b/code/framework/src/scripting/builtins/console.cpp
@@ -16,7 +16,7 @@
 #include <limits>
 #include <sstream>
 
-namespace Framework::Scripting {
+namespace Framework::Scripting::Builtins {
 
     void Console::Register(v8::Isolate *isolate, v8::Local<v8::Context> context, ResourceManager *resourceManager) {
         v8::Local<v8::Object> consoleObj = v8::Object::New(isolate);
@@ -190,4 +190,4 @@ namespace Framework::Scripting {
         LogWithLevel(args, spdlog::level::debug);
     }
 
-} // namespace Framework::Scripting
+} // namespace Framework::Scripting::Builtins

--- a/code/framework/src/scripting/builtins/console.h
+++ b/code/framework/src/scripting/builtins/console.h
@@ -16,8 +16,10 @@
 #include <string>
 
 namespace Framework::Scripting {
-
     class ResourceManager;
+}
+
+namespace Framework::Scripting::Builtins {
 
     /**
      * Console override that routes to Framework logger.
@@ -57,4 +59,4 @@ namespace Framework::Scripting {
 
     };
 
-} // namespace Framework::Scripting
+} // namespace Framework::Scripting::Builtins

--- a/code/framework/src/scripting/builtins/entity.cpp
+++ b/code/framework/src/scripting/builtins/entity.cpp
@@ -149,7 +149,7 @@ namespace Framework::Scripting::Builtins {
                 }
                 auto *targetEntity = target->Resolve();
                 if (!targetEntity || targetEntity->ownerGUID == MafiaNet::UNASSIGNED_PEER_GUID) {
-                    isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "setVisibleTo: target has no owning connection")));
+                    isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "setVisibleTo: target has no owning connection")));
                     return;
                 }
                 self->SetVisibleTo(targetEntity);

--- a/code/framework/src/scripting/builtins/environment.cpp
+++ b/code/framework/src/scripting/builtins/environment.cpp
@@ -15,14 +15,14 @@ namespace Framework::Scripting::Builtins {
 
     void Environment::Register(v8::Isolate *isolate, v8::Local<v8::Context> context, v8::Local<v8::Object> target, bool isClient) {
         v8pp::module env(isolate);
-        env.const_("IsClient", isClient);
-        env.const_("IsServer", !isClient);
+        env.const_("isClient", isClient);
+        env.const_("isServer", !isClient);
 
         target->Set(context, v8pp::to_v8(isolate, "Environment"), env.new_instance()).Check();
 
         auto &metadata = GetScriptingCatalog(isolate).global_object("Environment", "Runtime-side flags exposed as Core.Environment.");
-        metadata.add_property("IsClient", "boolean", "True in the sandboxed client scripting runtime.", true);
-        metadata.add_property("IsServer", "boolean", "True in the authoritative server scripting runtime.", true);
+        metadata.add_property("isClient", "boolean", "True in the sandboxed client scripting runtime.", true);
+        metadata.add_property("isServer", "boolean", "True in the authoritative server scripting runtime.", true);
     }
 
 } // namespace Framework::Scripting::Builtins

--- a/code/framework/src/scripting/builtins/environment.cpp
+++ b/code/framework/src/scripting/builtins/environment.cpp
@@ -11,7 +11,7 @@
 
 #include <v8pp/convert.hpp>
 
-namespace Framework::Scripting {
+namespace Framework::Scripting::Builtins {
 
     void Environment::Register(v8::Isolate *isolate, v8::Local<v8::Context> context, v8::Local<v8::Object> target, bool isClient) {
         v8pp::module env(isolate);
@@ -25,4 +25,4 @@ namespace Framework::Scripting {
         metadata.add_property("IsServer", "boolean", "True in the authoritative server scripting runtime.", true);
     }
 
-} // namespace Framework::Scripting
+} // namespace Framework::Scripting::Builtins

--- a/code/framework/src/scripting/builtins/environment.h
+++ b/code/framework/src/scripting/builtins/environment.h
@@ -16,8 +16,8 @@ namespace Framework::Scripting::Builtins {
      * JavaScript Environment API - provides runtime environment information.
      *
      * Exposes an Environment global object:
-     * - Environment.IsClient - true if running on the client side (read-only)
-     * - Environment.IsServer - true if running on the server side (read-only)
+     * - Environment.isClient - true if running on the client side (read-only)
+     * - Environment.isServer - true if running on the server side (read-only)
      */
     class Environment final {
       public:

--- a/code/framework/src/scripting/builtins/environment.h
+++ b/code/framework/src/scripting/builtins/environment.h
@@ -10,7 +10,7 @@
 
 #include <v8pp/module.hpp>
 
-namespace Framework::Scripting {
+namespace Framework::Scripting::Builtins {
 
     /**
      * JavaScript Environment API - provides runtime environment information.
@@ -34,4 +34,4 @@ namespace Framework::Scripting {
                             bool isClient);
     };
 
-} // namespace Framework::Scripting
+} // namespace Framework::Scripting::Builtins

--- a/code/framework/src/scripting/builtins/events.cpp
+++ b/code/framework/src/scripting/builtins/events.cpp
@@ -426,6 +426,7 @@ namespace Framework::Scripting::Builtins {
 
         CallbackContext *ctx = static_cast<CallbackContext *>(args.Data().As<v8::External>()->Value());
         if (!ctx || !ctx->events || !ctx->resourceManager) {
+            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, std::string("Events.") + api + ": context not available")));
             return;
         }
 
@@ -436,8 +437,10 @@ namespace Framework::Scripting::Builtins {
         v8::Local<v8::Function> handler = args[1].As<v8::Function>();
         std::string resourceName        = GetResourceContextWithFallback(isolate, manager, handler);
 
-        // If no resource context, we can't determine which resource to remove handlers for
+        // No resource context: like Events.on, this is a state error, not a silent no-op — we can't
+        // determine which resource's handler to remove.
         if (resourceName.empty()) {
+            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, std::string("Events.") + api + ": must be called from within a resource")));
             return;
         }
 

--- a/code/framework/src/scripting/builtins/events.cpp
+++ b/code/framework/src/scripting/builtins/events.cpp
@@ -16,7 +16,7 @@
 #include <logging/logger.h>
 #include <networking/network_peer.h>
 
-namespace Framework::Scripting {
+namespace Framework::Scripting::Builtins {
 
     // Context for AllSettled callback - holds resolver, error message, and owner for cleanup
     // Defined early so destructor can access it
@@ -984,4 +984,4 @@ namespace Framework::Scripting {
         args.GetReturnValue().Set(static_cast<uint32_t>(count));
     }
 
-} // namespace Framework::Scripting
+} // namespace Framework::Scripting::Builtins

--- a/code/framework/src/scripting/builtins/events.cpp
+++ b/code/framework/src/scripting/builtins/events.cpp
@@ -226,6 +226,8 @@ namespace Framework::Scripting::Builtins {
 
         auto *peer = CoreModules::GetNetworkPeer();
         if (!peer) {
+            // Missing subsystem is a state error, not a stale receiver — throw (README idiom).
+            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, std::string("Events.") + api + ": network peer unavailable")));
             return;
         }
         Framework::Integrations::Shared::RPC::EmitScriptEvent ev;

--- a/code/framework/src/scripting/builtins/events.cpp
+++ b/code/framework/src/scripting/builtins/events.cpp
@@ -203,7 +203,7 @@ namespace Framework::Scripting {
         v8::HandleScope handleScope(isolate);
 
         if (args.Length() < 1 || !args[0]->IsString()) {
-            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, std::string("Events.") + api + " requires an eventName string")));
+            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, std::string("Events.") + api + " requires an eventName string")));
             return;
         }
         const std::string eventName = v8pp::from_v8<std::string>(isolate, args[0]);
@@ -265,17 +265,17 @@ namespace Framework::Scripting {
         const char *api                = EventApiName(scope == HandlerScope::Client, "on");
 
         if (args.Length() < 2) {
-            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, std::string("Events.") + api + " requires 2 arguments: eventName, handler")));
+            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, std::string("Events.") + api + " requires 2 arguments: eventName, handler")));
             return;
         }
 
         if (!args[0]->IsString()) {
-            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, std::string("Events.") + api + ": eventName must be a string")));
+            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, std::string("Events.") + api + ": eventName must be a string")));
             return;
         }
 
         if (!args[1]->IsFunction()) {
-            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, std::string("Events.") + api + ": handler must be a function")));
+            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, std::string("Events.") + api + ": handler must be a function")));
             return;
         }
 
@@ -379,12 +379,12 @@ namespace Framework::Scripting {
         const char *api = EventApiName(scope == HandlerScope::Client, "once");
 
         if (args.Length() < 2) {
-            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, std::string("Events.") + api + " requires 2 arguments: eventName, handler")));
+            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, std::string("Events.") + api + " requires 2 arguments: eventName, handler")));
             return;
         }
 
         if (!args[0]->IsString() || !args[1]->IsFunction()) {
-            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, std::string("Events.") + api + ": invalid arguments")));
+            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, std::string("Events.") + api + ": invalid arguments")));
             return;
         }
 
@@ -414,11 +414,13 @@ namespace Framework::Scripting {
         const char *api = EventApiName(scope == HandlerScope::Client, "off");
 
         if (args.Length() < 2) {
-            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, std::string("Events.") + api + " requires 2 arguments: eventName, handler")));
+            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, std::string("Events.") + api + " requires 2 arguments: eventName, handler")));
             return;
         }
 
+        // Bad arguments must throw, like Events.on — a silent no-op here hid caller bugs.
         if (!args[0]->IsString() || !args[1]->IsFunction()) {
+            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, std::string("Events.") + api + ": eventName must be a string and handler a function")));
             return;
         }
 
@@ -739,12 +741,12 @@ namespace Framework::Scripting {
         v8::Local<v8::Context> context = isolate->GetCurrentContext();
 
         if (args.Length() < 1) {
-            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "Events.emit requires at least 1 argument: eventName")));
+            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "Events.emit requires at least 1 argument: eventName")));
             return;
         }
 
         if (!args[0]->IsString()) {
-            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "Events.emit: eventName must be a string")));
+            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "Events.emit: eventName must be a string")));
             return;
         }
 
@@ -771,12 +773,12 @@ namespace Framework::Scripting {
         v8::Local<v8::Context> context = isolate->GetCurrentContext();
 
         if (args.Length() < 2) {
-            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "Events.emitTo requires at least 2 arguments: resourceName, eventName")));
+            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "Events.emitTo requires at least 2 arguments: resourceName, eventName")));
             return;
         }
 
         if (!args[0]->IsString() || !args[1]->IsString()) {
-            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "Events.emitTo: resourceName and eventName must be strings")));
+            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "Events.emitTo: resourceName and eventName must be strings")));
             return;
         }
 
@@ -803,7 +805,7 @@ namespace Framework::Scripting {
         v8::HandleScope handleScope(isolate);
 
         if (args.Length() < 2 || !args[0]->IsString() || !args[1]->IsFunction()) {
-            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "Events.onLocal requires 2 arguments: eventName, handler")));
+            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "Events.onLocal requires 2 arguments: eventName, handler")));
             return;
         }
 
@@ -839,7 +841,7 @@ namespace Framework::Scripting {
         v8::Local<v8::Context> context = isolate->GetCurrentContext();
 
         if (args.Length() < 1 || !args[0]->IsString()) {
-            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "Events.emitLocal requires at least 1 argument: eventName")));
+            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "Events.emitLocal requires at least 1 argument: eventName")));
             return;
         }
 

--- a/code/framework/src/scripting/builtins/events.cpp
+++ b/code/framework/src/scripting/builtins/events.cpp
@@ -198,7 +198,7 @@ namespace Framework::Scripting::Builtins {
     // Shared body for emitServer/emitAllClients: BroadcastRPC a named event + payload over the peer's
     // connections (a client peer reaches only the server, a server peer all clients). A string payload
     // is sent verbatim; any other value is JSON-serialized here. `api` names the caller in errors.
-    static void BroadcastLuaEvent(const v8::FunctionCallbackInfo<v8::Value> &args, const char *api) {
+    static void BroadcastScriptEvent(const v8::FunctionCallbackInfo<v8::Value> &args, const char *api) {
         v8::Isolate *isolate = args.GetIsolate();
         v8::HandleScope handleScope(isolate);
 
@@ -365,12 +365,12 @@ namespace Framework::Scripting::Builtins {
 
     // Client -> server, dispatched there to onClient(name, (player, data)).
     void Events::EmitServerCallback(const v8::FunctionCallbackInfo<v8::Value> &args) {
-        BroadcastLuaEvent(args, "emitServer");
+        BroadcastScriptEvent(args, "emitServer");
     }
 
     // Server -> every client, arriving as Core.Events.on(name, data).
     void Events::EmitAllClientsCallback(const v8::FunctionCallbackInfo<v8::Value> &args) {
-        BroadcastLuaEvent(args, "emitAllClients");
+        BroadcastScriptEvent(args, "emitAllClients");
     }
 
     void Events::OnceImpl(const v8::FunctionCallbackInfo<v8::Value> &args, HandlerScope scope) {

--- a/code/framework/src/scripting/builtins/events.cpp
+++ b/code/framework/src/scripting/builtins/events.cpp
@@ -536,7 +536,15 @@ namespace Framework::Scripting {
             return;
         }
 
-        v8::Local<v8::Promise> allPromise = allSettledResult.ToLocalChecked().As<v8::Promise>();
+        // A script-replaced Promise.allSettled may return a non-Promise; guard before
+        // casting so we don't reach ->Then() on a bad handle. Soft-resolve like the siblings.
+        v8::Local<v8::Value> allSettledValue = allSettledResult.ToLocalChecked();
+        if (!allSettledValue->IsPromise()) {
+            resolver->Resolve(context, v8::Undefined(isolate)).Check();
+            return;
+        }
+
+        v8::Local<v8::Promise> allPromise = allSettledValue.As<v8::Promise>();
 
         // Allocate callback data and track it for cleanup on Events destruction
         // Use shared_ptr so the data survives until either:

--- a/code/framework/src/scripting/builtins/events.h
+++ b/code/framework/src/scripting/builtins/events.h
@@ -21,8 +21,10 @@
 #include <vector>
 
 namespace Framework::Scripting {
-
     class ResourceManager;
+}
+
+namespace Framework::Scripting::Builtins {
 
     /**
      * Handler entry with metadata
@@ -220,4 +222,4 @@ namespace Framework::Scripting {
         std::mutex _pendingCallbacksMutex;
     };
 
-} // namespace Framework::Scripting
+} // namespace Framework::Scripting::Builtins

--- a/code/framework/src/scripting/builtins/execution_environment.cpp
+++ b/code/framework/src/scripting/builtins/execution_environment.cpp
@@ -6,21 +6,21 @@
  * See LICENSE file in the source repository for information regarding licensing.
  */
 
-#include "environment.h"
+#include "execution_environment.h"
 #include "../scripting_catalog.h"
 
 #include <v8pp/convert.hpp>
 
 namespace Framework::Scripting::Builtins {
 
-    void Environment::Register(v8::Isolate *isolate, v8::Local<v8::Context> context, v8::Local<v8::Object> target, bool isClient) {
+    void ExecutionEnvironment::Register(v8::Isolate *isolate, v8::Local<v8::Context> context, v8::Local<v8::Object> target, bool isClient) {
         v8pp::module env(isolate);
         env.const_("isClient", isClient);
         env.const_("isServer", !isClient);
 
-        target->Set(context, v8pp::to_v8(isolate, "Environment"), env.new_instance()).Check();
+        target->Set(context, v8pp::to_v8(isolate, "ExecutionEnvironment"), env.new_instance()).Check();
 
-        auto &metadata = GetScriptingCatalog(isolate).global_object("Environment", "Runtime-side flags exposed as Core.Environment.");
+        auto &metadata = GetScriptingCatalog(isolate).global_object("ExecutionEnvironment", "Runtime-side flags exposed as the global ExecutionEnvironment.");
         metadata.add_property("isClient", "boolean", "True in the sandboxed client scripting runtime.", true);
         metadata.add_property("isServer", "boolean", "True in the authoritative server scripting runtime.", true);
     }

--- a/code/framework/src/scripting/builtins/execution_environment.h
+++ b/code/framework/src/scripting/builtins/execution_environment.h
@@ -13,19 +13,19 @@
 namespace Framework::Scripting::Builtins {
 
     /**
-     * JavaScript Environment API - provides runtime environment information.
+     * JavaScript ExecutionEnvironment API - provides runtime environment information.
      *
-     * Exposes an Environment global object:
-     * - Environment.isClient - true if running on the client side (read-only)
-     * - Environment.isServer - true if running on the server side (read-only)
+     * Exposes an ExecutionEnvironment global object:
+     * - ExecutionEnvironment.isClient - true if running on the client side (read-only)
+     * - ExecutionEnvironment.isServer - true if running on the server side (read-only)
      */
-    class Environment final {
+    class ExecutionEnvironment final {
       public:
         /**
-         * Register the Environment object on the target object.
+         * Register the ExecutionEnvironment object on the target object.
          * @param isolate V8 isolate
          * @param context Target context
-         * @param target Object to attach Environment to (e.g., Core)
+         * @param target Object to attach ExecutionEnvironment to (e.g., the global root)
          * @param isClient true if this is the client side, false for server
          */
         static void Register(v8::Isolate *isolate,

--- a/code/framework/src/scripting/builtins/exports.cpp
+++ b/code/framework/src/scripting/builtins/exports.cpp
@@ -13,7 +13,7 @@
 
 #include <logging/logger.h>
 
-namespace Framework::Scripting {
+namespace Framework::Scripting::Builtins {
 
     ResourceManager *Exports::_resourceManager = nullptr;
 
@@ -166,4 +166,4 @@ namespace Framework::Scripting {
         args.GetReturnValue().Set(exportValue);
     }
 
-} // namespace Framework::Scripting
+} // namespace Framework::Scripting::Builtins

--- a/code/framework/src/scripting/builtins/exports.cpp
+++ b/code/framework/src/scripting/builtins/exports.cpp
@@ -15,11 +15,7 @@
 
 namespace Framework::Scripting::Builtins {
 
-    ResourceManager *Exports::_resourceManager = nullptr;
-
     void Exports::Register(v8::Isolate *isolate, v8::Local<v8::Context> context, v8::Local<v8::Object> frameworkObj, ResourceManager *resourceManager) {
-        _resourceManager = resourceManager;
-
         v8::Local<v8::Object> exportsObj = v8::Object::New(isolate);
 
         // Store resource manager as external data for callbacks
@@ -53,7 +49,6 @@ namespace Framework::Scripting::Builtins {
     void Exports::RegisterCallback(const v8::FunctionCallbackInfo<v8::Value> &args) {
         v8::Isolate *isolate = args.GetIsolate();
         v8::HandleScope handleScope(isolate);
-        v8::Local<v8::Context> context = isolate->GetCurrentContext();
 
         if (args.Length() < 2) {
             isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "exports.register requires 2 arguments: name, value")));
@@ -113,7 +108,6 @@ namespace Framework::Scripting::Builtins {
     void Exports::GetCallback(const v8::FunctionCallbackInfo<v8::Value> &args) {
         v8::Isolate *isolate = args.GetIsolate();
         v8::HandleScope handleScope(isolate);
-        v8::Local<v8::Context> context = isolate->GetCurrentContext();
 
         if (args.Length() < 2) {
             isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "exports.get requires 2 arguments: resourceName, exportName")));

--- a/code/framework/src/scripting/builtins/exports.cpp
+++ b/code/framework/src/scripting/builtins/exports.cpp
@@ -33,9 +33,9 @@ namespace Framework::Scripting::Builtins {
         v8::Local<v8::FunctionTemplate> getTmpl = v8::FunctionTemplate::New(isolate, GetCallback, managerData);
         exportsObj->Set(context, v8pp::to_v8(isolate, "get"), getTmpl->GetFunction(context).ToLocalChecked()).Check();
 
-        frameworkObj->Set(context, v8pp::to_v8(isolate, "Exports"), exportsObj).Check();
+        frameworkObj->Set(context, v8pp::to_v8(isolate, "exports"), exportsObj).Check();
 
-        auto &metadata = GetScriptingCatalog(isolate).global_object("Exports", "Registration and lookup of cross-resource values through Framework.Exports.");
+        auto &metadata = GetScriptingCatalog(isolate).global_object("exports", "Registration and lookup of cross-resource values through Framework.exports.");
         metadata.record(v8pp::metadata::function_of<v8::FunctionCallback>("register", v8pp::metadata::docs("boolean",
                                                                                           {
                                                                                               v8pp::metadata::param("name", "string", false, "Export name, preferably declared in the current resource manifest."),
@@ -56,18 +56,18 @@ namespace Framework::Scripting::Builtins {
         v8::Local<v8::Context> context = isolate->GetCurrentContext();
 
         if (args.Length() < 2) {
-            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "Exports.register requires 2 arguments: name, value")));
+            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "exports.register requires 2 arguments: name, value")));
             return;
         }
 
         if (!args[0]->IsString()) {
-            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "Exports.register: name must be a string")));
+            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "exports.register: name must be a string")));
             return;
         }
 
         ResourceManager *manager = static_cast<ResourceManager *>(args.Data().As<v8::External>()->Value());
         if (!manager) {
-            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "Exports.register: resource manager not available")));
+            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "exports.register: resource manager not available")));
             return;
         }
 
@@ -77,7 +77,7 @@ namespace Framework::Scripting::Builtins {
         // Get the current resource context (use stack fallback for async ES modules)
         Resource *currentResource = manager->GetCurrentResourceWithStackFallback(isolate);
         if (!currentResource) {
-            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "Exports.register: no resource context")));
+            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "exports.register: no resource context")));
             return;
         }
 
@@ -101,7 +101,7 @@ namespace Framework::Scripting::Builtins {
             else {
                 // Export is in manifest but RegisterExport still failed - real error (isolate issue)
                 Logging::GetLogger(FRAMEWORK_INNER_SCRIPTING)->error("[{}] Failed to register export '{}' - isolate initialization issue", currentResource->GetName(), exportName);
-                isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "Exports.register: failed to register export '" + exportName + "' - internal error")));
+                isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "exports.register: failed to register export '" + exportName + "' - internal error")));
             }
         }
         else {
@@ -116,18 +116,18 @@ namespace Framework::Scripting::Builtins {
         v8::Local<v8::Context> context = isolate->GetCurrentContext();
 
         if (args.Length() < 2) {
-            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "Exports.get requires 2 arguments: resourceName, exportName")));
+            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "exports.get requires 2 arguments: resourceName, exportName")));
             return;
         }
 
         if (!args[0]->IsString() || !args[1]->IsString()) {
-            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "Exports.get: resourceName and exportName must be strings")));
+            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "exports.get: resourceName and exportName must be strings")));
             return;
         }
 
         ResourceManager *manager = static_cast<ResourceManager *>(args.Data().As<v8::External>()->Value());
         if (!manager) {
-            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "Exports.get: resource manager not available")));
+            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "exports.get: resource manager not available")));
             return;
         }
 
@@ -137,13 +137,13 @@ namespace Framework::Scripting::Builtins {
         // Get the target resource
         const Resource *resource = manager->GetResource(resourceName);
         if (!resource) {
-            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "Exports.get: resource '" + resourceName + "' not found")));
+            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "exports.get: resource '" + resourceName + "' not found")));
             return;
         }
 
         // Check if the resource is running
         if (!resource->IsRunning()) {
-            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "Exports.get: resource '" + resourceName + "' is not running")));
+            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "exports.get: resource '" + resourceName + "' is not running")));
             return;
         }
 
@@ -152,14 +152,14 @@ namespace Framework::Scripting::Builtins {
         if (resourceIsolate != isolate) {
             // Cross-isolate access is not supported - V8 values cannot be shared across isolates
             // This typically happens when resources run in separate isolates (e.g., different threads)
-            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "Exports.get: cannot access export '" + exportName + "' from resource '" + resourceName + "' - cross-isolate access is not supported. Both resources must share the same isolate.")));
+            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "exports.get: cannot access export '" + exportName + "' from resource '" + resourceName + "' - cross-isolate access is not supported. Both resources must share the same isolate.")));
             return;
         }
 
         // Get the export value (safe since we validated isolate ownership above)
         v8::Local<v8::Value> exportValue = resource->GetExportValue(exportName);
         if (exportValue.IsEmpty()) {
-            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "Exports.get: export '" + exportName + "' not found in resource '" + resourceName + "'")));
+            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "exports.get: export '" + exportName + "' not found in resource '" + resourceName + "'")));
             return;
         }
 

--- a/code/framework/src/scripting/builtins/exports.cpp
+++ b/code/framework/src/scripting/builtins/exports.cpp
@@ -56,12 +56,12 @@ namespace Framework::Scripting {
         v8::Local<v8::Context> context = isolate->GetCurrentContext();
 
         if (args.Length() < 2) {
-            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "Exports.register requires 2 arguments: name, value")));
+            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "Exports.register requires 2 arguments: name, value")));
             return;
         }
 
         if (!args[0]->IsString()) {
-            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "Exports.register: name must be a string")));
+            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "Exports.register: name must be a string")));
             return;
         }
 
@@ -116,12 +116,12 @@ namespace Framework::Scripting {
         v8::Local<v8::Context> context = isolate->GetCurrentContext();
 
         if (args.Length() < 2) {
-            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "Exports.get requires 2 arguments: resourceName, exportName")));
+            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "Exports.get requires 2 arguments: resourceName, exportName")));
             return;
         }
 
         if (!args[0]->IsString() || !args[1]->IsString()) {
-            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "Exports.get: resourceName and exportName must be strings")));
+            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "Exports.get: resourceName and exportName must be strings")));
             return;
         }
 

--- a/code/framework/src/scripting/builtins/exports.h
+++ b/code/framework/src/scripting/builtins/exports.h
@@ -13,6 +13,9 @@
 
 namespace Framework::Scripting {
     class ResourceManager;
+}
+
+namespace Framework::Scripting::Builtins {
 
     class Exports final {
       public:
@@ -28,4 +31,4 @@ namespace Framework::Scripting {
         static ResourceManager *_resourceManager;
     };
 
-} // namespace Framework::Scripting
+} // namespace Framework::Scripting::Builtins

--- a/code/framework/src/scripting/builtins/exports.h
+++ b/code/framework/src/scripting/builtins/exports.h
@@ -27,8 +27,6 @@ namespace Framework::Scripting::Builtins {
       private:
         static void RegisterCallback(const v8::FunctionCallbackInfo<v8::Value> &args);
         static void GetCallback(const v8::FunctionCallbackInfo<v8::Value> &args);
-
-        static ResourceManager *_resourceManager;
     };
 
 } // namespace Framework::Scripting::Builtins

--- a/code/framework/src/scripting/builtins/imports.cpp
+++ b/code/framework/src/scripting/builtins/imports.cpp
@@ -85,36 +85,37 @@ namespace Framework::Scripting {
             }
         }
 
-        // Get registered export names and build an object
-        std::vector<std::string> exportNames = resource->GetRegisteredExportNames();
-
-        if (exportNames.empty()) {
-            // Return empty object if no exports
-            args.GetReturnValue().Set(v8::Object::New(isolate));
+        // Validate isolate ownership - export values are bound to their resource's isolate.
+        // Mirrors Exports::GetCallback: V8 values cannot be shared across isolates.
+        v8::Isolate *resourceIsolate = resource->GetIsolate();
+        if (resourceIsolate != isolate) {
+            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "imports.get: cannot access exports from resource '" + resourceName + "' - cross-isolate access is not supported. Both resources must share the same isolate.")));
             return;
         }
 
-        // Note: The current implementation stores exports as v8::Global<v8::Value>
-        // We need to access them from the resource. For now, return an object
-        // that indicates the exports are available but we need the isolate
-        // from the target resource to actually retrieve them.
+        // Build an object mapping every registered export name to its real value.
+        v8::Local<v8::Object> exportsObj = BuildImportsObject(isolate, context, resource);
 
-        // For cross-resource exports to work properly, we need a shared context
-        // or value serialization. For now, return the list of available exports.
-
-        v8::Local<v8::Object> exportsObj = v8::Object::New(isolate);
-
-        // Add a special property listing available exports
-        v8::Local<v8::Array> exportArray = v8::Array::New(isolate, static_cast<int>(exportNames.size()));
-        for (size_t i = 0; i < exportNames.size(); ++i) {
-            exportArray->Set(context, static_cast<uint32_t>(i), v8pp::to_v8(isolate, exportNames[i])).Check();
-        }
-        exportsObj->Set(context, v8pp::to_v8(isolate, "_availableExports"), exportArray).Check();
-
-        // Log for debugging
-        Logging::GetLogger(FRAMEWORK_INNER_SCRIPTING)->debug("[{}] Imported {} exports from '{}'", callerResource, exportNames.size(), resourceName);
+        Logging::GetLogger(FRAMEWORK_INNER_SCRIPTING)->debug("[{}] Imported {} exports from '{}'", callerResource, resource->GetRegisteredExportNames().size(), resourceName);
 
         args.GetReturnValue().Set(exportsObj);
+    }
+
+    v8::Local<v8::Object> Imports::BuildImportsObject(v8::Isolate *isolate, v8::Local<v8::Context> context, const Resource *resource) {
+        v8::Local<v8::Object> exportsObj = v8::Object::New(isolate);
+        if (!resource) {
+            return exportsObj;
+        }
+
+        for (const std::string &exportName : resource->GetRegisteredExportNames()) {
+            v8::Local<v8::Value> exportValue = resource->GetExportValue(exportName);
+            if (exportValue.IsEmpty()) {
+                continue;
+            }
+            exportsObj->Set(context, v8pp::to_v8(isolate, exportName), exportValue).Check();
+        }
+
+        return exportsObj;
     }
 
 } // namespace Framework::Scripting

--- a/code/framework/src/scripting/builtins/imports.cpp
+++ b/code/framework/src/scripting/builtins/imports.cpp
@@ -46,12 +46,12 @@ namespace Framework::Scripting {
         v8::Local<v8::Context> context = isolate->GetCurrentContext();
 
         if (args.Length() < 1) {
-            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "imports.get requires 1 argument: resourceName")));
+            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "imports.get requires 1 argument: resourceName")));
             return;
         }
 
         if (!args[0]->IsString()) {
-            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "imports.get: resourceName must be a string")));
+            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "imports.get: resourceName must be a string")));
             return;
         }
 

--- a/code/framework/src/scripting/builtins/imports.cpp
+++ b/code/framework/src/scripting/builtins/imports.cpp
@@ -13,7 +13,7 @@
 
 #include <logging/logger.h>
 
-namespace Framework::Scripting {
+namespace Framework::Scripting::Builtins {
 
     ResourceManager *Imports::_resourceManager = nullptr;
 
@@ -118,4 +118,4 @@ namespace Framework::Scripting {
         return exportsObj;
     }
 
-} // namespace Framework::Scripting
+} // namespace Framework::Scripting::Builtins

--- a/code/framework/src/scripting/builtins/imports.cpp
+++ b/code/framework/src/scripting/builtins/imports.cpp
@@ -15,11 +15,7 @@
 
 namespace Framework::Scripting::Builtins {
 
-    ResourceManager *Imports::_resourceManager = nullptr;
-
     void Imports::Register(v8::Isolate *isolate, v8::Local<v8::Context> context, v8::Local<v8::Object> frameworkObj, ResourceManager *resourceManager) {
-        _resourceManager = resourceManager;
-
         v8::Local<v8::Object> importsObj = v8::Object::New(isolate);
 
         // Store resource manager as external data for callbacks

--- a/code/framework/src/scripting/builtins/imports.h
+++ b/code/framework/src/scripting/builtins/imports.h
@@ -15,9 +15,11 @@
 #include <string>
 
 namespace Framework::Scripting {
-
     class ResourceManager;
     class Resource;
+}
+
+namespace Framework::Scripting::Builtins {
 
     /**
      * Resource imports system for accessing exports from other resources.
@@ -58,4 +60,4 @@ namespace Framework::Scripting {
         static ResourceManager *_resourceManager;
     };
 
-} // namespace Framework::Scripting
+} // namespace Framework::Scripting::Builtins

--- a/code/framework/src/scripting/builtins/imports.h
+++ b/code/framework/src/scripting/builtins/imports.h
@@ -17,6 +17,7 @@
 namespace Framework::Scripting {
 
     class ResourceManager;
+    class Resource;
 
     /**
      * Resource imports system for accessing exports from other resources.
@@ -36,6 +37,19 @@ namespace Framework::Scripting {
                             v8::Local<v8::Context> context,
                             v8::Local<v8::Object> frameworkObj,
                             ResourceManager *resourceManager);
+
+        /**
+         * Build an object mapping every registered export name of a resource to its
+         * real value. Assumes the caller has already validated that the resource's
+         * values live in `isolate` (V8 values cannot cross isolates).
+         * @param isolate V8 isolate owning the target resource's export values
+         * @param context Context to build the result object in
+         * @param resource Resource whose registered exports should be read
+         * @return Object keyed by export name; empty object when there are no exports
+         */
+        static v8::Local<v8::Object> BuildImportsObject(v8::Isolate *isolate,
+                                                        v8::Local<v8::Context> context,
+                                                        const Resource *resource);
 
       private:
         // V8 callback implementations

--- a/code/framework/src/scripting/builtins/imports.h
+++ b/code/framework/src/scripting/builtins/imports.h
@@ -56,8 +56,6 @@ namespace Framework::Scripting::Builtins {
       private:
         // V8 callback implementations
         static void GetCallback(const v8::FunctionCallbackInfo<v8::Value> &args);
-
-        static ResourceManager *_resourceManager;
     };
 
 } // namespace Framework::Scripting::Builtins

--- a/code/framework/src/scripting/builtins/messages.cpp
+++ b/code/framework/src/scripting/builtins/messages.cpp
@@ -14,7 +14,7 @@
 
 namespace Framework::Scripting {
 
-    std::map<std::string, std::map<std::string, v8::Global<v8::Function>>> Messages::_handlers;
+    std::map<std::string, std::map<std::string, Messages::Handler>> Messages::_handlers;
     std::mutex Messages::_handlersMutex;
     std::map<uint64_t, Messages::PendingRequest> Messages::_pendingRequests;
     std::mutex Messages::_pendingRequestsMutex;
@@ -106,7 +106,9 @@ namespace Framework::Scripting {
 
         {
             std::scoped_lock lock(_handlersMutex);
-            _handlers[resourceName][messageType].Reset(isolate, handler);
+            Handler &entry = _handlers[resourceName][messageType];
+            entry.isolate  = isolate;
+            entry.function.Reset(isolate, handler);
         }
     }
 
@@ -164,7 +166,16 @@ namespace Framework::Scripting {
                 return;
             }
 
-            handler.Reset(isolate, handlerIt->second.Get(isolate));
+            // The handler's Global<Function> is bound to the isolate it was registered on.
+            // Getting it from a different isolate crashes, so reject cross-isolate requests
+            // (mirrors the Exports.get isolate-ownership guard).
+            if (handlerIt->second.isolate != isolate) {
+                resolver->Reject(context, v8pp::to_v8(isolate, "messages.request: cannot invoke handler '" + messageType + "' in resource '" + targetResource + "' - cross-isolate access is not supported. Both resources must share the same isolate.")).Check();
+                args.GetReturnValue().Set(promise);
+                return;
+            }
+
+            handler.Reset(isolate, handlerIt->second.function.Get(isolate));
         }
 
         // Generate request ID and store pending request
@@ -284,7 +295,14 @@ namespace Framework::Scripting {
                 return; // Silently ignore
             }
 
-            handler.Reset(isolate, handlerIt->second.Get(isolate));
+            // Cross-isolate handler: Getting its Global<Function> from this isolate would
+            // crash. Skip delivery (send is fire-and-forget) and warn (mirrors Exports.get).
+            if (handlerIt->second.isolate != isolate) {
+                Logging::GetLogger(FRAMEWORK_INNER_SCRIPTING)->warn("messages.send to '{}' skipped: handler '{}' lives in a different isolate", targetResource, messageType);
+                return;
+            }
+
+            handler.Reset(isolate, handlerIt->second.function.Get(isolate));
         }
 
         // Create no-op reply function
@@ -341,6 +359,29 @@ namespace Framework::Scripting {
             }
 
             _pendingRequests.erase(it);
+        }
+    }
+
+    void Messages::CleanupResource(const std::string &resourceName) {
+        // Drop the stopped resource's registered handlers so its Global<Function>
+        // handles are released now instead of lingering until Shutdown().
+        {
+            std::scoped_lock lock(_handlersMutex);
+            _handlers.erase(resourceName);
+        }
+
+        // Drop any requests this resource originated; their resolver Globals would
+        // otherwise dangle (the reply can never be delivered to a stopped resource).
+        {
+            std::scoped_lock lock(_pendingRequestsMutex);
+            for (auto it = _pendingRequests.begin(); it != _pendingRequests.end();) {
+                if (it->second.sourceResource == resourceName) {
+                    it = _pendingRequests.erase(it);
+                }
+                else {
+                    ++it;
+                }
+            }
         }
     }
 

--- a/code/framework/src/scripting/builtins/messages.cpp
+++ b/code/framework/src/scripting/builtins/messages.cpp
@@ -180,7 +180,7 @@ namespace Framework::Scripting::Builtins {
         {
             std::scoped_lock lock(_pendingRequestsMutex);
             requestId = _nextRequestId++;
-            _pendingRequests.try_emplace(requestId, requestId, v8::Global<v8::Promise::Resolver>(isolate, resolver), sourceResource);
+            _pendingRequests.try_emplace(requestId, requestId, v8::Global<v8::Promise::Resolver>(isolate, resolver), sourceResource, targetResource);
         }
 
         // Create reply function - passes requestId as BigInt to avoid dangling pointer issues
@@ -359,7 +359,7 @@ namespace Framework::Scripting::Builtins {
         }
     }
 
-    void Messages::CleanupResource(const std::string &resourceName) {
+    void Messages::CleanupResource(v8::Isolate *isolate, v8::Local<v8::Context> context, const std::string &resourceName) {
         // Drop the stopped resource's registered handlers so its Global<Function>
         // handles are released now instead of lingering until Shutdown().
         {
@@ -367,12 +367,21 @@ namespace Framework::Scripting::Builtins {
             _handlers.erase(resourceName);
         }
 
-        // Drop any requests this resource originated; their resolver Globals would
-        // otherwise dangle (the reply can never be delivered to a stopped resource).
+        // Settle and drop every pending request tied to the stopped resource:
+        // - source: a request this resource made, whose reply it can no longer receive;
+        // - target: a request another resource is still awaiting a reply from this one.
+        // Reject the awaiting Promise first (so `await request(...)` rejects instead of hanging
+        // forever) before erasing, then release the resolver Global.
         {
             std::scoped_lock lock(_pendingRequestsMutex);
             for (auto it = _pendingRequests.begin(); it != _pendingRequests.end();) {
-                if (it->second.sourceResource == resourceName) {
+                PendingRequest &req = it->second;
+                if (req.sourceResource == resourceName || req.targetResource == resourceName) {
+                    // A request still in the table is not yet settled — ProcessPendingResponses
+                    // settles and erases atomically under this same mutex — so rejecting always
+                    // moves the awaiting Promise out of pending (and V8 ignores a reject on an
+                    // already-settled promise anyway). After erasing, a late reply() finds nothing.
+                    req.resolver.Get(isolate)->Reject(context, v8pp::to_v8(isolate, "messages.request: resource '" + resourceName + "' stopped before reply")).Check();
                     it = _pendingRequests.erase(it);
                 }
                 else {

--- a/code/framework/src/scripting/builtins/messages.cpp
+++ b/code/framework/src/scripting/builtins/messages.cpp
@@ -74,17 +74,17 @@ namespace Framework::Scripting {
         v8::HandleScope handleScope(isolate);
 
         if (args.Length() < 2) {
-            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "messages.handle requires 2 arguments: messageType, handler")));
+            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "messages.handle requires 2 arguments: messageType, handler")));
             return;
         }
 
         if (!args[0]->IsString()) {
-            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "messages.handle: messageType must be a string")));
+            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "messages.handle: messageType must be a string")));
             return;
         }
 
         if (!args[1]->IsFunction()) {
-            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "messages.handle: handler must be a function")));
+            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "messages.handle: handler must be a function")));
             return;
         }
 
@@ -118,17 +118,17 @@ namespace Framework::Scripting {
         v8::Local<v8::Context> context = isolate->GetCurrentContext();
 
         if (args.Length() < 2) {
-            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "messages.request requires at least 2 arguments: resourceName, messageType")));
+            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "messages.request requires at least 2 arguments: resourceName, messageType")));
             return;
         }
 
         if (!args[0]->IsString()) {
-            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "messages.request: resourceName must be a string")));
+            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "messages.request: resourceName must be a string")));
             return;
         }
 
         if (!args[1]->IsString()) {
-            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "messages.request: messageType must be a string")));
+            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "messages.request: messageType must be a string")));
             return;
         }
 
@@ -260,17 +260,17 @@ namespace Framework::Scripting {
         v8::Local<v8::Context> context = isolate->GetCurrentContext();
 
         if (args.Length() < 2) {
-            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "messages.send requires at least 2 arguments: resourceName, messageType")));
+            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "messages.send requires at least 2 arguments: resourceName, messageType")));
             return;
         }
 
         if (!args[0]->IsString()) {
-            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "messages.send: resourceName must be a string")));
+            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "messages.send: resourceName must be a string")));
             return;
         }
 
         if (!args[1]->IsString()) {
-            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "messages.send: messageType must be a string")));
+            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "messages.send: messageType must be a string")));
             return;
         }
 

--- a/code/framework/src/scripting/builtins/messages.cpp
+++ b/code/framework/src/scripting/builtins/messages.cpp
@@ -12,7 +12,7 @@
 
 #include <logging/logger.h>
 
-namespace Framework::Scripting {
+namespace Framework::Scripting::Builtins {
 
     std::map<std::string, std::map<std::string, Messages::Handler>> Messages::_handlers;
     std::mutex Messages::_handlersMutex;
@@ -401,4 +401,4 @@ namespace Framework::Scripting {
         _resourceManager = nullptr;
     }
 
-} // namespace Framework::Scripting
+} // namespace Framework::Scripting::Builtins

--- a/code/framework/src/scripting/builtins/messages.cpp
+++ b/code/framework/src/scripting/builtins/messages.cpp
@@ -20,12 +20,9 @@ namespace Framework::Scripting::Builtins {
     std::mutex Messages::_pendingRequestsMutex;
     std::vector<Messages::PendingResponse> Messages::_responseQueue;
     std::mutex Messages::_responseQueueMutex;
-    uint64_t Messages::_nextRequestId           = 1;
-    ResourceManager *Messages::_resourceManager = nullptr;
+    uint64_t Messages::_nextRequestId = 1;
 
     void Messages::Register(v8::Isolate *isolate, v8::Local<v8::Context> context, v8::Local<v8::Object> frameworkObj, ResourceManager *resourceManager) {
-        _resourceManager = resourceManager;
-
         v8::Local<v8::Object> messagesObj = v8::Object::New(isolate);
 
         // Store resource manager as external data for callbacks
@@ -398,7 +395,6 @@ namespace Framework::Scripting::Builtins {
             std::scoped_lock lock(_responseQueueMutex);
             _responseQueue.clear();
         }
-        _resourceManager = nullptr;
     }
 
 } // namespace Framework::Scripting::Builtins

--- a/code/framework/src/scripting/builtins/messages.h
+++ b/code/framework/src/scripting/builtins/messages.h
@@ -103,8 +103,6 @@ namespace Framework::Scripting::Builtins {
         static std::mutex _responseQueueMutex;
 
         static uint64_t _nextRequestId;
-
-        static ResourceManager *_resourceManager;
     };
 
 } // namespace Framework::Scripting::Builtins

--- a/code/framework/src/scripting/builtins/messages.h
+++ b/code/framework/src/scripting/builtins/messages.h
@@ -19,8 +19,10 @@
 #include <vector>
 
 namespace Framework::Scripting {
-
     class ResourceManager;
+}
+
+namespace Framework::Scripting::Builtins {
 
     /**
      * JavaScript messages system for request/response communication.
@@ -105,4 +107,4 @@ namespace Framework::Scripting {
         static ResourceManager *_resourceManager;
     };
 
-} // namespace Framework::Scripting
+} // namespace Framework::Scripting::Builtins

--- a/code/framework/src/scripting/builtins/messages.h
+++ b/code/framework/src/scripting/builtins/messages.h
@@ -47,11 +47,13 @@ namespace Framework::Scripting::Builtins {
         static void ProcessPendingResponses(v8::Isolate *isolate, v8::Local<v8::Context> context);
 
         /**
-         * Drop a stopped resource's registered handlers and any requests it
-         * originated, so its Global<Function> handles don't dangle until the
-         * whole isolate is torn down. Mirrors Events::CleanupResource.
+         * Drop a stopped resource's registered handlers, and reject+erase every
+         * pending request it originated or targeted, so its Global<Function>
+         * handles don't dangle and awaiting `request(...)` Promises reject
+         * instead of hanging until isolate teardown. Needs an active
+         * isolate/context to settle those Promises. Mirrors Events::CleanupResource.
          */
-        static void CleanupResource(const std::string &resourceName);
+        static void CleanupResource(v8::Isolate *isolate, v8::Local<v8::Context> context, const std::string &resourceName);
 
         /**
          * Cleanup all static V8 globals.
@@ -80,11 +82,12 @@ namespace Framework::Scripting::Builtins {
         struct PendingRequest {
             uint64_t requestId;
             v8::Global<v8::Promise::Resolver> resolver;
-            std::string sourceResource;
+            std::string sourceResource; // resource awaiting the reply (owns the Promise)
+            std::string targetResource; // resource whose handler must reply
             std::atomic<bool> consumed{false}; // Prevents double-reply
 
-            PendingRequest(uint64_t id, v8::Global<v8::Promise::Resolver> res, std::string src)
-                : requestId(id), resolver(std::move(res)), sourceResource(std::move(src)), consumed(false) {}
+            PendingRequest(uint64_t id, v8::Global<v8::Promise::Resolver> res, std::string src, std::string tgt)
+                : requestId(id), resolver(std::move(res)), sourceResource(std::move(src)), targetResource(std::move(tgt)), consumed(false) {}
             PendingRequest(PendingRequest&&) = delete;
             PendingRequest& operator=(PendingRequest&&) = delete;
         };

--- a/code/framework/src/scripting/builtins/messages.h
+++ b/code/framework/src/scripting/builtins/messages.h
@@ -45,6 +45,13 @@ namespace Framework::Scripting {
         static void ProcessPendingResponses(v8::Isolate *isolate, v8::Local<v8::Context> context);
 
         /**
+         * Drop a stopped resource's registered handlers and any requests it
+         * originated, so its Global<Function> handles don't dangle until the
+         * whole isolate is torn down. Mirrors Events::CleanupResource.
+         */
+        static void CleanupResource(const std::string &resourceName);
+
+        /**
          * Cleanup all static V8 globals.
          * Must be called before the V8 isolate is disposed.
          */
@@ -56,8 +63,15 @@ namespace Framework::Scripting {
         static void RequestCallback(const v8::FunctionCallbackInfo<v8::Value> &args);
         static void SendCallback(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+        // A registered handler together with the isolate its Global<Function> is
+        // bound to. Requests/sends must not Get() a handler from a foreign isolate.
+        struct Handler {
+            v8::Isolate *isolate = nullptr;
+            v8::Global<v8::Function> function;
+        };
+
         // Message handler storage: resourceName -> messageType -> handler
-        static std::map<std::string, std::map<std::string, v8::Global<v8::Function>>> _handlers;
+        static std::map<std::string, std::map<std::string, Handler>> _handlers;
         static std::mutex _handlersMutex;
 
         // Pending request structure

--- a/code/framework/src/scripting/builtins/player.cpp
+++ b/code/framework/src/scripting/builtins/player.cpp
@@ -123,6 +123,12 @@ namespace Framework::Scripting::Builtins {
         return peer ? peer->GetPeerIdentity(MafiaNet::ToGuid(entity->ownerGUID)) : nullptr;
     }
 
+    void Player::Register(v8::Isolate *isolate, v8::Local<v8::Object> global) {
+        v8pp::class_<Player> &cls = GetClass(isolate);
+        auto ctx                  = isolate->GetCurrentContext();
+        global->Set(ctx, v8pp::to_v8(isolate, "Player"), cls.js_function_template()->GetFunction(ctx).ToLocalChecked()).Check();
+    }
+
     void Player::UnregisterIsolate(v8::Isolate *isolate) {
         _classes.erase(isolate);
     }

--- a/code/framework/src/scripting/builtins/player.h
+++ b/code/framework/src/scripting/builtins/player.h
@@ -52,6 +52,11 @@ namespace Framework::Scripting::Builtins {
 
         static v8pp::class_<Player> &GetClass(v8::Isolate *isolate);
 
+        // Publish the Player constructor on a target object, like Entity::Register /
+        // TextLabel::Register. Games opt in; the framework itself exposes Player lazily
+        // through GetClass (see integrations/server/instance.cpp).
+        static void Register(v8::Isolate *isolate, v8::Local<v8::Object> global);
+
         static void UnregisterIsolate(v8::Isolate *isolate);
 
       protected:

--- a/code/framework/src/scripting/builtins/quaternion.cpp
+++ b/code/framework/src/scripting/builtins/quaternion.cpp
@@ -63,7 +63,8 @@ namespace Framework::Scripting::Builtins {
                                                   },
                                                   "Creates a quaternion in w, x, y, z component order."))
             // Instance methods
-            .function("multiply", &Quaternion::multiply,
+            // Named mul for parity with Vector.mul (was multiply).
+            .function("mul", &Quaternion::multiply,
                 v8pp::metadata::docs("this", {v8pp::metadata::param("other", "Quaternion", false, "Rotation composed after this quaternion.")}, "Composes this rotation with another quaternion in place.", "This mutated quaternion for chaining."))
             .function("normalize", &Quaternion::normalize, v8pp::metadata::docs("this", {}, "Normalizes this quaternion in place.", "This unit quaternion for chaining."))
             .function("conjugate", &Quaternion::conjugate, v8pp::metadata::docs("Quaternion", {}, "Computes the conjugate without changing this quaternion.", "New conjugated quaternion."))
@@ -148,6 +149,22 @@ namespace Framework::Scripting::Builtins {
                 }
             });
         cls->document_property("z", v8pp::metadata::property_docs("number", "Mutable Z imaginary component."));
+
+        // Read-only property: length (magnitude / norm)
+        protoTemplate->SetNativeDataProperty(v8pp::to_v8(isolate, "length").As<v8::Name>(), [](v8::Local<v8::Name>, const v8::PropertyCallbackInfo<v8::Value> &info) {
+            auto *self = v8pp::class_<Quaternion>::unwrap_object(info.GetIsolate(), info.This());
+            if (self)
+                info.GetReturnValue().Set(self->getLength());
+        });
+        cls->document_property("length", {"Read-only magnitude (norm) of this quaternion; 1 for a unit rotation.", "number", true, false});
+
+        // Read-only property: lengthSquared
+        protoTemplate->SetNativeDataProperty(v8pp::to_v8(isolate, "lengthSquared").As<v8::Name>(), [](v8::Local<v8::Name>, const v8::PropertyCallbackInfo<v8::Value> &info) {
+            auto *self = v8pp::class_<Quaternion>::unwrap_object(info.GetIsolate(), info.This());
+            if (self)
+                info.GetReturnValue().Set(self->getLengthSquared());
+        });
+        cls->document_property("lengthSquared", {"Read-only squared magnitude, avoiding a square-root calculation.", "number", true, false});
 
         // toJSON method for JSON.stringify support - returns plain JS object
         protoTemplate->Set(v8pp::to_v8(isolate, "toJSON"), v8::FunctionTemplate::New(isolate, [](const v8::FunctionCallbackInfo<v8::Value> &info) {

--- a/code/framework/src/scripting/builtins/quaternion.cpp
+++ b/code/framework/src/scripting/builtins/quaternion.cpp
@@ -52,21 +52,21 @@ namespace Framework::Scripting::Builtins {
         }
 
         auto &cls = _classes[isolate];
-        cls       = std::make_unique<v8pp::class_<Quaternion>>(isolate, GetScriptingCatalog(isolate), "Quaternion", "Mutable quaternion exposed as Core.Quaternion for three-dimensional rotations.");
+        cls       = std::make_unique<v8pp::class_<Quaternion>>(isolate, GetScriptingCatalog(isolate), "Quaternion", "Mutable quaternion exposed as Core.Quaternion for three-dimensional rotations. Components are scalar-first (w, x, y, z), matching GLM — not the x, y, z, w order some libraries use.");
         cls->auto_wrap_objects(true); // Enable auto-wrapping for return values
         cls->ctor<float, float, float, float>(v8pp::metadata::docs("void",
                                                   {
-                                                      v8pp::metadata::param("w", "number", false, "Initial scalar component."),
+                                                      v8pp::metadata::param("w", "number", false, "Initial scalar component (comes first — this is not x, y, z, w order)."),
                                                       v8pp::metadata::param("x", "number", false, "Initial X imaginary component."),
                                                       v8pp::metadata::param("y", "number", false, "Initial Y imaginary component."),
                                                       v8pp::metadata::param("z", "number", false, "Initial Z imaginary component."),
                                                   },
-                                                  "Creates a quaternion in w, x, y, z component order."))
+                                                  "Creates a quaternion in scalar-first w, x, y, z component order. Watch the trap: the scalar w is the first argument, unlike the x, y, z, w order used by some other libraries."))
             // Instance methods
             // Named mul for parity with Vector.mul (was multiply).
             .function("mul", &Quaternion::multiply,
                 v8pp::metadata::docs("this", {v8pp::metadata::param("other", "Quaternion", false, "Rotation composed after this quaternion.")}, "Composes this rotation with another quaternion in place.", "This mutated quaternion for chaining."))
-            .function("normalize", &Quaternion::normalize, v8pp::metadata::docs("this", {}, "Normalizes this quaternion in place.", "This unit quaternion for chaining."))
+            .function("normalize", &Quaternion::normalize, v8pp::metadata::docs("this", {}, "Normalizes this quaternion in place; a zero quaternion becomes the identity rotation instead of NaN.", "This unit quaternion for chaining."))
             .function("conjugate", &Quaternion::conjugate, v8pp::metadata::docs("Quaternion", {}, "Computes the conjugate without changing this quaternion.", "New conjugated quaternion."))
             .function("inverse", &Quaternion::inverse, v8pp::metadata::docs("Quaternion", {}, "Computes the inverse rotation without changing this quaternion.", "New inverse quaternion."))
             .function("slerp", &Quaternion::slerp,

--- a/code/framework/src/scripting/builtins/quaternion.h
+++ b/code/framework/src/scripting/builtins/quaternion.h
@@ -48,7 +48,12 @@ class Quaternion final {
 
     // Mutable methods (modify in place, return this for chaining)
     Quaternion& multiply(const Quaternion& other) { _quat = _quat * other._quat; return *this; }
-    Quaternion& normalize() { _quat = glm::normalize(_quat); return *this; }
+    // A zero (degenerate) quaternion has no direction to normalize toward, so it
+    // collapses to the identity rotation rather than producing NaNs.
+    Quaternion& normalize() {
+        _quat = (glm::dot(_quat, _quat) > 0.0f) ? glm::normalize(_quat) : glm::quat(1.0f, 0.0f, 0.0f, 0.0f);
+        return *this;
+    }
     Quaternion& slerp(const Quaternion& target, float t) { _quat = glm::slerp(_quat, target._quat, t); return *this; }
     Quaternion& set(float w, float x, float y, float z) { _quat.w = w; _quat.x = x; _quat.y = y; _quat.z = z; return *this; }
 

--- a/code/framework/src/scripting/builtins/quaternion.h
+++ b/code/framework/src/scripting/builtins/quaternion.h
@@ -22,72 +22,116 @@
 
 namespace Framework::Scripting::Builtins {
 
-// Forward declaration
-class Vector3;
+    // Forward declaration
+    class Vector3;
 
-/**
- * Quaternion wrapper class for V8 bindings using v8pp.
- * Provides a clean C++ interface that wraps glm::quat.
- * Uses (w, x, y, z) order internally matching GLM.
- */
-class Quaternion final {
-  public:
-    Quaternion() : _quat(1.0f, 0.0f, 0.0f, 0.0f) {}
-    Quaternion(float w, float x, float y, float z) : _quat(w, x, y, z) {}
-    Quaternion(const glm::quat& q) : _quat(q) {}
+    /**
+     * Quaternion wrapper class for V8 bindings using v8pp.
+     * Provides a clean C++ interface that wraps glm::quat.
+     * Uses (w, x, y, z) order internally matching GLM.
+     */
+    class Quaternion final {
+      public:
+        Quaternion(): _quat(1.0f, 0.0f, 0.0f, 0.0f) {}
+        Quaternion(float w, float x, float y, float z): _quat(w, x, y, z) {}
+        Quaternion(const glm::quat &q): _quat(q) {}
 
-    // Property accessors
-    float getW() const { return _quat.w; }
-    void setW(float v) { _quat.w = v; }
-    float getX() const { return _quat.x; }
-    void setX(float v) { _quat.x = v; }
-    float getY() const { return _quat.y; }
-    void setY(float v) { _quat.y = v; }
-    float getZ() const { return _quat.z; }
-    void setZ(float v) { _quat.z = v; }
+        // Property accessors
+        float getW() const {
+            return _quat.w;
+        }
+        void setW(float v) {
+            _quat.w = v;
+        }
+        float getX() const {
+            return _quat.x;
+        }
+        void setX(float v) {
+            _quat.x = v;
+        }
+        float getY() const {
+            return _quat.y;
+        }
+        void setY(float v) {
+            _quat.y = v;
+        }
+        float getZ() const {
+            return _quat.z;
+        }
+        void setZ(float v) {
+            _quat.z = v;
+        }
 
-    // Mutable methods (modify in place, return this for chaining)
-    Quaternion& multiply(const Quaternion& other) { _quat = _quat * other._quat; return *this; }
-    // A zero (degenerate) quaternion has no direction to normalize toward, so it
-    // collapses to the identity rotation rather than producing NaNs.
-    Quaternion& normalize() {
-        _quat = (glm::dot(_quat, _quat) > 0.0f) ? glm::normalize(_quat) : glm::quat(1.0f, 0.0f, 0.0f, 0.0f);
-        return *this;
-    }
-    Quaternion& slerp(const Quaternion& target, float t) { _quat = glm::slerp(_quat, target._quat, t); return *this; }
-    Quaternion& set(float w, float x, float y, float z) { _quat.w = w; _quat.x = x; _quat.y = y; _quat.z = z; return *this; }
+        // Mutable methods (modify in place, return this for chaining)
+        Quaternion &multiply(const Quaternion &other) {
+            _quat = _quat * other._quat;
+            return *this;
+        }
+        // A zero (degenerate) quaternion has no direction to normalize toward, so it
+        // collapses to the identity rotation rather than producing NaNs.
+        Quaternion &normalize() {
+            _quat = (glm::dot(_quat, _quat) > 0.0f) ? glm::normalize(_quat) : glm::quat(1.0f, 0.0f, 0.0f, 0.0f);
+            return *this;
+        }
+        Quaternion &slerp(const Quaternion &target, float t) {
+            _quat = glm::slerp(_quat, target._quat, t);
+            return *this;
+        }
+        Quaternion &set(float w, float x, float y, float z) {
+            _quat.w = w;
+            _quat.x = x;
+            _quat.y = y;
+            _quat.z = z;
+            return *this;
+        }
 
-    // Read-only magnitude, mirroring Vector length/lengthSquared. A unit
-    // quaternion has length 1; the squared form avoids the square root.
-    float getLength() const { return glm::length(_quat); }
-    float getLengthSquared() const { return glm::dot(_quat, _quat); }
+        // Read-only magnitude, mirroring Vector length/lengthSquared. A unit
+        // quaternion has length 1; the squared form avoids the square root.
+        float getLength() const {
+            return glm::length(_quat);
+        }
+        float getLengthSquared() const {
+            return glm::dot(_quat, _quat);
+        }
 
-    // Non-mutating methods
-    Quaternion conjugate() const { return Quaternion(glm::conjugate(_quat)); }
-    Quaternion inverse() const { return Quaternion(glm::inverse(_quat)); }
-    float dot(const Quaternion& other) const { return glm::dot(_quat, other._quat); }
-    Vector3 rotateVector(const Vector3& v) const;
-    Vector3 toEuler() const;
-    Quaternion clone() const { return Quaternion(_quat); }
-    std::string toString() const;
+        // Non-mutating methods
+        Quaternion conjugate() const {
+            return Quaternion(glm::conjugate(_quat));
+        }
+        Quaternion inverse() const {
+            return Quaternion(glm::inverse(_quat));
+        }
+        float dot(const Quaternion &other) const {
+            return glm::dot(_quat, other._quat);
+        }
+        Vector3 rotateVector(const Vector3 &v) const;
+        Vector3 toEuler() const;
+        Quaternion clone() const {
+            return Quaternion(_quat);
+        }
+        std::string toString() const;
 
-    // Static factory methods
-    static Quaternion identity() { return Quaternion(1.0f, 0.0f, 0.0f, 0.0f); }
-    static Quaternion fromEuler(float pitch, float yaw, float roll);
-    static Quaternion fromAxisAngle(const Vector3& axis, float angle);
+        // Static factory methods
+        static Quaternion identity() {
+            return Quaternion(1.0f, 0.0f, 0.0f, 0.0f);
+        }
+        static Quaternion fromEuler(float pitch, float yaw, float roll);
+        static Quaternion fromAxisAngle(const Vector3 &axis, float angle);
 
-    // Access underlying GLM type
-    const glm::quat& quat() const { return _quat; }
+        // Access underlying GLM type
+        const glm::quat &quat() const {
+            return _quat;
+        }
 
-    // V8 Registration
-    static void Register(v8::Isolate* isolate, v8::Local<v8::Object> global);
-    static v8pp::class_<Quaternion>& GetClass(v8::Isolate* isolate);
-    static v8::Local<v8::Object> NewInstance(v8::Isolate* isolate, const glm::quat& value);
-    static void UnregisterIsolate(v8::Isolate* isolate);
+        // V8 Registration
+        static void Register(v8::Isolate *isolate, v8::Local<v8::Object> global);
+        static v8pp::class_<Quaternion> &GetClass(v8::Isolate *isolate);
+        static v8::Local<v8::Object> NewInstance(v8::Isolate *isolate, const glm::quat &value);
+        static void UnregisterIsolate(v8::Isolate *isolate);
 
-  private:
-    glm::quat _quat;
-    static std::unordered_map<v8::Isolate*, std::unique_ptr<v8pp::class_<Quaternion>>> _classes;
-};
+      private:
+        glm::quat _quat;
+        static std::unordered_map<v8::Isolate *, std::unique_ptr<v8pp::class_<Quaternion>>> _classes;
+    };
 
 } // namespace Framework::Scripting::Builtins

--- a/code/framework/src/scripting/builtins/quaternion.h
+++ b/code/framework/src/scripting/builtins/quaternion.h
@@ -52,6 +52,11 @@ class Quaternion final {
     Quaternion& slerp(const Quaternion& target, float t) { _quat = glm::slerp(_quat, target._quat, t); return *this; }
     Quaternion& set(float w, float x, float y, float z) { _quat.w = w; _quat.x = x; _quat.y = y; _quat.z = z; return *this; }
 
+    // Read-only magnitude, mirroring Vector length/lengthSquared. A unit
+    // quaternion has length 1; the squared form avoids the square root.
+    float getLength() const { return glm::length(_quat); }
+    float getLengthSquared() const { return glm::dot(_quat, _quat); }
+
     // Non-mutating methods
     Quaternion conjugate() const { return Quaternion(glm::conjugate(_quat)); }
     Quaternion inverse() const { return Quaternion(glm::inverse(_quat)); }

--- a/code/framework/src/scripting/builtins/text_label.cpp
+++ b/code/framework/src/scripting/builtins/text_label.cpp
@@ -169,13 +169,13 @@ namespace Framework::Scripting::Builtins {
         v8::HandleScope hs(isolate);
 
         if (info.Length() < 4 || !info[0]->IsNumber() || !info[1]->IsNumber() || !info[2]->IsNumber() || !info[3]->IsString()) {
-            isolate->ThrowError(v8pp::to_v8(isolate, "TextLabel.create: expected (x, y, z, text, fontSize?, drawDistance?, virtualWorld?)"));
+            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "TextLabel.create: expected (x, y, z, text, fontSize?, drawDistance?, virtualWorld?)")));
             return;
         }
 
         auto *replication = CoreModules::GetReplication();
         if (!replication) {
-            isolate->ThrowError(v8pp::to_v8(isolate, "TextLabel.create: replication unavailable"));
+            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "TextLabel.create: replication unavailable")));
             return;
         }
 
@@ -184,13 +184,13 @@ namespace Framework::Scripting::Builtins {
             ++count;
         });
         if (count >= kMaxLabels) {
-            isolate->ThrowError(v8pp::to_v8(isolate, "TextLabel.create: label limit reached"));
+            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "TextLabel.create: label limit reached")));
             return;
         }
 
         auto *label = replication->CreateEntity<LabelEntity>();
         if (!label) {
-            isolate->ThrowError(v8pp::to_v8(isolate, "TextLabel.create: failed to create entity (type not registered?)"));
+            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "TextLabel.create: failed to create entity (type not registered?)")));
             return;
         }
 

--- a/code/framework/src/scripting/builtins/text_label.cpp
+++ b/code/framework/src/scripting/builtins/text_label.cpp
@@ -8,6 +8,7 @@
 
 #include "text_label.h"
 #include "../scripting_catalog.h"
+#include "color.h"
 
 #include <core_modules.h>
 
@@ -36,11 +37,15 @@ namespace Framework::Scripting::Builtins {
     }
 
     void TextLabel::SetColor(int r, int g, int b, int a) {
+        const auto clamp = [](int c) {
+            return static_cast<uint32_t>(std::clamp(c, 0, 255));
+        };
+        SetColorPacked((clamp(a) << 24) | (clamp(r) << 16) | (clamp(g) << 8) | clamp(b));
+    }
+
+    void TextLabel::SetColorPacked(uint32_t argb) {
         if (auto *label = ResolveLabel()) {
-            const auto clamp = [](int c) {
-                return static_cast<uint32_t>(std::clamp(c, 0, 255));
-            };
-            label->color = (clamp(a) << 24) | (clamp(r) << 16) | (clamp(g) << 8) | clamp(b);
+            label->color = argb;
         }
     }
 
@@ -123,11 +128,6 @@ namespace Framework::Scripting::Builtins {
             .function("toString", &TextLabel::ToString, v8pp::metadata::docs("string", {}, "Formats this label for logging and debugging.", "Text containing the label ID and current text."))
             .function("destroy", &TextLabel::Destroy, v8pp::metadata::docs("void", {}, "Destroys this replicated label; stale wrappers no longer resolve afterward."))
             .function("setText", &TextLabel::SetText, v8pp::metadata::docs("void", {v8pp::metadata::param("text", "string", false, "Replacement text replicated to clients.")}, "Changes the label's displayed text."))
-            .function("setColor", &TextLabel::SetColor,
-                v8pp::metadata::docs("void",
-                    {v8pp::metadata::param("r", "number", false, "Red byte, clamped from 0 to 255."), v8pp::metadata::param("g", "number", false, "Green byte, clamped from 0 to 255."), v8pp::metadata::param("b", "number", false, "Blue byte, clamped from 0 to 255."),
-                        v8pp::metadata::param("a", "number", false, "Alpha byte, clamped from 0 to 255.")},
-                    "Changes the label's packed ARGB color."))
             .function("setFontSize", &TextLabel::SetFontSize, v8pp::metadata::docs("void", {v8pp::metadata::param("size", "number", false, "Font size clamped from 6 to 128.")}, "Changes the rendered font size."))
             .function("setDrawDistance", &TextLabel::SetDrawDistance, v8pp::metadata::docs("void", {v8pp::metadata::param("distance", "number", false, "Maximum rendering distance, clamped from 1 to 1000 world units.")}, "Changes how far away clients can render the label."))
             .function("setFadeDistance", &TextLabel::SetFadeDistance,
@@ -139,6 +139,35 @@ namespace Framework::Scripting::Builtins {
             .property("drawDistance", &TextLabel::GetDrawDistance, v8pp::metadata::property_docs("number", "Current maximum rendering distance in world units."))
             .property("fadeDistance", &TextLabel::GetFadeDistance, v8pp::metadata::property_docs("number", "Current fade range in world units."))
             .property("style", &TextLabel::GetStyle, v8pp::metadata::property_docs("number", "Current framework text-label style enum value."));
+
+        // setColor accepts either a Core.Color or byte components (r, g, b, a from 0-255), so scripts
+        // don't have to hand-pack this API's ARGB layout. Registered as a raw prototype function
+        // because v8pp's typed binding can't express the Color|number overload.
+        cls->prototype_function(
+            "setColor",
+            [](const v8::FunctionCallbackInfo<v8::Value> &info) {
+                v8::Isolate *iso = info.GetIsolate();
+                auto *self       = v8pp::class_<TextLabel>::unwrap_object(iso, info.This());
+                if (!self) {
+                    return;
+                }
+                if (info.Length() >= 1) {
+                    if (auto *col = v8pp::class_<Color>::unwrap_object(iso, info[0])) {
+                        self->SetColorPacked(col->toARGB());
+                        return;
+                    }
+                }
+                v8::Local<v8::Context> ctx = iso->GetCurrentContext();
+                const auto num             = [&](int i, int fallback) {
+                    return (info.Length() > i && info[i]->IsNumber()) ? info[i]->Int32Value(ctx).FromMaybe(fallback) : fallback;
+                };
+                self->SetColor(num(0, 0), num(1, 0), num(2, 0), num(3, 255));
+            },
+            v8pp::metadata::docs("void",
+                {v8pp::metadata::param("colorOrR", "Color | number", false, "A Core.Color, or the red byte (0-255) when passing components."),
+                    v8pp::metadata::param("g", "number", true, "Green byte (0-255) when passing components."), v8pp::metadata::param("b", "number", true, "Blue byte (0-255) when passing components."),
+                    v8pp::metadata::param("a", "number", true, "Alpha byte (0-255) when passing components; defaults to 255.")},
+                "Changes the label's packed ARGB color from a Core.Color or byte components."));
 
         return *cls;
     }

--- a/code/framework/src/scripting/builtins/text_label.h
+++ b/code/framework/src/scripting/builtins/text_label.h
@@ -39,6 +39,8 @@ namespace Framework::Scripting::Builtins {
 
         uint32_t GetColor() const;
         void SetColor(int r, int g, int b, int a);
+        // Write an already-packed ARGB value (e.g. from Color::toARGB()).
+        void SetColorPacked(uint32_t argb);
 
         float GetFontSize() const;
         void SetFontSize(float size);

--- a/code/framework/src/scripting/builtins/vector2.h
+++ b/code/framework/src/scripting/builtins/vector2.h
@@ -8,64 +8,107 @@
 
 #pragma once
 
+#include <glm/glm.hpp>
+#include <memory>
+#include <string>
+#include <unordered_map>
 #include <v8pp/class.hpp>
 #include <v8pp/property.hpp>
-#include <glm/glm.hpp>
-#include <string>
-#include <memory>
-#include <unordered_map>
 
 namespace Framework::Scripting::Builtins {
 
-/**
- * Vector2 wrapper class for V8 bindings using v8pp.
- * Provides a clean C++ interface that wraps glm::vec2.
- */
-class Vector2 final {
-  public:
-    Vector2() : _vec(0.0f) {}
-    Vector2(float x, float y) : _vec(x, y) {}
-    Vector2(const glm::vec2& v) : _vec(v) {}
+    /**
+     * Vector2 wrapper class for V8 bindings using v8pp.
+     * Provides a clean C++ interface that wraps glm::vec2.
+     */
+    class Vector2 final {
+      public:
+        Vector2(): _vec(0.0f) {}
+        Vector2(float x, float y): _vec(x, y) {}
+        Vector2(const glm::vec2 &v): _vec(v) {}
 
-    // Property accessors
-    float getX() const { return _vec.x; }
-    void setX(float v) { _vec.x = v; }
-    float getY() const { return _vec.y; }
-    void setY(float v) { _vec.y = v; }
-    float getLength() const { return glm::length(_vec); }
-    float getLengthSquared() const { return glm::dot(_vec, _vec); }
+        // Property accessors
+        float getX() const {
+            return _vec.x;
+        }
+        void setX(float v) {
+            _vec.x = v;
+        }
+        float getY() const {
+            return _vec.y;
+        }
+        void setY(float v) {
+            _vec.y = v;
+        }
+        float getLength() const {
+            return glm::length(_vec);
+        }
+        float getLengthSquared() const {
+            return glm::dot(_vec, _vec);
+        }
 
-    // Mutable methods (modify in place, return this for chaining)
-    Vector2& add(const Vector2& other) { _vec += other._vec; return *this; }
-    Vector2& sub(const Vector2& other) { _vec -= other._vec; return *this; }
-    Vector2& mul(float scalar) { _vec *= scalar; return *this; }
-    Vector2& div(float scalar) { _vec /= scalar; return *this; }
-    Vector2& normalize();
-    Vector2& lerp(const Vector2& target, float t) { _vec = glm::mix(_vec, target._vec, t); return *this; }
-    Vector2& set(float x, float y) { _vec.x = x; _vec.y = y; return *this; }
+        // Mutable methods (modify in place, return this for chaining)
+        Vector2 &add(const Vector2 &other) {
+            _vec += other._vec;
+            return *this;
+        }
+        Vector2 &sub(const Vector2 &other) {
+            _vec -= other._vec;
+            return *this;
+        }
+        Vector2 &mul(float scalar) {
+            _vec *= scalar;
+            return *this;
+        }
+        Vector2 &div(float scalar) {
+            _vec /= scalar;
+            return *this;
+        }
+        Vector2 &normalize();
+        Vector2 &lerp(const Vector2 &target, float t) {
+            _vec = glm::mix(_vec, target._vec, t);
+            return *this;
+        }
+        Vector2 &set(float x, float y) {
+            _vec.x = x;
+            _vec.y = y;
+            return *this;
+        }
 
-    // Non-mutating methods
-    float dot(const Vector2& other) const { return glm::dot(_vec, other._vec); }
-    float distance(const Vector2& other) const { return glm::distance(_vec, other._vec); }
-    Vector2 clone() const { return Vector2(_vec); }
-    std::string toString() const;
+        // Non-mutating methods
+        float dot(const Vector2 &other) const {
+            return glm::dot(_vec, other._vec);
+        }
+        float distance(const Vector2 &other) const {
+            return glm::distance(_vec, other._vec);
+        }
+        Vector2 clone() const {
+            return Vector2(_vec);
+        }
+        std::string toString() const;
 
-    // Static factory methods
-    static Vector2 zero() { return Vector2(0, 0); }
-    static Vector2 one() { return Vector2(1, 1); }
+        // Static factory methods
+        static Vector2 zero() {
+            return Vector2(0, 0);
+        }
+        static Vector2 one() {
+            return Vector2(1, 1);
+        }
 
-    // Access underlying GLM type
-    const glm::vec2& vec() const { return _vec; }
+        // Access underlying GLM type
+        const glm::vec2 &vec() const {
+            return _vec;
+        }
 
-    // V8 Registration
-    static void Register(v8::Isolate* isolate, v8::Local<v8::Object> global);
-    static v8pp::class_<Vector2>& GetClass(v8::Isolate* isolate);
-    static v8::Local<v8::Object> NewInstance(v8::Isolate* isolate, const glm::vec2& value);
-    static void UnregisterIsolate(v8::Isolate* isolate);
+        // V8 Registration
+        static void Register(v8::Isolate *isolate, v8::Local<v8::Object> global);
+        static v8pp::class_<Vector2> &GetClass(v8::Isolate *isolate);
+        static v8::Local<v8::Object> NewInstance(v8::Isolate *isolate, const glm::vec2 &value);
+        static void UnregisterIsolate(v8::Isolate *isolate);
 
-  private:
-    glm::vec2 _vec;
-    static std::unordered_map<v8::Isolate*, std::unique_ptr<v8pp::class_<Vector2>>> _classes;
-};
+      private:
+        glm::vec2 _vec;
+        static std::unordered_map<v8::Isolate *, std::unique_ptr<v8pp::class_<Vector2>>> _classes;
+    };
 
 } // namespace Framework::Scripting::Builtins

--- a/code/framework/src/scripting/builtins/vector3.h
+++ b/code/framework/src/scripting/builtins/vector3.h
@@ -8,70 +8,127 @@
 
 #pragma once
 
+#include <glm/glm.hpp>
+#include <memory>
+#include <string>
+#include <unordered_map>
 #include <v8pp/class.hpp>
 #include <v8pp/property.hpp>
-#include <glm/glm.hpp>
-#include <string>
-#include <memory>
-#include <unordered_map>
 
 namespace Framework::Scripting::Builtins {
 
-/**
- * Vector3 wrapper class for V8 bindings using v8pp.
- * Provides a clean C++ interface that wraps glm::vec3.
- */
-class Vector3 final {
-  public:
-    Vector3() : _vec(0.0f) {}
-    Vector3(float x, float y, float z) : _vec(x, y, z) {}
-    Vector3(const glm::vec3& v) : _vec(v) {}
+    /**
+     * Vector3 wrapper class for V8 bindings using v8pp.
+     * Provides a clean C++ interface that wraps glm::vec3.
+     */
+    class Vector3 final {
+      public:
+        Vector3(): _vec(0.0f) {}
+        Vector3(float x, float y, float z): _vec(x, y, z) {}
+        Vector3(const glm::vec3 &v): _vec(v) {}
 
-    // Property accessors
-    float getX() const { return _vec.x; }
-    void setX(float v) { _vec.x = v; }
-    float getY() const { return _vec.y; }
-    void setY(float v) { _vec.y = v; }
-    float getZ() const { return _vec.z; }
-    void setZ(float v) { _vec.z = v; }
-    float getLength() const { return glm::length(_vec); }
-    float getLengthSquared() const { return glm::dot(_vec, _vec); }
+        // Property accessors
+        float getX() const {
+            return _vec.x;
+        }
+        void setX(float v) {
+            _vec.x = v;
+        }
+        float getY() const {
+            return _vec.y;
+        }
+        void setY(float v) {
+            _vec.y = v;
+        }
+        float getZ() const {
+            return _vec.z;
+        }
+        void setZ(float v) {
+            _vec.z = v;
+        }
+        float getLength() const {
+            return glm::length(_vec);
+        }
+        float getLengthSquared() const {
+            return glm::dot(_vec, _vec);
+        }
 
-    // Mutable methods (modify in place, return this for chaining)
-    Vector3& add(const Vector3& other) { _vec += other._vec; return *this; }
-    Vector3& sub(const Vector3& other) { _vec -= other._vec; return *this; }
-    Vector3& mul(float scalar) { _vec *= scalar; return *this; }
-    Vector3& div(float scalar) { _vec /= scalar; return *this; }
-    Vector3& cross(const Vector3& other) { _vec = glm::cross(_vec, other._vec); return *this; }
-    Vector3& normalize();
-    Vector3& lerp(const Vector3& target, float t) { _vec = glm::mix(_vec, target._vec, t); return *this; }
-    Vector3& set(float x, float y, float z) { _vec.x = x; _vec.y = y; _vec.z = z; return *this; }
+        // Mutable methods (modify in place, return this for chaining)
+        Vector3 &add(const Vector3 &other) {
+            _vec += other._vec;
+            return *this;
+        }
+        Vector3 &sub(const Vector3 &other) {
+            _vec -= other._vec;
+            return *this;
+        }
+        Vector3 &mul(float scalar) {
+            _vec *= scalar;
+            return *this;
+        }
+        Vector3 &div(float scalar) {
+            _vec /= scalar;
+            return *this;
+        }
+        Vector3 &cross(const Vector3 &other) {
+            _vec = glm::cross(_vec, other._vec);
+            return *this;
+        }
+        Vector3 &normalize();
+        Vector3 &lerp(const Vector3 &target, float t) {
+            _vec = glm::mix(_vec, target._vec, t);
+            return *this;
+        }
+        Vector3 &set(float x, float y, float z) {
+            _vec.x = x;
+            _vec.y = y;
+            _vec.z = z;
+            return *this;
+        }
 
-    // Non-mutating methods
-    float dot(const Vector3& other) const { return glm::dot(_vec, other._vec); }
-    float distance(const Vector3& other) const { return glm::distance(_vec, other._vec); }
-    Vector3 clone() const { return Vector3(_vec); }
-    std::string toString() const;
+        // Non-mutating methods
+        float dot(const Vector3 &other) const {
+            return glm::dot(_vec, other._vec);
+        }
+        float distance(const Vector3 &other) const {
+            return glm::distance(_vec, other._vec);
+        }
+        Vector3 clone() const {
+            return Vector3(_vec);
+        }
+        std::string toString() const;
 
-    // Static factory methods
-    static Vector3 zero() { return Vector3(0, 0, 0); }
-    static Vector3 one() { return Vector3(1, 1, 1); }
-    static Vector3 up() { return Vector3(0, 1, 0); }
-    static Vector3 forward() { return Vector3(0, 0, 1); }
-    static Vector3 right() { return Vector3(1, 0, 0); }
+        // Static factory methods
+        static Vector3 zero() {
+            return Vector3(0, 0, 0);
+        }
+        static Vector3 one() {
+            return Vector3(1, 1, 1);
+        }
+        static Vector3 up() {
+            return Vector3(0, 1, 0);
+        }
+        static Vector3 forward() {
+            return Vector3(0, 0, 1);
+        }
+        static Vector3 right() {
+            return Vector3(1, 0, 0);
+        }
 
-    // Access underlying GLM type
-    const glm::vec3& vec() const { return _vec; }
+        // Access underlying GLM type
+        const glm::vec3 &vec() const {
+            return _vec;
+        }
 
-    // V8 Registration
-    static void Register(v8::Isolate* isolate, v8::Local<v8::Object> global);
-    static v8pp::class_<Vector3>& GetClass(v8::Isolate* isolate);
-    static v8::Local<v8::Object> NewInstance(v8::Isolate* isolate, const glm::vec3& value);
-    static void UnregisterIsolate(v8::Isolate* isolate);
+        // V8 Registration
+        static void Register(v8::Isolate *isolate, v8::Local<v8::Object> global);
+        static v8pp::class_<Vector3> &GetClass(v8::Isolate *isolate);
+        static v8::Local<v8::Object> NewInstance(v8::Isolate *isolate, const glm::vec3 &value);
+        static void UnregisterIsolate(v8::Isolate *isolate);
 
-  private:
-    glm::vec3 _vec;
-    static std::unordered_map<v8::Isolate*, std::unique_ptr<v8pp::class_<Vector3>>> _classes;
-};
+      private:
+        glm::vec3 _vec;
+        static std::unordered_map<v8::Isolate *, std::unique_ptr<v8pp::class_<Vector3>>> _classes;
+    };
 
 } // namespace Framework::Scripting::Builtins

--- a/code/framework/src/scripting/builtins/vector4.h
+++ b/code/framework/src/scripting/builtins/vector4.h
@@ -8,68 +8,121 @@
 
 #pragma once
 
+#include <glm/glm.hpp>
+#include <memory>
+#include <string>
+#include <unordered_map>
 #include <v8pp/class.hpp>
 #include <v8pp/property.hpp>
-#include <glm/glm.hpp>
-#include <string>
-#include <memory>
-#include <unordered_map>
 
 namespace Framework::Scripting::Builtins {
 
-/**
- * Vector4 wrapper class for V8 bindings using v8pp.
- * Provides a clean C++ interface that wraps glm::vec4.
- */
-class Vector4 final {
-  public:
-    Vector4() : _vec(0.0f) {}
-    Vector4(float x, float y, float z, float w) : _vec(x, y, z, w) {}
-    Vector4(const glm::vec4& v) : _vec(v) {}
+    /**
+     * Vector4 wrapper class for V8 bindings using v8pp.
+     * Provides a clean C++ interface that wraps glm::vec4.
+     */
+    class Vector4 final {
+      public:
+        Vector4(): _vec(0.0f) {}
+        Vector4(float x, float y, float z, float w): _vec(x, y, z, w) {}
+        Vector4(const glm::vec4 &v): _vec(v) {}
 
-    // Property accessors
-    float getX() const { return _vec.x; }
-    void setX(float v) { _vec.x = v; }
-    float getY() const { return _vec.y; }
-    void setY(float v) { _vec.y = v; }
-    float getZ() const { return _vec.z; }
-    void setZ(float v) { _vec.z = v; }
-    float getW() const { return _vec.w; }
-    void setW(float v) { _vec.w = v; }
-    float getLength() const { return glm::length(_vec); }
-    float getLengthSquared() const { return glm::dot(_vec, _vec); }
+        // Property accessors
+        float getX() const {
+            return _vec.x;
+        }
+        void setX(float v) {
+            _vec.x = v;
+        }
+        float getY() const {
+            return _vec.y;
+        }
+        void setY(float v) {
+            _vec.y = v;
+        }
+        float getZ() const {
+            return _vec.z;
+        }
+        void setZ(float v) {
+            _vec.z = v;
+        }
+        float getW() const {
+            return _vec.w;
+        }
+        void setW(float v) {
+            _vec.w = v;
+        }
+        float getLength() const {
+            return glm::length(_vec);
+        }
+        float getLengthSquared() const {
+            return glm::dot(_vec, _vec);
+        }
 
-    // Mutable methods (modify in place, return this for chaining)
-    Vector4& add(const Vector4& other) { _vec += other._vec; return *this; }
-    Vector4& sub(const Vector4& other) { _vec -= other._vec; return *this; }
-    Vector4& mul(float scalar) { _vec *= scalar; return *this; }
-    Vector4& div(float scalar) { _vec /= scalar; return *this; }
-    Vector4& normalize();
-    Vector4& lerp(const Vector4& target, float t) { _vec = glm::mix(_vec, target._vec, t); return *this; }
-    Vector4& set(float x, float y, float z, float w) { _vec.x = x; _vec.y = y; _vec.z = z; _vec.w = w; return *this; }
+        // Mutable methods (modify in place, return this for chaining)
+        Vector4 &add(const Vector4 &other) {
+            _vec += other._vec;
+            return *this;
+        }
+        Vector4 &sub(const Vector4 &other) {
+            _vec -= other._vec;
+            return *this;
+        }
+        Vector4 &mul(float scalar) {
+            _vec *= scalar;
+            return *this;
+        }
+        Vector4 &div(float scalar) {
+            _vec /= scalar;
+            return *this;
+        }
+        Vector4 &normalize();
+        Vector4 &lerp(const Vector4 &target, float t) {
+            _vec = glm::mix(_vec, target._vec, t);
+            return *this;
+        }
+        Vector4 &set(float x, float y, float z, float w) {
+            _vec.x = x;
+            _vec.y = y;
+            _vec.z = z;
+            _vec.w = w;
+            return *this;
+        }
 
-    // Non-mutating methods
-    float dot(const Vector4& other) const { return glm::dot(_vec, other._vec); }
-    float distance(const Vector4& other) const { return glm::distance(_vec, other._vec); }
-    Vector4 clone() const { return Vector4(_vec); }
-    std::string toString() const;
+        // Non-mutating methods
+        float dot(const Vector4 &other) const {
+            return glm::dot(_vec, other._vec);
+        }
+        float distance(const Vector4 &other) const {
+            return glm::distance(_vec, other._vec);
+        }
+        Vector4 clone() const {
+            return Vector4(_vec);
+        }
+        std::string toString() const;
 
-    // Static factory methods
-    static Vector4 zero() { return Vector4(0, 0, 0, 0); }
-    static Vector4 one() { return Vector4(1, 1, 1, 1); }
+        // Static factory methods
+        static Vector4 zero() {
+            return Vector4(0, 0, 0, 0);
+        }
+        static Vector4 one() {
+            return Vector4(1, 1, 1, 1);
+        }
 
-    // Access underlying GLM type
-    const glm::vec4& vec() const { return _vec; }
+        // Access underlying GLM type
+        const glm::vec4 &vec() const {
+            return _vec;
+        }
 
-    // V8 Registration
-    static void Register(v8::Isolate* isolate, v8::Local<v8::Object> global);
-    static v8pp::class_<Vector4>& GetClass(v8::Isolate* isolate);
-    static v8::Local<v8::Object> NewInstance(v8::Isolate* isolate, const glm::vec4& value);
-    static void UnregisterIsolate(v8::Isolate* isolate);
+        // V8 Registration
+        static void Register(v8::Isolate *isolate, v8::Local<v8::Object> global);
+        static v8pp::class_<Vector4> &GetClass(v8::Isolate *isolate);
+        static v8::Local<v8::Object> NewInstance(v8::Isolate *isolate, const glm::vec4 &value);
+        static void UnregisterIsolate(v8::Isolate *isolate);
 
-  private:
-    glm::vec4 _vec;
-    static std::unordered_map<v8::Isolate*, std::unique_ptr<v8pp::class_<Vector4>>> _classes;
-};
+      private:
+        glm::vec4 _vec;
+        static std::unordered_map<v8::Isolate *, std::unique_ptr<v8pp::class_<Vector4>>> _classes;
+    };
 
 } // namespace Framework::Scripting::Builtins

--- a/code/framework/src/scripting/node_engine.cpp
+++ b/code/framework/src/scripting/node_engine.cpp
@@ -88,7 +88,7 @@ namespace Framework::Scripting {
             v8::HandleScope handleScope(_isolate);
             v8::Context::Scope contextScope(_setup->context());
 
-            Messages::Shutdown();
+            Builtins::Messages::Shutdown();
         }
         // All V8 scopes have now exited
 

--- a/code/framework/src/scripting/resource/resource_manager.cpp
+++ b/code/framework/src/scripting/resource/resource_manager.cpp
@@ -719,7 +719,7 @@ namespace Framework::Scripting {
     bool ResourceManager::CallResourceStop(std::string_view resourceName) {
         // Cleanup handlers before resource fully stops
         _events.CleanupResource(resourceName);
-        Messages::CleanupResource(std::string(resourceName));
+        Builtins::Messages::CleanupResource(std::string(resourceName));
         return true;
     }
 
@@ -814,7 +814,7 @@ namespace Framework::Scripting {
         return _jsEngine;
     }
 
-    Events &ResourceManager::GetEvents() {
+    Builtins::Events &ResourceManager::GetEvents() {
         return _events;
     }
 

--- a/code/framework/src/scripting/resource/resource_manager.cpp
+++ b/code/framework/src/scripting/resource/resource_manager.cpp
@@ -719,7 +719,18 @@ namespace Framework::Scripting {
     bool ResourceManager::CallResourceStop(std::string_view resourceName) {
         // Cleanup handlers before resource fully stops
         _events.CleanupResource(resourceName);
-        Builtins::Messages::CleanupResource(std::string(resourceName));
+
+        // Reject and drop message requests tied to this resource. Rejecting the awaiting
+        // Promises needs an active isolate/context, so scope one here.
+        if (_jsEngine && _jsEngine->IsInitialized()) {
+            v8::Isolate *isolate = _jsEngine->GetIsolate();
+            v8::Locker locker(isolate);
+            v8::Isolate::Scope isolateScope(isolate);
+            v8::HandleScope handleScope(isolate);
+            v8::Local<v8::Context> context = _jsEngine->GetContext();
+            v8::Context::Scope contextScope(context);
+            Builtins::Messages::CleanupResource(isolate, context, std::string(resourceName));
+        }
         return true;
     }
 

--- a/code/framework/src/scripting/resource/resource_manager.cpp
+++ b/code/framework/src/scripting/resource/resource_manager.cpp
@@ -9,6 +9,7 @@
 #include "resource_manager.h"
 
 #include "../builtins/events.h"
+#include "../builtins/messages.h"
 
 #include <algorithm>
 #include <cctype>
@@ -718,6 +719,7 @@ namespace Framework::Scripting {
     bool ResourceManager::CallResourceStop(std::string_view resourceName) {
         // Cleanup handlers before resource fully stops
         _events.CleanupResource(resourceName);
+        Messages::CleanupResource(std::string(resourceName));
         return true;
     }
 

--- a/code/framework/src/scripting/resource/resource_manager.h
+++ b/code/framework/src/scripting/resource/resource_manager.h
@@ -257,7 +257,7 @@ namespace Framework::Scripting {
         /**
          * Get the Events instance owned by this manager.
          */
-        Events &GetEvents();
+        Builtins::Events &GetEvents();
 
         // Current Resource Context
 
@@ -422,7 +422,7 @@ namespace Framework::Scripting {
         std::chrono::steady_clock::time_point _lastFileWatchPoll{};
 
         // Events instance owned by this manager
-        Events _events;
+        Builtins::Events _events;
     };
 
 } // namespace Framework::Scripting

--- a/code/framework/src/scripting/v8_engine.cpp
+++ b/code/framework/src/scripting/v8_engine.cpp
@@ -146,7 +146,7 @@ namespace Framework::Scripting {
             v8::Local<v8::Context> context = _context.Get(_isolate);
             v8::Context::Scope contextScope(context);
 
-            Messages::Shutdown();
+            Builtins::Messages::Shutdown();
         }
 
         // Clear all timer callbacks (prevent dangling references)

--- a/code/framework/src/scripting/v8pp_types.h
+++ b/code/framework/src/scripting/v8pp_types.h
@@ -8,10 +8,10 @@
 
 #pragma once
 
-#include <v8pp/convert.hpp>
 #include <glm/glm.hpp>
 #include <glm/gtc/quaternion.hpp>
 #include <stdexcept>
+#include <v8pp/convert.hpp>
 
 // Forward declare wrapper classes
 namespace Framework::Scripting::Builtins {
@@ -19,177 +19,177 @@ namespace Framework::Scripting::Builtins {
     class Vector3;
     class Vector4;
     class Quaternion;
-}
+} // namespace Framework::Scripting::Builtins
 
 namespace v8pp {
 
-// glm::vec2 converter
-template<>
-struct convert<glm::vec2> {
-    using from_type = glm::vec2;
-    using to_type = v8::Local<v8::Object>;
+    // glm::vec2 converter
+    template <>
+    struct convert<glm::vec2> {
+        using from_type = glm::vec2;
+        using to_type   = v8::Local<v8::Object>;
 
-    static bool is_valid(v8::Isolate*, v8::Local<v8::Value> value) {
-        return value->IsObject();
-    }
-
-    static glm::vec2 from_v8(v8::Isolate* isolate, v8::Local<v8::Value> value) {
-        if (!value->IsObject()) {
-            throw std::invalid_argument("expected object for vec2");
+        static bool is_valid(v8::Isolate *, v8::Local<v8::Value> value) {
+            return value->IsObject();
         }
-        auto obj = value.As<v8::Object>();
-        auto ctx = isolate->GetCurrentContext();
 
-        float x = 0, y = 0;
-        v8::Local<v8::Value> xVal, yVal;
-        if (obj->Get(ctx, v8pp::to_v8(isolate, "x")).ToLocal(&xVal) && xVal->IsNumber()) {
-            x = static_cast<float>(xVal->NumberValue(ctx).FromMaybe(0.0));
+        static glm::vec2 from_v8(v8::Isolate *isolate, v8::Local<v8::Value> value) {
+            if (!value->IsObject()) {
+                throw std::invalid_argument("expected object for vec2");
+            }
+            auto obj = value.As<v8::Object>();
+            auto ctx = isolate->GetCurrentContext();
+
+            float x = 0, y = 0;
+            v8::Local<v8::Value> xVal, yVal;
+            if (obj->Get(ctx, v8pp::to_v8(isolate, "x")).ToLocal(&xVal) && xVal->IsNumber()) {
+                x = static_cast<float>(xVal->NumberValue(ctx).FromMaybe(0.0));
+            }
+            if (obj->Get(ctx, v8pp::to_v8(isolate, "y")).ToLocal(&yVal) && yVal->IsNumber()) {
+                y = static_cast<float>(yVal->NumberValue(ctx).FromMaybe(0.0));
+            }
+            return glm::vec2(x, y);
         }
-        if (obj->Get(ctx, v8pp::to_v8(isolate, "y")).ToLocal(&yVal) && yVal->IsNumber()) {
-            y = static_cast<float>(yVal->NumberValue(ctx).FromMaybe(0.0));
+
+        static v8::Local<v8::Object> to_v8(v8::Isolate *isolate, const glm::vec2 &value);
+    };
+
+    // glm::vec3 converter
+    template <>
+    struct convert<glm::vec3> {
+        using from_type = glm::vec3;
+        using to_type   = v8::Local<v8::Object>;
+
+        static bool is_valid(v8::Isolate *, v8::Local<v8::Value> value) {
+            return value->IsObject();
         }
-        return glm::vec2(x, y);
-    }
 
-    static v8::Local<v8::Object> to_v8(v8::Isolate* isolate, const glm::vec2& value);
-};
+        static glm::vec3 from_v8(v8::Isolate *isolate, v8::Local<v8::Value> value) {
+            if (!value->IsObject()) {
+                throw std::invalid_argument("expected object for vec3");
+            }
+            auto obj = value.As<v8::Object>();
+            auto ctx = isolate->GetCurrentContext();
 
-// glm::vec3 converter
-template<>
-struct convert<glm::vec3> {
-    using from_type = glm::vec3;
-    using to_type = v8::Local<v8::Object>;
-
-    static bool is_valid(v8::Isolate*, v8::Local<v8::Value> value) {
-        return value->IsObject();
-    }
-
-    static glm::vec3 from_v8(v8::Isolate* isolate, v8::Local<v8::Value> value) {
-        if (!value->IsObject()) {
-            throw std::invalid_argument("expected object for vec3");
+            float x = 0, y = 0, z = 0;
+            v8::Local<v8::Value> xVal, yVal, zVal;
+            if (obj->Get(ctx, v8pp::to_v8(isolate, "x")).ToLocal(&xVal) && xVal->IsNumber()) {
+                x = static_cast<float>(xVal->NumberValue(ctx).FromMaybe(0.0));
+            }
+            if (obj->Get(ctx, v8pp::to_v8(isolate, "y")).ToLocal(&yVal) && yVal->IsNumber()) {
+                y = static_cast<float>(yVal->NumberValue(ctx).FromMaybe(0.0));
+            }
+            if (obj->Get(ctx, v8pp::to_v8(isolate, "z")).ToLocal(&zVal) && zVal->IsNumber()) {
+                z = static_cast<float>(zVal->NumberValue(ctx).FromMaybe(0.0));
+            }
+            return glm::vec3(x, y, z);
         }
-        auto obj = value.As<v8::Object>();
-        auto ctx = isolate->GetCurrentContext();
 
-        float x = 0, y = 0, z = 0;
-        v8::Local<v8::Value> xVal, yVal, zVal;
-        if (obj->Get(ctx, v8pp::to_v8(isolate, "x")).ToLocal(&xVal) && xVal->IsNumber()) {
-            x = static_cast<float>(xVal->NumberValue(ctx).FromMaybe(0.0));
-        }
-        if (obj->Get(ctx, v8pp::to_v8(isolate, "y")).ToLocal(&yVal) && yVal->IsNumber()) {
-            y = static_cast<float>(yVal->NumberValue(ctx).FromMaybe(0.0));
-        }
-        if (obj->Get(ctx, v8pp::to_v8(isolate, "z")).ToLocal(&zVal) && zVal->IsNumber()) {
-            z = static_cast<float>(zVal->NumberValue(ctx).FromMaybe(0.0));
-        }
-        return glm::vec3(x, y, z);
-    }
+        static v8::Local<v8::Object> to_v8(v8::Isolate *isolate, const glm::vec3 &value);
+    };
 
-    static v8::Local<v8::Object> to_v8(v8::Isolate* isolate, const glm::vec3& value);
-};
+    // glm::vec4 converter
+    template <>
+    struct convert<glm::vec4> {
+        using from_type = glm::vec4;
+        using to_type   = v8::Local<v8::Object>;
 
-// glm::vec4 converter
-template<>
-struct convert<glm::vec4> {
-    using from_type = glm::vec4;
-    using to_type = v8::Local<v8::Object>;
+        static bool is_valid(v8::Isolate *, v8::Local<v8::Value> value) {
+            return value->IsObject();
+        }
 
-    static bool is_valid(v8::Isolate*, v8::Local<v8::Value> value) {
-        return value->IsObject();
-    }
+        static glm::vec4 from_v8(v8::Isolate *isolate, v8::Local<v8::Value> value) {
+            if (!value->IsObject()) {
+                throw std::invalid_argument("expected object for vec4");
+            }
+            auto obj = value.As<v8::Object>();
+            auto ctx = isolate->GetCurrentContext();
 
-    static glm::vec4 from_v8(v8::Isolate* isolate, v8::Local<v8::Value> value) {
-        if (!value->IsObject()) {
-            throw std::invalid_argument("expected object for vec4");
+            float x = 0, y = 0, z = 0, w = 0;
+            v8::Local<v8::Value> xVal, yVal, zVal, wVal;
+            if (obj->Get(ctx, v8pp::to_v8(isolate, "x")).ToLocal(&xVal) && xVal->IsNumber()) {
+                x = static_cast<float>(xVal->NumberValue(ctx).FromMaybe(0.0));
+            }
+            if (obj->Get(ctx, v8pp::to_v8(isolate, "y")).ToLocal(&yVal) && yVal->IsNumber()) {
+                y = static_cast<float>(yVal->NumberValue(ctx).FromMaybe(0.0));
+            }
+            if (obj->Get(ctx, v8pp::to_v8(isolate, "z")).ToLocal(&zVal) && zVal->IsNumber()) {
+                z = static_cast<float>(zVal->NumberValue(ctx).FromMaybe(0.0));
+            }
+            if (obj->Get(ctx, v8pp::to_v8(isolate, "w")).ToLocal(&wVal) && wVal->IsNumber()) {
+                w = static_cast<float>(wVal->NumberValue(ctx).FromMaybe(0.0));
+            }
+            return glm::vec4(x, y, z, w);
         }
-        auto obj = value.As<v8::Object>();
-        auto ctx = isolate->GetCurrentContext();
 
-        float x = 0, y = 0, z = 0, w = 0;
-        v8::Local<v8::Value> xVal, yVal, zVal, wVal;
-        if (obj->Get(ctx, v8pp::to_v8(isolate, "x")).ToLocal(&xVal) && xVal->IsNumber()) {
-            x = static_cast<float>(xVal->NumberValue(ctx).FromMaybe(0.0));
-        }
-        if (obj->Get(ctx, v8pp::to_v8(isolate, "y")).ToLocal(&yVal) && yVal->IsNumber()) {
-            y = static_cast<float>(yVal->NumberValue(ctx).FromMaybe(0.0));
-        }
-        if (obj->Get(ctx, v8pp::to_v8(isolate, "z")).ToLocal(&zVal) && zVal->IsNumber()) {
-            z = static_cast<float>(zVal->NumberValue(ctx).FromMaybe(0.0));
-        }
-        if (obj->Get(ctx, v8pp::to_v8(isolate, "w")).ToLocal(&wVal) && wVal->IsNumber()) {
-            w = static_cast<float>(wVal->NumberValue(ctx).FromMaybe(0.0));
-        }
-        return glm::vec4(x, y, z, w);
-    }
+        static v8::Local<v8::Object> to_v8(v8::Isolate *isolate, const glm::vec4 &value);
+    };
 
-    static v8::Local<v8::Object> to_v8(v8::Isolate* isolate, const glm::vec4& value);
-};
+    // glm::quat converter
+    template <>
+    struct convert<glm::quat> {
+        using from_type = glm::quat;
+        using to_type   = v8::Local<v8::Object>;
 
-// glm::quat converter
-template<>
-struct convert<glm::quat> {
-    using from_type = glm::quat;
-    using to_type = v8::Local<v8::Object>;
+        static bool is_valid(v8::Isolate *, v8::Local<v8::Value> value) {
+            return value->IsObject();
+        }
 
-    static bool is_valid(v8::Isolate*, v8::Local<v8::Value> value) {
-        return value->IsObject();
-    }
+        static glm::quat from_v8(v8::Isolate *isolate, v8::Local<v8::Value> value) {
+            if (!value->IsObject()) {
+                throw std::invalid_argument("expected object for quat");
+            }
+            auto obj = value.As<v8::Object>();
+            auto ctx = isolate->GetCurrentContext();
 
-    static glm::quat from_v8(v8::Isolate* isolate, v8::Local<v8::Value> value) {
-        if (!value->IsObject()) {
-            throw std::invalid_argument("expected object for quat");
+            float w = 1, x = 0, y = 0, z = 0;
+            v8::Local<v8::Value> wVal, xVal, yVal, zVal;
+            if (obj->Get(ctx, v8pp::to_v8(isolate, "w")).ToLocal(&wVal) && wVal->IsNumber()) {
+                w = static_cast<float>(wVal->NumberValue(ctx).FromMaybe(1.0));
+            }
+            if (obj->Get(ctx, v8pp::to_v8(isolate, "x")).ToLocal(&xVal) && xVal->IsNumber()) {
+                x = static_cast<float>(xVal->NumberValue(ctx).FromMaybe(0.0));
+            }
+            if (obj->Get(ctx, v8pp::to_v8(isolate, "y")).ToLocal(&yVal) && yVal->IsNumber()) {
+                y = static_cast<float>(yVal->NumberValue(ctx).FromMaybe(0.0));
+            }
+            if (obj->Get(ctx, v8pp::to_v8(isolate, "z")).ToLocal(&zVal) && zVal->IsNumber()) {
+                z = static_cast<float>(zVal->NumberValue(ctx).FromMaybe(0.0));
+            }
+            return glm::quat(w, x, y, z);
         }
-        auto obj = value.As<v8::Object>();
-        auto ctx = isolate->GetCurrentContext();
 
-        float w = 1, x = 0, y = 0, z = 0;
-        v8::Local<v8::Value> wVal, xVal, yVal, zVal;
-        if (obj->Get(ctx, v8pp::to_v8(isolate, "w")).ToLocal(&wVal) && wVal->IsNumber()) {
-            w = static_cast<float>(wVal->NumberValue(ctx).FromMaybe(1.0));
-        }
-        if (obj->Get(ctx, v8pp::to_v8(isolate, "x")).ToLocal(&xVal) && xVal->IsNumber()) {
-            x = static_cast<float>(xVal->NumberValue(ctx).FromMaybe(0.0));
-        }
-        if (obj->Get(ctx, v8pp::to_v8(isolate, "y")).ToLocal(&yVal) && yVal->IsNumber()) {
-            y = static_cast<float>(yVal->NumberValue(ctx).FromMaybe(0.0));
-        }
-        if (obj->Get(ctx, v8pp::to_v8(isolate, "z")).ToLocal(&zVal) && zVal->IsNumber()) {
-            z = static_cast<float>(zVal->NumberValue(ctx).FromMaybe(0.0));
-        }
-        return glm::quat(w, x, y, z);
-    }
-
-    static v8::Local<v8::Object> to_v8(v8::Isolate* isolate, const glm::quat& value);
-};
+        static v8::Local<v8::Object> to_v8(v8::Isolate *isolate, const glm::quat &value);
+    };
 
 } // namespace v8pp
 
 // Include builtin headers for to_v8 implementations
+#include "builtins/quaternion.h"
 #include "builtins/vector2.h"
 #include "builtins/vector3.h"
 #include "builtins/vector4.h"
-#include "builtins/quaternion.h"
 
 namespace v8pp {
 
-// Implementation of glm::vec2 to_v8 using Vector2 wrapper class
-inline v8::Local<v8::Object> convert<glm::vec2>::to_v8(v8::Isolate* isolate, const glm::vec2& value) {
-    return Framework::Scripting::Builtins::Vector2::NewInstance(isolate, value);
-}
+    // Implementation of glm::vec2 to_v8 using Vector2 wrapper class
+    inline v8::Local<v8::Object> convert<glm::vec2>::to_v8(v8::Isolate *isolate, const glm::vec2 &value) {
+        return Framework::Scripting::Builtins::Vector2::NewInstance(isolate, value);
+    }
 
-// Implementation of glm::vec3 to_v8 using Vector3 wrapper class
-inline v8::Local<v8::Object> convert<glm::vec3>::to_v8(v8::Isolate* isolate, const glm::vec3& value) {
-    return Framework::Scripting::Builtins::Vector3::NewInstance(isolate, value);
-}
+    // Implementation of glm::vec3 to_v8 using Vector3 wrapper class
+    inline v8::Local<v8::Object> convert<glm::vec3>::to_v8(v8::Isolate *isolate, const glm::vec3 &value) {
+        return Framework::Scripting::Builtins::Vector3::NewInstance(isolate, value);
+    }
 
-// Implementation of glm::vec4 to_v8 using Vector4 wrapper class
-inline v8::Local<v8::Object> convert<glm::vec4>::to_v8(v8::Isolate* isolate, const glm::vec4& value) {
-    return Framework::Scripting::Builtins::Vector4::NewInstance(isolate, value);
-}
+    // Implementation of glm::vec4 to_v8 using Vector4 wrapper class
+    inline v8::Local<v8::Object> convert<glm::vec4>::to_v8(v8::Isolate *isolate, const glm::vec4 &value) {
+        return Framework::Scripting::Builtins::Vector4::NewInstance(isolate, value);
+    }
 
-// Implementation of glm::quat to_v8 using Quaternion wrapper class
-inline v8::Local<v8::Object> convert<glm::quat>::to_v8(v8::Isolate* isolate, const glm::quat& value) {
-    return Framework::Scripting::Builtins::Quaternion::NewInstance(isolate, value);
-}
+    // Implementation of glm::quat to_v8 using Quaternion wrapper class
+    inline v8::Local<v8::Object> convert<glm::quat>::to_v8(v8::Isolate *isolate, const glm::quat &value) {
+        return Framework::Scripting::Builtins::Quaternion::NewInstance(isolate, value);
+    }
 
 } // namespace v8pp

--- a/code/tests/modules/js_features_ut.h
+++ b/code/tests/modules/js_features_ut.h
@@ -12,6 +12,8 @@
 #include "scripting/builtins/builtins.h"
 #include "scripting/builtins/console.h"
 #include "scripting/builtins/events.h"
+#include "scripting/builtins/imports.h"
+#include "scripting/resource/resource.h"
 #include "scripting/resource/resource_manager.h"
 
 #include <cppfs/FileHandle.h>
@@ -670,6 +672,55 @@ MODULE(js_features, {
         EQUALS(RunJS(engine, "globalThis.__r"), 2);
 
         cleanupResource(engine, manager);
+        engine.Shutdown();
+        EventsTestHelper::Cleanup();
+    });
+
+    // ========================================
+    // IMPORTS (real cross-resource values)
+    // ========================================
+    // imports.get must return an object of *real* export values keyed by name — mirroring
+    // Exports.get — not a placeholder listing export names. Regression guard for the old
+    // `_availableExports` stub that returned names instead of values.
+    IT("imports.get builds an object of real export values keyed by name", {
+        EventsTestHelper::Setup();
+
+        // Provider resource declaring two exports in its manifest.
+        std::string providerPath = EventsTestHelper::GetTestPath() + "/provider";
+        {
+            cppfs::FileHandle dir = cppfs::fs::open(providerPath);
+            if (!dir.exists()) dir.createDirectory();
+            std::ofstream pkg(providerPath + "/package.json");
+            pkg << R"({"name":"provider","version":"1.0.0","mafiahub":{"exports":["alpha","beta"]}})";
+        }
+
+        NodeEngine engine({});
+        EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
+
+        v8::Isolate *isolate = engine.GetIsolate();
+        {
+            v8::Locker locker(isolate);
+            v8::Isolate::Scope isolateScope(isolate);
+            v8::HandleScope handleScope(isolate);
+            v8::Local<v8::Context> context = engine.GetContext();
+            v8::Context::Scope contextScope(context);
+
+            Resource provider(providerPath);
+            provider.SetIsolate(isolate);
+            EQUALS(provider.RegisterExport("alpha", v8::Integer::New(isolate, 42)), true);
+            EQUALS(provider.RegisterExport("beta", v8pp::to_v8(isolate, std::string("hello"))), true);
+
+            v8::Local<v8::Object> imported = Imports::BuildImportsObject(isolate, context, &provider);
+            context->Global()->Set(context, v8pp::to_v8(isolate, "__imp"), imported).Check();
+        }
+
+        // Real values, not a name list.
+        EQUALS(RunJS(engine, "__imp.alpha"), 42);
+        EQUALS(RunJSBool(engine, "__imp.beta === 'hello'"), true);
+        // The old placeholder key must be gone, and only the two exports present.
+        EQUALS(RunJSBool(engine, "__imp._availableExports === undefined"), true);
+        EQUALS(RunJSBool(engine, "Object.keys(__imp).length === 2"), true);
+
         engine.Shutdown();
         EventsTestHelper::Cleanup();
     });

--- a/code/tests/modules/js_features_ut.h
+++ b/code/tests/modules/js_features_ut.h
@@ -171,6 +171,7 @@ class EventsTestHelper {
 
 MODULE(js_features, {
     using namespace Framework::Scripting;
+    using namespace Framework::Scripting::Builtins;
 
     // ========================================
     // BUILTIN TYPES TESTS (single engine to avoid v8pp caching bug)

--- a/code/tests/modules/js_features_ut.h
+++ b/code/tests/modules/js_features_ut.h
@@ -272,6 +272,43 @@ MODULE(js_features, {
         engine.Shutdown();
     });
 
+    // Doc/impl reconciliation (now user-facing via @mafiahub/types): toHex is lowercase, fromHex
+    // 3/4-digit shorthands are unsupported (yield white), Quaternion.normalize maps zero to identity,
+    // and the ctor is scalar-first (w, x, y, z).
+    IT("Color hex and Quaternion normalize/ctor match their docs", {
+        NodeEngine engine({});
+        EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
+        {
+            v8::Isolate *isolate = engine.GetIsolate();
+            v8::Locker locker(isolate);
+            v8::Isolate::Scope isolateScope(isolate);
+            v8::HandleScope handleScope(isolate);
+            v8::Local<v8::Context> context = engine.GetContext();
+            v8::Context::Scope contextScope(context);
+            v8::Local<v8::Object> coreObj = v8::Object::New(isolate);
+            context->Global()->Set(context, v8::String::NewFromUtf8Literal(isolate, "Core"), coreObj).Check();
+            RegisterValueTypes(isolate, coreObj);
+        }
+
+        // toHex emits lowercase, as documented.
+        std::string hex = RunJSString(engine, "new Core.Color(1, 0.5, 0, 1).toHex()");
+        STREQUALS(hex.c_str(), "#ff8000");
+        std::string hexA = RunJSString(engine, "new Core.Color(1, 0.5, 0, 1).toHex(true)");
+        STREQUALS(hexA.c_str(), "#ff8000ff");
+
+        // Full-length hex parses; unsupported 3-digit shorthand falls back to opaque white.
+        EQUALS(RunJSBool(engine, "Math.abs(Core.Color.fromHex('#ff0000').r - 1) < 0.001"), true);
+        EQUALS(RunJSBool(engine, "(() => { const c = Core.Color.fromHex('#f00'); return c.r === 1 && c.g === 1 && c.b === 1; })()"), true);
+
+        // normalize maps a zero quaternion to identity rather than NaN.
+        EQUALS(RunJSBool(engine, "(() => { const q = new Core.Quaternion(0,0,0,0).normalize(); return q.w === 1 && q.x === 0 && q.y === 0 && q.z === 0; })()"), true);
+
+        // Constructor is scalar-first: w is the first argument.
+        EQUALS(RunJSBool(engine, "(() => { const p = new Core.Quaternion(1,2,3,4); return p.w === 1 && p.x === 2 && p.y === 3 && p.z === 4; })()"), true);
+
+        engine.Shutdown();
+    });
+
     // The two packed layouts Chat (RGBA) and TextLabel (ARGB) accept a Color through are computed by
     // Color::toRGBA/toARGB. Their end-to-end use needs networking/replication (integration-tested);
     // here we lock the byte ordering directly. Color(1, 0.5, 0, 1) -> R=255 G=128 B=0 A=255.

--- a/code/tests/modules/js_features_ut.h
+++ b/code/tests/modules/js_features_ut.h
@@ -13,6 +13,7 @@
 #include "scripting/builtins/console.h"
 #include "scripting/builtins/events.h"
 #include "scripting/builtins/imports.h"
+#include "scripting/builtins/messages.h"
 #include "scripting/resource/resource.h"
 #include "scripting/resource/resource_manager.h"
 
@@ -721,6 +722,89 @@ MODULE(js_features, {
         EQUALS(RunJSBool(engine, "__imp._availableExports === undefined"), true);
         EQUALS(RunJSBool(engine, "Object.keys(__imp).length === 2"), true);
 
+        engine.Shutdown();
+        EventsTestHelper::Cleanup();
+    });
+
+    // ========================================
+    // MESSAGES (handler lifecycle)
+    // ========================================
+    // messages.handle stores a Global<Function> per (resource, type). A stopped resource must not
+    // leave those handlers behind until full Shutdown — CleanupResource drops them eagerly, like
+    // Events. (The cross-isolate guard added alongside can only be exercised with two live isolates,
+    // which libnode cannot host in one process, so it is covered by integration testing.)
+    auto registerMessages = [](NodeEngine &engine, ResourceManager &manager) {
+        v8::Isolate *isolate = engine.GetIsolate();
+        v8::Locker locker(isolate);
+        v8::Isolate::Scope isolateScope(isolate);
+        v8::HandleScope handleScope(isolate);
+        v8::Local<v8::Context> context = engine.GetContext();
+        v8::Context::Scope contextScope(context);
+        v8::Local<v8::Object> frameworkObj = v8::Object::New(isolate);
+        context->Global()->Set(context, v8pp::to_v8(isolate, "Framework"), frameworkObj).Check();
+        Messages::Register(isolate, context, frameworkObj, &manager);
+    };
+
+    auto pumpMessages = [](NodeEngine &engine) {
+        for (int i = 0; i < 8; ++i) {
+            {
+                v8::Isolate *isolate = engine.GetIsolate();
+                v8::Locker locker(isolate);
+                v8::Isolate::Scope isolateScope(isolate);
+                v8::HandleScope handleScope(isolate);
+                v8::Local<v8::Context> context = engine.GetContext();
+                v8::Context::Scope contextScope(context);
+                Messages::ProcessPendingResponses(isolate, context);
+            }
+            engine.Tick();
+        }
+    };
+
+    // A registered handler answers a same-isolate request; after CleanupResource the same request
+    // is rejected because the handler is gone — proving the resource's handlers were released.
+    IT("messages.request round-trips, and CleanupResource drops the handler", {
+        EventsTestHelper::Setup();
+        NodeEngine engine({});
+        EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
+        ResourceManagerConfig config;
+        config.resourcesPath = EventsTestHelper::GetTestPath();
+        ResourceManager manager(&engine, config);
+        registerMessages(engine, manager);
+
+        // Register the handler as resource 'provider'.
+        manager.SetCurrentResourceContext("provider");
+        RunJS(engine, "Framework.messages.handle('ping', (payload, reply) => { reply(payload + 1); }); 0");
+
+        // Issue a request as resource 'consumer'.
+        manager.SetCurrentResourceContext("consumer");
+        RunJS(engine, R"(
+            globalThis.__reply = 0;
+            Framework.messages.request('provider', 'ping', 41).then(v => { globalThis.__reply = v; },
+                                                                    () => { globalThis.__reply = -1; });
+            0
+        )");
+        pumpMessages(engine);
+        EQUALS(RunJS(engine, "globalThis.__reply"), 42);
+
+        // Drop 'provider' handlers as its resource stops.
+        Messages::CleanupResource("provider");
+
+        // The same request now rejects: no handler remains for the target resource.
+        RunJS(engine, R"(
+            globalThis.__after = 0;
+            Framework.messages.request('provider', 'ping', 1).then(() => { globalThis.__after = 1; },
+                                                                   () => { globalThis.__after = 2; });
+            0
+        )");
+        pumpMessages(engine);
+        EQUALS(RunJS(engine, "globalThis.__after"), 2);
+
+        {
+            v8::Isolate *isolate = engine.GetIsolate();
+            v8::Locker locker(isolate);
+            v8::Isolate::Scope isolateScope(isolate);
+            Messages::Shutdown();
+        }
         engine.Shutdown();
         EventsTestHelper::Cleanup();
     });

--- a/code/tests/modules/js_features_ut.h
+++ b/code/tests/modules/js_features_ut.h
@@ -618,6 +618,35 @@ MODULE(js_features, {
         EventsTestHelper::Cleanup();
     });
 
+    // Non-Promise return: pre-fix, allSettledResult.ToLocalChecked().As<v8::Promise>()->Then()
+    // runs on a non-Promise handle and aborts. Post-fix the IsPromise() guard soft-resolves.
+    IT("emit survives a Promise.allSettled that returns a non-Promise", {
+        EventsTestHelper::Setup();
+        NodeEngine engine({});
+        EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
+        ResourceManagerConfig config;
+        config.resourcesPath = EventsTestHelper::GetTestPath();
+        ResourceManager manager(&engine, config);
+        registerEvents(engine, manager);
+
+        RunJS(engine, R"(
+            globalThis.__done3 = 0;
+            Promise.allSettled = function () { return 42; };
+            Core.Events.on('hostile3', () => 1);
+            Core.Events.emit('hostile3').then(() => { globalThis.__done3 = 1; },
+                                              () => { globalThis.__done3 = 2; });
+            0
+        )");
+
+        for (int i = 0; i < 8; ++i) engine.Tick();
+
+        EQUALS(RunJS(engine, "globalThis.__done3"), 1);
+
+        cleanupResource(engine, manager);
+        engine.Shutdown();
+        EventsTestHelper::Cleanup();
+    });
+
     // Sanity: the hardening must not swallow genuine, well-formed rejections.
     IT("emit still rejects when a handler rejects (real allSettled)", {
         EventsTestHelper::Setup();

--- a/code/tests/modules/js_features_ut.h
+++ b/code/tests/modules/js_features_ut.h
@@ -290,10 +290,13 @@ MODULE(js_features, {
             RegisterValueTypes(isolate, coreObj);
         }
 
-        // toHex emits lowercase, as documented.
-        std::string hex = RunJSString(engine, "new Core.Color(1, 0.5, 0, 1).toHex()");
+        // The 3-argument constructor works and alpha defaults to 1 (v8pp optional-ctor fix).
+        EQUALS(RunJSBool(engine, "new Core.Color(0.25, 0.5, 0.75).a === 1"), true);
+
+        // toHex emits lowercase, as documented (exercised through the 3-arg ctor).
+        std::string hex = RunJSString(engine, "new Core.Color(1, 0.5, 0).toHex()");
         STREQUALS(hex.c_str(), "#ff8000");
-        std::string hexA = RunJSString(engine, "new Core.Color(1, 0.5, 0, 1).toHex(true)");
+        std::string hexA = RunJSString(engine, "new Core.Color(1, 0.5, 0).toHex(true)");
         STREQUALS(hexA.c_str(), "#ff8000ff");
 
         // Full-length hex parses; unsupported 3-digit shorthand falls back to opaque white.

--- a/code/tests/modules/js_features_ut.h
+++ b/code/tests/modules/js_features_ut.h
@@ -132,6 +132,13 @@ static bool RunJSThrows(Framework::Scripting::NodeEngine &engine, const char *co
     return tryCatch.HasCaught();
 }
 
+// Run code and return the constructor name of whatever it throws ("TypeError", "Error", ...),
+// or "" when it does not throw. Used to assert the builtins' throw-idiom convention.
+static std::string RunJSErrorName(Framework::Scripting::NodeEngine &engine, const std::string &code) {
+    std::string wrapped = "(() => { try { " + code + "; return ''; } catch (e) { return (e && e.constructor && e.constructor.name) || 'Error'; } })()";
+    return RunJSString(engine, wrapped.c_str());
+}
+
 // Test helper for Events tests
 class EventsTestHelper {
   public:
@@ -419,6 +426,63 @@ MODULE(js_features, {
         EQUALS(RunJSThrows(engine, "Core.Events.on('test')"), true);
         EQUALS(RunJSThrows(engine, "Core.Events.on(123, () => {})"), true);
         EQUALS(RunJSThrows(engine, "Core.Events.on('test', 'notafunction')"), true);
+
+        {
+            v8::Isolate *isolate = engine.GetIsolate();
+            v8::Locker locker(isolate);
+            v8::Isolate::Scope isolateScope(isolate);
+            v8::HandleScope handleScope(isolate);
+            manager.GetEvents().CleanupResource("testResource");
+        }
+        engine.Shutdown();
+        EventsTestHelper::Cleanup();
+    });
+
+    // Throw-idiom convention: arg-shape errors are TypeError (not Error), and Events.off no longer
+    // swallows bad arguments — it throws like Events.on. Guards the builtins conventions sweep.
+    IT("Events arg-shape errors are TypeError and off is no longer silent", {
+        EventsTestHelper::Setup();
+
+        NodeEngine engine({});
+        EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
+
+        ResourceManagerConfig config;
+        config.resourcesPath = EventsTestHelper::GetTestPath();
+        ResourceManager manager(&engine, config);
+
+        {
+            v8::Isolate *isolate = engine.GetIsolate();
+            v8::Locker locker(isolate);
+            v8::Isolate::Scope isolateScope(isolate);
+            v8::HandleScope handleScope(isolate);
+            v8::Local<v8::Context> context = engine.GetContext();
+            v8::Context::Scope contextScope(context);
+
+            v8::Local<v8::Object> coreObj = v8::Object::New(isolate);
+            context->Global()->Set(context, v8::String::NewFromUtf8Literal(isolate, "Core"), coreObj).Check();
+            manager.GetEvents().Register(isolate, context, coreObj, &manager);
+            manager.SetCurrentResourceContext("testResource");
+        }
+
+        std::string err;
+        // Arg-shape failures throw TypeError.
+        err = RunJSErrorName(engine, "Core.Events.on()");
+        STREQUALS(err.c_str(), "TypeError");
+        err = RunJSErrorName(engine, "Core.Events.on(123, () => {})");
+        STREQUALS(err.c_str(), "TypeError");
+        err = RunJSErrorName(engine, "Core.Events.emit()");
+        STREQUALS(err.c_str(), "TypeError");
+        err = RunJSErrorName(engine, "Core.Events.emitTo('r')");
+        STREQUALS(err.c_str(), "TypeError");
+
+        // Events.off used to silently ignore bad arguments; it now throws TypeError like on().
+        err = RunJSErrorName(engine, "Core.Events.off('e', 'notafn')");
+        STREQUALS(err.c_str(), "TypeError");
+        err = RunJSErrorName(engine, "Core.Events.off('e')");
+        STREQUALS(err.c_str(), "TypeError");
+        // A well-formed off() with no matching handler stays a quiet no-op.
+        err = RunJSErrorName(engine, "Core.Events.off('e', () => {})");
+        STREQUALS(err.c_str(), "");
 
         {
             v8::Isolate *isolate = engine.GetIsolate();
@@ -770,6 +834,13 @@ MODULE(js_features, {
         config.resourcesPath = EventsTestHelper::GetTestPath();
         ResourceManager manager(&engine, config);
         registerMessages(engine, manager);
+
+        // Arg-shape failures throw TypeError (convention), before any state checks.
+        std::string margErr;
+        margErr = RunJSErrorName(engine, "Framework.messages.request(123)");
+        STREQUALS(margErr.c_str(), "TypeError");
+        margErr = RunJSErrorName(engine, "Framework.messages.send('r')");
+        STREQUALS(margErr.c_str(), "TypeError");
 
         // Register the handler as resource 'provider'.
         manager.SetCurrentResourceContext("provider");

--- a/code/tests/modules/js_features_ut.h
+++ b/code/tests/modules/js_features_ut.h
@@ -272,6 +272,22 @@ MODULE(js_features, {
         engine.Shutdown();
     });
 
+    // The two packed layouts Chat (RGBA) and TextLabel (ARGB) accept a Color through are computed by
+    // Color::toRGBA/toARGB. Their end-to-end use needs networking/replication (integration-tested);
+    // here we lock the byte ordering directly. Color(1, 0.5, 0, 1) -> R=255 G=128 B=0 A=255.
+    IT("Color packs to RGBA and ARGB with the documented byte order", {
+        Color c(1.0f, 0.5f, 0.0f, 1.0f);
+        // 0xRRGGBBAA
+        UEQUALS(c.toRGBA(), (uint32_t)0xFF80'00FFu);
+        // 0xAARRGGBB
+        UEQUALS(c.toARGB(), (uint32_t)0xFFFF'8000u);
+
+        // Fully opaque red, distinct in the two layouts.
+        Color red(1.0f, 0.0f, 0.0f, 1.0f);
+        UEQUALS(red.toRGBA(), (uint32_t)0xFF00'00FFu);
+        UEQUALS(red.toARGB(), (uint32_t)0xFFFF'0000u);
+    });
+
     // ========================================
     // EVENTS SYSTEM TESTS
     // ========================================

--- a/code/tests/modules/js_features_ut.h
+++ b/code/tests/modules/js_features_ut.h
@@ -14,6 +14,7 @@
 #include "scripting/builtins/events.h"
 #include "scripting/builtins/imports.h"
 #include "scripting/builtins/messages.h"
+#include "scripting/builtins/player.h"
 #include "scripting/resource/resource.h"
 #include "scripting/resource/resource_manager.h"
 
@@ -192,7 +193,7 @@ MODULE(js_features, {
             context->Global()->Set(context,
                 v8::String::NewFromUtf8Literal(isolate, "Core"),
                 coreObj).Check();
-            Builtins::RegisterAll(isolate, coreObj);
+            Builtins::RegisterValueTypes(isolate, coreObj);
         }
 
         // Vector3 tests
@@ -876,6 +877,38 @@ MODULE(js_features, {
             v8::Isolate::Scope isolateScope(isolate);
             Messages::Shutdown();
         }
+        engine.Shutdown();
+        EventsTestHelper::Cleanup();
+    });
+
+    // ========================================
+    // REGISTRATION SHAPE
+    // ========================================
+    // RegisterValueTypes publishes only the value types; Player gained a Register that publishes its
+    // constructor like its handle-type siblings (Entity, TextLabel). Guards the registration sweep.
+    IT("RegisterValueTypes and Player::Register publish their constructors", {
+        EventsTestHelper::Setup();
+        NodeEngine engine({});
+        EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
+
+        v8::Isolate *isolate = engine.GetIsolate();
+        {
+            v8::Locker locker(isolate);
+            v8::Isolate::Scope isolateScope(isolate);
+            v8::HandleScope handleScope(isolate);
+            v8::Local<v8::Context> context = engine.GetContext();
+            v8::Context::Scope contextScope(context);
+            v8::Local<v8::Object> target = context->Global();
+            Builtins::RegisterValueTypes(isolate, target);
+            Builtins::Player::Register(isolate, target);
+        }
+
+        // Value types published by RegisterValueTypes.
+        EQUALS(RunJSBool(engine, "typeof Vector3 === 'function'"), true);
+        EQUALS(RunJSBool(engine, "typeof Color === 'function'"), true);
+        // Player constructor published by the new Player::Register.
+        EQUALS(RunJSBool(engine, "typeof Player === 'function'"), true);
+
         engine.Shutdown();
         EventsTestHelper::Cleanup();
     });

--- a/code/tests/modules/js_features_ut.h
+++ b/code/tests/modules/js_features_ut.h
@@ -12,6 +12,8 @@
 #include "scripting/builtins/builtins.h"
 #include "scripting/builtins/console.h"
 #include "scripting/builtins/events.h"
+#include "scripting/builtins/environment.h"
+#include "scripting/builtins/exports.h"
 #include "scripting/builtins/imports.h"
 #include "scripting/builtins/messages.h"
 #include "scripting/builtins/player.h"
@@ -909,6 +911,51 @@ MODULE(js_features, {
         EQUALS(RunJSBool(engine, "typeof Color === 'function'"), true);
         // Player constructor published by the new Player::Register.
         EQUALS(RunJSBool(engine, "typeof Player === 'function'"), true);
+
+        engine.Shutdown();
+        EventsTestHelper::Cleanup();
+    });
+
+    // ========================================
+    // JS-FACING NAMING
+    // ========================================
+    // The Framework.* namespace group uses one casing: exports joins the lowercase imports/messages
+    // (was Framework.Exports). Environment flags are camelCase isClient/isServer (were IsClient/
+    // IsServer). Guards the breaking rename; the old names must be gone.
+    IT("Framework.exports is lowercase and Environment flags are camelCase", {
+        EventsTestHelper::Setup();
+        NodeEngine engine({});
+        EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
+        ResourceManagerConfig config;
+        config.resourcesPath = EventsTestHelper::GetTestPath();
+        ResourceManager manager(&engine, config);
+
+        {
+            v8::Isolate *isolate = engine.GetIsolate();
+            v8::Locker locker(isolate);
+            v8::Isolate::Scope isolateScope(isolate);
+            v8::HandleScope handleScope(isolate);
+            v8::Local<v8::Context> context = engine.GetContext();
+            v8::Context::Scope contextScope(context);
+            v8::Local<v8::Object> frameworkObj = v8::Object::New(isolate);
+            context->Global()->Set(context, v8pp::to_v8(isolate, "Framework"), frameworkObj).Check();
+            v8::Local<v8::Object> coreObj = v8::Object::New(isolate);
+            context->Global()->Set(context, v8pp::to_v8(isolate, "Core"), coreObj).Check();
+            Exports::Register(isolate, context, frameworkObj, &manager);
+            Environment::Register(isolate, context, coreObj, /*isClient*/ true);
+        }
+
+        // exports: lowercase, matching imports/messages; the capitalized name is gone.
+        EQUALS(RunJSBool(engine, "typeof Framework.exports === 'object' && Framework.exports !== null"), true);
+        EQUALS(RunJSBool(engine, "typeof Framework.exports.register === 'function'"), true);
+        EQUALS(RunJSBool(engine, "typeof Framework.exports.get === 'function'"), true);
+        EQUALS(RunJSBool(engine, "Framework.Exports === undefined"), true);
+
+        // Environment flags: camelCase; the PascalCase names are gone.
+        EQUALS(RunJSBool(engine, "Core.Environment.isClient === true"), true);
+        EQUALS(RunJSBool(engine, "Core.Environment.isServer === false"), true);
+        EQUALS(RunJSBool(engine, "Core.Environment.IsClient === undefined"), true);
+        EQUALS(RunJSBool(engine, "Core.Environment.IsServer === undefined"), true);
 
         engine.Shutdown();
         EventsTestHelper::Cleanup();

--- a/code/tests/modules/js_features_ut.h
+++ b/code/tests/modules/js_features_ut.h
@@ -584,6 +584,12 @@ MODULE(js_features, {
         err = RunJSErrorName(engine, "Core.Events.off('e', () => {})");
         STREQUALS(err.c_str(), "");
 
+        // State error: with no resource context, off() can't tell which resource's handler to drop,
+        // so it throws Exception::Error like Events.on — not a silent return (README idiom).
+        manager.SetCurrentResourceContext("");
+        err = RunJSErrorName(engine, "Core.Events.off('e', () => {})");
+        STREQUALS(err.c_str(), "Error");
+
         {
             v8::Isolate *isolate = engine.GetIsolate();
             v8::Locker locker(isolate);

--- a/code/tests/modules/js_features_ut.h
+++ b/code/tests/modules/js_features_ut.h
@@ -12,7 +12,7 @@
 #include "scripting/builtins/builtins.h"
 #include "scripting/builtins/console.h"
 #include "scripting/builtins/events.h"
-#include "scripting/builtins/environment.h"
+#include "scripting/builtins/execution_environment.h"
 #include "scripting/builtins/exports.h"
 #include "scripting/builtins/imports.h"
 #include "scripting/builtins/messages.h"
@@ -1046,9 +1046,10 @@ MODULE(js_features, {
     // JS-FACING NAMING
     // ========================================
     // The Framework.* namespace group uses one casing: exports joins the lowercase imports/messages
-    // (was Framework.Exports). Environment flags are camelCase isClient/isServer (were IsClient/
-    // IsServer). Guards the breaking rename; the old names must be gone.
-    IT("Framework.exports is lowercase and Environment flags are camelCase", {
+    // (was Framework.Exports). The runtime-flags global is ExecutionEnvironment (was Environment) at
+    // the root, with camelCase isClient/isServer (were IsClient/IsServer). Guards the breaking
+    // renames; the old names must be gone.
+    IT("Framework.exports is lowercase and ExecutionEnvironment flags are camelCase", {
         EventsTestHelper::Setup();
         NodeEngine engine({});
         EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
@@ -1065,10 +1066,9 @@ MODULE(js_features, {
             v8::Context::Scope contextScope(context);
             v8::Local<v8::Object> frameworkObj = v8::Object::New(isolate);
             context->Global()->Set(context, v8pp::to_v8(isolate, "Framework"), frameworkObj).Check();
-            v8::Local<v8::Object> coreObj = v8::Object::New(isolate);
-            context->Global()->Set(context, v8pp::to_v8(isolate, "Core"), coreObj).Check();
             Exports::Register(isolate, context, frameworkObj, &manager);
-            Environment::Register(isolate, context, coreObj, /*isClient*/ true);
+            // Registered at the global root, as production does.
+            ExecutionEnvironment::Register(isolate, context, context->Global(), /*isClient*/ true);
         }
 
         // exports: lowercase, matching imports/messages; the capitalized name is gone.
@@ -1077,11 +1077,12 @@ MODULE(js_features, {
         EQUALS(RunJSBool(engine, "typeof Framework.exports.get === 'function'"), true);
         EQUALS(RunJSBool(engine, "Framework.Exports === undefined"), true);
 
-        // Environment flags: camelCase; the PascalCase names are gone.
-        EQUALS(RunJSBool(engine, "Core.Environment.isClient === true"), true);
-        EQUALS(RunJSBool(engine, "Core.Environment.isServer === false"), true);
-        EQUALS(RunJSBool(engine, "Core.Environment.IsClient === undefined"), true);
-        EQUALS(RunJSBool(engine, "Core.Environment.IsServer === undefined"), true);
+        // ExecutionEnvironment at root, camelCase flags; old Environment name and PascalCase are gone.
+        EQUALS(RunJSBool(engine, "ExecutionEnvironment.isClient === true"), true);
+        EQUALS(RunJSBool(engine, "ExecutionEnvironment.isServer === false"), true);
+        EQUALS(RunJSBool(engine, "typeof Environment === 'undefined'"), true);
+        EQUALS(RunJSBool(engine, "ExecutionEnvironment.IsClient === undefined"), true);
+        EQUALS(RunJSBool(engine, "ExecutionEnvironment.IsServer === undefined"), true);
 
         engine.Shutdown();
         EventsTestHelper::Cleanup();

--- a/code/tests/modules/js_features_ut.h
+++ b/code/tests/modules/js_features_ut.h
@@ -232,6 +232,46 @@ MODULE(js_features, {
         engine.Shutdown();
     });
 
+    // Value-type parity: Quaternion gained length/lengthSquared (like Vector) and mul (renamed from
+    // multiply — the old name is gone); Color gained NewInstance so native C++ can return a Color.
+    IT("Quaternion length/mul parity and Color::NewInstance", {
+        NodeEngine engine({});
+        EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
+
+        v8::Isolate *isolate = engine.GetIsolate();
+        {
+            v8::Locker locker(isolate);
+            v8::Isolate::Scope isolateScope(isolate);
+            v8::HandleScope handleScope(isolate);
+            v8::Local<v8::Context> context = engine.GetContext();
+            v8::Context::Scope contextScope(context);
+            v8::Local<v8::Object> coreObj = v8::Object::New(isolate);
+            context->Global()->Set(context, v8::String::NewFromUtf8Literal(isolate, "Core"), coreObj).Check();
+            RegisterValueTypes(isolate, coreObj);
+
+            // Native C++ hands a Color to JS via NewInstance (the native-SDK direction).
+            v8::Local<v8::Object> col = Color::NewInstance(isolate, glm::vec4(0.25f, 0.5f, 0.75f, 1.0f));
+            context->Global()->Set(context, v8pp::to_v8(isolate, "__col"), col).Check();
+        }
+
+        // length / lengthSquared, mirroring Vector.
+        EQUALS(RunJSBool(engine, "Math.abs(new Core.Quaternion(0,3,4,0).length - 5) < 0.001"), true);
+        EQUALS(RunJSBool(engine, "Math.abs(new Core.Quaternion(0,3,4,0).lengthSquared - 25) < 0.001"), true);
+        EQUALS(RunJSBool(engine, "Math.abs(Core.Quaternion.identity().length - 1) < 0.001"), true);
+
+        // mul is the (renamed) composition; multiply is gone.
+        EQUALS(RunJSBool(engine, "typeof new Core.Quaternion(1,0,0,0).mul === 'function'"), true);
+        EQUALS(RunJSBool(engine, "new Core.Quaternion(1,0,0,0).multiply === undefined"), true);
+        EQUALS(RunJSBool(engine, "Core.Quaternion.identity().mul(Core.Quaternion.identity()).w === 1"), true);
+
+        // Color::NewInstance produced a real, live Core.Color.
+        EQUALS(RunJSBool(engine, "__col instanceof Core.Color"), true);
+        EQUALS(RunJSBool(engine, "Math.abs(__col.r - 0.25) < 0.001 && Math.abs(__col.g - 0.5) < 0.001 && Math.abs(__col.b - 0.75) < 0.001"), true);
+        EQUALS(RunJSBool(engine, "typeof __col.toHex === 'function'"), true);
+
+        engine.Shutdown();
+    });
+
     // ========================================
     // EVENTS SYSTEM TESTS
     // ========================================

--- a/code/tests/modules/js_features_ut.h
+++ b/code/tests/modules/js_features_ut.h
@@ -963,10 +963,34 @@ MODULE(js_features, {
         pumpMessages(engine);
         EQUALS(RunJS(engine, "globalThis.__reply"), 42);
 
-        // Drop 'provider' handlers as its resource stops.
-        Messages::CleanupResource("provider");
+        // A request whose target hasn't replied yet stays pending...
+        manager.SetCurrentResourceContext("provider");
+        RunJS(engine, "Framework.messages.handle('slow', (payload, reply) => { globalThis.__saved = reply; }); 0");
+        manager.SetCurrentResourceContext("consumer");
+        RunJS(engine, R"(
+            globalThis.__inflight = 0;
+            Framework.messages.request('provider', 'slow', 1).then(() => { globalThis.__inflight = 1; },
+                                                                   () => { globalThis.__inflight = 2; });
+            0
+        )");
+        pumpMessages(engine);
+        EQUALS(RunJS(engine, "globalThis.__inflight"), 0);
 
-        // The same request now rejects: no handler remains for the target resource.
+        // Drop 'provider' handlers and reject requests tied to it as its resource stops.
+        {
+            v8::Isolate *isolate = engine.GetIsolate();
+            v8::Locker locker(isolate);
+            v8::Isolate::Scope isolateScope(isolate);
+            v8::HandleScope handleScope(isolate);
+            v8::Local<v8::Context> context = engine.GetContext();
+            v8::Context::Scope contextScope(context);
+            Messages::CleanupResource(isolate, context, "provider");
+        }
+        pumpMessages(engine);
+        // ...and the in-flight Promise now rejects instead of hanging forever.
+        EQUALS(RunJS(engine, "globalThis.__inflight"), 2);
+
+        // A new request after cleanup also rejects: no handler remains for the target resource.
         RunJS(engine, R"(
             globalThis.__after = 0;
             Framework.messages.request('provider', 'ping', 1).then(() => { globalThis.__after = 1; },


### PR DESCRIPTION
## Summary

A batch of scripting-layer fixes and cleanups across the V8 builtins: correctness guards, a documented set of conventions with the code swept to match, value-type parity, and dead-code removal. Every functional fix ships with a regression test; the suite is green (156/156).

**Version: MINOR.** Several changes rename JS-facing identifiers or change observable error types, so scripts must migrate (details below). No netcode/sync-flow changes.

## Correctness

- **allSettled aggregation**: guard `emit()`'s aggregation against a script-replaced `Promise.allSettled` returning a non-Promise (previously reached `.As<v8::Promise>()->Then()` and aborted).
- **`imports.get`**: return the *real* export values keyed by name instead of a placeholder `_availableExports` name-list; adopt the same-isolate ownership guard `Exports.get` uses.
- **Messages cross-isolate**: `messages.request`/`send` recorded each handler's owning isolate and reject/skip cross-isolate delivery instead of crashing; added `Messages::CleanupResource` (wired into resource stop) so stopped resources don't leak `Global<Function>` handlers until shutdown.
- **Color ctor**: `new Core.Color(r, g, b)` threw despite alpha being documented optional (a v8pp factory perfect-forwarding quirk) — fixed with a custom constructor callback.
- **Quaternion.normalize**: a zero quaternion now collapses to identity instead of producing NaN.

## Conventions (documented, then swept)

New `code/framework/src/scripting/builtins/README.md` captures namespace, throw-idiom, registration, and color conventions. The code was swept to match:

- **Throw idiom**: arg-shape errors throw `TypeError`, state errors `Error`, silent no-op only for a stale receiver. Replaced non-idiomatic `isolate->ThrowError`; fixed silent outliers (`Chat.sendToPlayer`, `Chat.send` missing-peer, `Events.off`).
- **Registration**: `RegisterAll` → `RegisterValueTypes` (it only registered the 5 value types); gave `Player` a `Register` like its handle-type siblings.
- **Namespace**: moved the 6 service builtins (`Console`, `Environment`, `Events`, `Exports`, `Imports`, `Messages`) into `Framework::Scripting::Builtins`, matching every other builtin.

## Value-type parity

- `Color::NewInstance(isolate, const glm::vec4&)` so native C++ can return a Color to JS.
- `length`/`lengthSquared` on Quaternion, mirroring Vector.
- Documented the four color representations; `Chat` and `TextLabel.setColor` now also accept a `Core.Color` (converted to each API's packed layout via `Color::toRGBA`/`toARGB`).

## Docs, cleanup, formatting

- Fixed doc/impl mismatches now user-facing via `@mafiahub/types` (`Color.toHex` lowercase, `Color.fromHex` shorthand claim, Quaternion normalize + scalar-first ctor-order trap).
- Removed dead code (write-only `_resourceManager` statics, unused `context` locals) and renamed `BroadcastLuaEvent` → `BroadcastScriptEvent` (it's the V8/JS runtime, not Lua).
- clang-format on the value-type headers + `v8pp_types.h`.

## Breaking (script migration required)

- `Framework.Exports` → `Framework.exports`
- `Core.Environment.IsClient`/`IsServer` → `isClient`/`isServer`
- `Quaternion.multiply` → `mul` (no alias)
- Argument-shape failures now throw `TypeError` instead of `Error`; `Events.off` throws on bad args instead of silently ignoring.

## Testing

`cmake --build build --target RunFrameworkTests` — **156/156 pass**. New regression tests cover every functional fix.

## Verification note

The test target links `Framework` + `FrameworkServer`, so the server half and all tests are verified locally. The client integration half (`FrameworkClient`) isn't buildable in this environment; the namespace move and registration rename touch client code that **relies on CI** to verify. The whole tree (incl. `code/projects/*`) was swept for stale references (clean).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added color conversion to packed RGBA/ARGB values and support for Color objects in chat and text labels.
  * Imports now provide actual exported values between resources.
  * Added Quaternion length properties and the `mul` method.
* **Bug Fixes**
  * Improved scripting validation and error reporting for chat, events, messaging, and resource access.
  * Prevented cross-isolate message issues and cleaned up handlers when resources stop.
  * Zero-length quaternion normalization now returns an identity rotation.
* **Documentation**
  * Clarified scripting builtin behavior, color formats, and error conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->