### PR TITLE
scripting: expose builtins at the global root

### DIFF
--- a/code/framework/src/integrations/client/scripting/builtins/chat.cpp
+++ b/code/framework/src/integrations/client/scripting/builtins/chat.cpp
@@ -73,10 +73,9 @@ namespace Framework::Integrations::Client::Scripting::Builtins {
         args.GetReturnValue().Set(box && box->IsInputActive());
     }
 
-    void Chat::Register(v8::Isolate *isolate, v8::Local<v8::Context> context, v8::Local<v8::Object> frameworkObj, Framework::Scripting::ResourceManager *resourceManager) {
-        (void)frameworkObj;
+    void Chat::Register(v8::Isolate *isolate, v8::Local<v8::Context> context, v8::Local<v8::Object> target, Framework::Scripting::ResourceManager *resourceManager) {
         (void)resourceManager;
-        if (!isolate || context.IsEmpty()) {
+        if (!isolate || context.IsEmpty() || target.IsEmpty()) {
             return;
         }
 
@@ -92,7 +91,7 @@ namespace Framework::Integrations::Client::Scripting::Builtins {
         attach(chatObj, "open", &Chat::OpenCallback);
         attach(chatObj, "close", &Chat::CloseCallback);
         attach(chatObj, "isOpen", &Chat::IsOpenCallback);
-        context->Global()->Set(context, v8pp::to_v8(isolate, "Chat"), chatObj).Check();
+        target->Set(context, v8pp::to_v8(isolate, "Chat"), chatObj).Check();
 
         auto &metadata = Framework::Scripting::GetScriptingCatalog(isolate).global_object("Chat", "Client chat transport and native chat-box controls.");
         metadata.record(v8pp::metadata::function_of<v8::FunctionCallback>("send",

--- a/code/framework/src/integrations/client/scripting/builtins/chat.h
+++ b/code/framework/src/integrations/client/scripting/builtins/chat.h
@@ -22,7 +22,7 @@ namespace Framework::Integrations::Client::Scripting::Builtins {
       public:
         static void Register(v8::Isolate *isolate,
                              v8::Local<v8::Context> context,
-                             v8::Local<v8::Object> frameworkObj,
+                             v8::Local<v8::Object> target,
                              Framework::Scripting::ResourceManager *resourceManager);
 
       private:

--- a/code/framework/src/integrations/client/scripting/builtins/discord.cpp
+++ b/code/framework/src/integrations/client/scripting/builtins/discord.cpp
@@ -396,9 +396,9 @@ namespace Framework::Integrations::Client::Scripting::Builtins {
         args.GetReturnValue().Set(presence && presence->IsInitialized());
     }
 
-    void Discord::Register(v8::Isolate *isolate, v8::Local<v8::Context> context, v8::Local<v8::Object> frameworkObj, Framework::Scripting::ResourceManager *resourceManager) {
+    void Discord::Register(v8::Isolate *isolate, v8::Local<v8::Context> context, v8::Local<v8::Object> target, Framework::Scripting::ResourceManager *resourceManager) {
         (void)resourceManager;
-        if (!isolate || context.IsEmpty() || frameworkObj.IsEmpty()) {
+        if (!isolate || context.IsEmpty() || target.IsEmpty()) {
             return;
         }
 
@@ -448,9 +448,9 @@ namespace Framework::Integrations::Client::Scripting::Builtins {
         attach("getUserId", &Discord::GetUserIdCallback);
         attach("isAvailable", &Discord::IsAvailableCallback);
 
-        frameworkObj->Set(context, v8pp::to_v8(isolate, "Discord"), discordObj).Check();
+        target->Set(context, v8pp::to_v8(isolate, "Discord"), discordObj).Check();
 
-        auto &metadata   = Framework::Scripting::GetScriptingCatalog(isolate).global_object("Discord", "Client-only Discord rich-presence composer exposed as Framework.Discord; setters stage values until update or setPresence publishes them.");
+        auto &metadata   = Framework::Scripting::GetScriptingCatalog(isolate).global_object("Discord", "Client-only Discord rich-presence composer exposed as the global Discord; setters stage values until update or setPresence publishes them.");
         const auto field = [&](const char *name, const char *type, const char *parameter, const char *description) {
             metadata.record(v8pp::metadata::function_of<v8::FunctionCallback>(name, v8pp::metadata::docs("void", {v8pp::metadata::param(parameter, type, false, description)}, std::string("Stages ") + description)));
         };

--- a/code/framework/src/integrations/client/scripting/builtins/discord.h
+++ b/code/framework/src/integrations/client/scripting/builtins/discord.h
@@ -16,14 +16,14 @@ namespace Framework::Scripting {
 
 namespace Framework::Integrations::Client::Scripting::Builtins {
 
-    // Client-side Discord rich presence API (Framework.Discord); see types/framework/discord.d.ts.
+    // Client-side Discord rich presence API (global Discord); see types/framework/discord.d.ts.
     // Setters stage onto a pending activity; update()/setPresence() publish it (full-object replace,
     // rate-limited, so callers batch then commit once).
     class Discord final {
       public:
         static void Register(v8::Isolate *isolate,
                              v8::Local<v8::Context> context,
-                             v8::Local<v8::Object> frameworkObj,
+                             v8::Local<v8::Object> target,
                              Framework::Scripting::ResourceManager *resourceManager);
 
       private:

--- a/code/framework/src/integrations/client/scripting/builtins/keybinds.cpp
+++ b/code/framework/src/integrations/client/scripting/builtins/keybinds.cpp
@@ -133,7 +133,7 @@ namespace Framework::Integrations::Client::Scripting::Builtins {
     std::function<bool()> Keybinds::_activeCallback;
     Framework::Scripting::ResourceManager *Keybinds::_resourceManager = nullptr;
 
-    void Keybinds::Register(v8::Isolate *isolate, v8::Local<v8::Context> context, v8::Local<v8::Object> frameworkObj, Framework::Scripting::ResourceManager *resourceManager) {
+    void Keybinds::Register(v8::Isolate *isolate, v8::Local<v8::Context> context, v8::Local<v8::Object> target, Framework::Scripting::ResourceManager *resourceManager) {
         {
             std::scoped_lock lock(_mutex);
             _buckets.clear();
@@ -151,9 +151,9 @@ namespace Framework::Integrations::Client::Scripting::Builtins {
         bind("unbind", UnbindCallback);
         bind("isDown", IsDownCallback);
 
-        frameworkObj->Set(context, v8pp::to_v8(isolate, "Key"), keyObj).Check();
+        target->Set(context, v8pp::to_v8(isolate, "Key"), keyObj).Check();
 
-        auto &metadata = Framework::Scripting::GetScriptingCatalog(isolate).global_object("Key", "Client-only, resource-owned physical key bindings exposed as Framework.Key.");
+        auto &metadata = Framework::Scripting::GetScriptingCatalog(isolate).global_object("Key", "Client-only, resource-owned physical key bindings exposed as the global Key.");
         metadata.record(
             v8pp::metadata::function_of<v8::FunctionCallback>("bind", v8pp::metadata::docs("boolean",
                                                                           {

--- a/code/framework/src/integrations/client/scripting/builtins/keybinds.h
+++ b/code/framework/src/integrations/client/scripting/builtins/keybinds.h
@@ -23,14 +23,14 @@ namespace Framework::Scripting {
 
 namespace Framework::Integrations::Client::Scripting::Builtins {
 
-    // Client-side keybinding API, exposed as Framework.Key. See docs/scripting_keybindings.md.
+    // Client-side keybinding API, exposed as the global Key. See docs/scripting_keybindings.md.
     // Polled once per frame via Update(); the host mod supplies the input gate through
     // SetActiveCallback so binds stay quiet while UI owns input.
     class Keybinds final {
       public:
         static void Register(v8::Isolate *isolate,
                              v8::Local<v8::Context> context,
-                             v8::Local<v8::Object> frameworkObj,
+                             v8::Local<v8::Object> target,
                              Framework::Scripting::ResourceManager *resourceManager);
 
         // Poll physical keys, detect edges, dispatch matching handlers into JS.

--- a/code/framework/src/integrations/client/scripting/builtins/web.cpp
+++ b/code/framework/src/integrations/client/scripting/builtins/web.cpp
@@ -105,7 +105,7 @@ namespace Framework::Integrations::Client::Scripting::Builtins {
     std::mutex Web::_mutex;
     Framework::Scripting::ResourceManager *Web::_resourceManager = nullptr;
 
-    void Web::Register(v8::Isolate *isolate, v8::Local<v8::Context> context, v8::Local<v8::Object> frameworkObj, Framework::Scripting::ResourceManager *resourceManager) {
+    void Web::Register(v8::Isolate *isolate, v8::Local<v8::Context> context, v8::Local<v8::Object> target, Framework::Scripting::ResourceManager *resourceManager) {
         {
             std::scoped_lock lock(_mutex);
             _handlers.clear();
@@ -134,9 +134,9 @@ namespace Framework::Integrations::Client::Scripting::Builtins {
         bind("emit", EmitCallback);
         bind("getScreenSize", GetScreenSizeCallback);
 
-        frameworkObj->Set(context, v8pp::to_v8(isolate, "Web"), webObj).Check();
+        target->Set(context, v8pp::to_v8(isolate, "Web"), webObj).Check();
 
-        auto &metadata = Framework::Scripting::GetScriptingCatalog(isolate).global_object("Web", "Client-only, resource-owned CEF web-view API exposed as Framework.Web.");
+        auto &metadata = Framework::Scripting::GetScriptingCatalog(isolate).global_object("Web", "Client-only, resource-owned CEF web-view API exposed as the global Web.");
         metadata.record(v8pp::metadata::function_of<v8::FunctionCallback>("createView",
             v8pp::metadata::docs("number",
                 {v8pp::metadata::param("url", "string", false, "Resource-relative URL or allowed absolute URL loaded into the view."),

--- a/code/framework/src/integrations/client/scripting/builtins/web.h
+++ b/code/framework/src/integrations/client/scripting/builtins/web.h
@@ -25,7 +25,7 @@ namespace Framework::GUI {
 
 namespace Framework::Integrations::Client::Scripting::Builtins {
 
-    // Client-side web view API, exposed as Framework.Web:
+    // Client-side web view API, exposed as the global Web:
     //   createView(url, {width, height, x, y, zIndex, visible, focus}?) -> id
     //   destroyView / showView / hideView / focusView / isViewVisible
     //   loadURL(id, url) / resizeView(id, w, h) / setViewPosition(id, x, y)
@@ -40,7 +40,7 @@ namespace Framework::Integrations::Client::Scripting::Builtins {
       public:
         static void Register(v8::Isolate *isolate,
                              v8::Local<v8::Context> context,
-                             v8::Local<v8::Object> frameworkObj,
+                             v8::Local<v8::Object> target,
                              Framework::Scripting::ResourceManager *resourceManager);
 
         static void CleanupResource(const std::string &resourceName);

--- a/code/framework/src/integrations/client/scripting/module.cpp
+++ b/code/framework/src/integrations/client/scripting/module.cpp
@@ -130,38 +130,25 @@ namespace Framework::Integrations::Client::Scripting {
         v8::Local<v8::Context> context = _engine->GetContext();
         v8::Context::Scope contextScope(context);
 
-        // Framework global object (created by V8Engine); builtins register at the global root.
-        v8::Local<v8::Object> frameworkObj = _engine->GetFrameworkObject();
-        v8::Local<v8::Object> global       = context->Global();
+        v8::Local<v8::Object> global = context->Global();
 
         Framework::Scripting::SetScriptingCatalog(isolate, "framework-client");
 
-        // Register value-type builtins at the global root (new Vector3, not new Core.Vector3)
+        // Every builtin registers at the global root (new Vector3, not new Core.Vector3).
         Framework::Scripting::Builtins::RegisterValueTypes(isolate, global);
 
-        // Register communication APIs
         _resourceManager->GetEvents().Register(isolate, context, global, _resourceManager.get(), /*isClient*/ true);
-        Framework::Scripting::Builtins::Messages::Register(isolate, context, frameworkObj, _resourceManager.get());
-        Framework::Scripting::Builtins::Exports::Register(isolate, context, frameworkObj, _resourceManager.get());
-        Framework::Scripting::Builtins::Imports::Register(isolate, context, frameworkObj, _resourceManager.get());
-
-        // Register console override
+        Framework::Scripting::Builtins::Messages::Register(isolate, context, global, _resourceManager.get());
+        Framework::Scripting::Builtins::Exports::Register(isolate, context, global, _resourceManager.get());
+        Framework::Scripting::Builtins::Imports::Register(isolate, context, global, _resourceManager.get());
         Framework::Scripting::Builtins::Console::Register(isolate, context, _resourceManager.get());
-
-        // Register environment info at the global root
         Framework::Scripting::Builtins::ExecutionEnvironment::Register(isolate, context, global, true);
 
-        // Register web views API (client only)
-        Builtins::Web::Register(isolate, context, frameworkObj, _resourceManager.get());
-
-        // Register keybinding API (client only)
-        Builtins::Keybinds::Register(isolate, context, frameworkObj, _resourceManager.get());
-
-        // Register chat networking API (client only): global Chat.send + overlay visibility
-        Builtins::Chat::Register(isolate, context, frameworkObj, _resourceManager.get());
-
-        // Register Discord rich presence API (client only)
-        Builtins::Discord::Register(isolate, context, frameworkObj, _resourceManager.get());
+        // Client-only surface.
+        Builtins::Web::Register(isolate, context, global, _resourceManager.get());
+        Builtins::Keybinds::Register(isolate, context, global, _resourceManager.get());
+        Builtins::Chat::Register(isolate, context, global, _resourceManager.get());
+        Builtins::Discord::Register(isolate, context, global, _resourceManager.get());
 
         Logging::GetLogger(FRAMEWORK_INNER_SCRIPTING)->debug("Registered Framework bindings (client, V8 engine)");
     }

--- a/code/framework/src/integrations/server/scripting/module.cpp
+++ b/code/framework/src/integrations/server/scripting/module.cpp
@@ -102,49 +102,18 @@ namespace Framework::Integrations::Server::Scripting {
         v8::Local<v8::Context> context = _nodeEngine->GetContext();
         v8::Context::Scope contextScope(context);
 
-        // Get or create Framework global object
         v8::Local<v8::Object> global = context->Global();
         Framework::Scripting::SetScriptingCatalog(isolate, "framework-server");
-        v8::Local<v8::String> frameworkKey = v8::String::NewFromUtf8(isolate, "Framework").ToLocalChecked();
 
-        v8::Local<v8::Object> frameworkObj;
-        v8::Local<v8::Value> existingFramework;
-        if (global->Get(context, frameworkKey).ToLocal(&existingFramework) && existingFramework->IsObject()) {
-            frameworkObj = existingFramework.As<v8::Object>();
-        }
-        else {
-            frameworkObj = v8::Object::New(isolate);
-            global->Set(context, frameworkKey, frameworkObj).Check();
-        }
-
-        // Get or create Core global object
-        v8::Local<v8::String> coreKey = v8::String::NewFromUtf8(isolate, "Core").ToLocalChecked();
-        v8::Local<v8::Object> coreObj;
-        v8::Local<v8::Value> existingCore;
-        if (global->Get(context, coreKey).ToLocal(&existingCore) && existingCore->IsObject()) {
-            coreObj = existingCore.As<v8::Object>();
-        }
-        else {
-            coreObj = v8::Object::New(isolate);
-            global->Set(context, coreKey, coreObj).Check();
-        }
-
-        // Register value-type builtins at the global root (new Vector3, not new Core.Vector3)
+        // Every builtin registers at the global root (new Vector3, not new Core.Vector3).
         Framework::Scripting::Builtins::RegisterValueTypes(isolate, global);
 
-        // Register communication APIs
         _resourceManager->GetEvents().Register(isolate, context, global, _resourceManager.get());
-        Framework::Scripting::Builtins::Messages::Register(isolate, context, frameworkObj, _resourceManager.get());
-        Framework::Scripting::Builtins::Imports::Register(isolate, context, frameworkObj, _resourceManager.get());
-        Framework::Scripting::Builtins::Exports::Register(isolate, context, frameworkObj, _resourceManager.get());
-
-        // Register console override
+        Framework::Scripting::Builtins::Messages::Register(isolate, context, global, _resourceManager.get());
+        Framework::Scripting::Builtins::Imports::Register(isolate, context, global, _resourceManager.get());
+        Framework::Scripting::Builtins::Exports::Register(isolate, context, global, _resourceManager.get());
         Framework::Scripting::Builtins::Console::Register(isolate, context, _resourceManager.get());
-
-        // Register environment info at the global root
         Framework::Scripting::Builtins::ExecutionEnvironment::Register(isolate, context, global, false);
-
-        // Register the chat API on the global object (Chat.sendToAll / Chat.sendToPlayer)
         Framework::Scripting::Builtins::Chat::Register(isolate, global);
 
         Logging::GetLogger(FRAMEWORK_INNER_SCRIPTING)->debug("Registered Framework JS bindings");

--- a/code/framework/src/scripting/builtins/README.md
+++ b/code/framework/src/scripting/builtins/README.md
@@ -45,6 +45,11 @@ Rules:
 
 ## Registration
 
+`target` is always the context's global root — there is no namespace object to
+nest under, so every builtin is reachable as a bare global (`Web`, `Key`,
+`Exports`, …). Names that Node's CommonJS module scope would shadow are
+capitalized for that reason: `Exports`, not `exports`.
+
 There are two legitimate `Register` shapes; a builtin uses the one that matches
 what it needs, and nothing else diverges:
 

--- a/code/framework/src/scripting/builtins/exports.cpp
+++ b/code/framework/src/scripting/builtins/exports.cpp
@@ -6,7 +6,7 @@
  * See LICENSE file in the source repository for information regarding licensing.
  */
 
-#include "Exports.h"
+#include "exports.h"
 #include "../resource/resource.h"
 #include "../resource/resource_manager.h"
 #include "../scripting_catalog.h"

--- a/code/framework/src/scripting/builtins/exports.cpp
+++ b/code/framework/src/scripting/builtins/exports.cpp
@@ -6,7 +6,7 @@
  * See LICENSE file in the source repository for information regarding licensing.
  */
 
-#include "exports.h"
+#include "Exports.h"
 #include "../resource/resource.h"
 #include "../resource/resource_manager.h"
 #include "../scripting_catalog.h"
@@ -15,7 +15,7 @@
 
 namespace Framework::Scripting::Builtins {
 
-    void Exports::Register(v8::Isolate *isolate, v8::Local<v8::Context> context, v8::Local<v8::Object> frameworkObj, ResourceManager *resourceManager) {
+    void Exports::Register(v8::Isolate *isolate, v8::Local<v8::Context> context, v8::Local<v8::Object> target, ResourceManager *resourceManager) {
         v8::Local<v8::Object> exportsObj = v8::Object::New(isolate);
 
         // Store resource manager as external data for callbacks
@@ -29,9 +29,9 @@ namespace Framework::Scripting::Builtins {
         v8::Local<v8::FunctionTemplate> getTmpl = v8::FunctionTemplate::New(isolate, GetCallback, managerData);
         exportsObj->Set(context, v8pp::to_v8(isolate, "get"), getTmpl->GetFunction(context).ToLocalChecked()).Check();
 
-        frameworkObj->Set(context, v8pp::to_v8(isolate, "exports"), exportsObj).Check();
+        target->Set(context, v8pp::to_v8(isolate, "Exports"), exportsObj).Check();
 
-        auto &metadata = GetScriptingCatalog(isolate).global_object("exports", "Registration and lookup of cross-resource values through Framework.exports.");
+        auto &metadata = GetScriptingCatalog(isolate).global_object("Exports", "Registration and lookup of cross-resource values through the global Exports object.");
         metadata.record(v8pp::metadata::function_of<v8::FunctionCallback>("register", v8pp::metadata::docs("boolean",
                                                                                           {
                                                                                               v8pp::metadata::param("name", "string", false, "Export name, preferably declared in the current resource manifest."),
@@ -51,18 +51,18 @@ namespace Framework::Scripting::Builtins {
         v8::HandleScope handleScope(isolate);
 
         if (args.Length() < 2) {
-            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "exports.register requires 2 arguments: name, value")));
+            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "Exports.register requires 2 arguments: name, value")));
             return;
         }
 
         if (!args[0]->IsString()) {
-            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "exports.register: name must be a string")));
+            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "Exports.register: name must be a string")));
             return;
         }
 
         ResourceManager *manager = static_cast<ResourceManager *>(args.Data().As<v8::External>()->Value());
         if (!manager) {
-            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "exports.register: resource manager not available")));
+            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "Exports.register: resource manager not available")));
             return;
         }
 
@@ -72,7 +72,7 @@ namespace Framework::Scripting::Builtins {
         // Get the current resource context (use stack fallback for async ES modules)
         Resource *currentResource = manager->GetCurrentResourceWithStackFallback(isolate);
         if (!currentResource) {
-            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "exports.register: no resource context")));
+            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "Exports.register: no resource context")));
             return;
         }
 
@@ -96,7 +96,7 @@ namespace Framework::Scripting::Builtins {
             else {
                 // Export is in manifest but RegisterExport still failed - real error (isolate issue)
                 Logging::GetLogger(FRAMEWORK_INNER_SCRIPTING)->error("[{}] Failed to register export '{}' - isolate initialization issue", currentResource->GetName(), exportName);
-                isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "exports.register: failed to register export '" + exportName + "' - internal error")));
+                isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "Exports.register: failed to register export '" + exportName + "' - internal error")));
             }
         }
         else {
@@ -110,18 +110,18 @@ namespace Framework::Scripting::Builtins {
         v8::HandleScope handleScope(isolate);
 
         if (args.Length() < 2) {
-            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "exports.get requires 2 arguments: resourceName, exportName")));
+            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "Exports.get requires 2 arguments: resourceName, exportName")));
             return;
         }
 
         if (!args[0]->IsString() || !args[1]->IsString()) {
-            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "exports.get: resourceName and exportName must be strings")));
+            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "Exports.get: resourceName and exportName must be strings")));
             return;
         }
 
         ResourceManager *manager = static_cast<ResourceManager *>(args.Data().As<v8::External>()->Value());
         if (!manager) {
-            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "exports.get: resource manager not available")));
+            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "Exports.get: resource manager not available")));
             return;
         }
 
@@ -131,13 +131,13 @@ namespace Framework::Scripting::Builtins {
         // Get the target resource
         const Resource *resource = manager->GetResource(resourceName);
         if (!resource) {
-            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "exports.get: resource '" + resourceName + "' not found")));
+            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "Exports.get: resource '" + resourceName + "' not found")));
             return;
         }
 
         // Check if the resource is running
         if (!resource->IsRunning()) {
-            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "exports.get: resource '" + resourceName + "' is not running")));
+            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "Exports.get: resource '" + resourceName + "' is not running")));
             return;
         }
 
@@ -146,14 +146,14 @@ namespace Framework::Scripting::Builtins {
         if (resourceIsolate != isolate) {
             // Cross-isolate access is not supported - V8 values cannot be shared across isolates
             // This typically happens when resources run in separate isolates (e.g., different threads)
-            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "exports.get: cannot access export '" + exportName + "' from resource '" + resourceName + "' - cross-isolate access is not supported. Both resources must share the same isolate.")));
+            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "Exports.get: cannot access export '" + exportName + "' from resource '" + resourceName + "' - cross-isolate access is not supported. Both resources must share the same isolate.")));
             return;
         }
 
         // Get the export value (safe since we validated isolate ownership above)
         v8::Local<v8::Value> exportValue = resource->GetExportValue(exportName);
         if (exportValue.IsEmpty()) {
-            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "exports.get: export '" + exportName + "' not found in resource '" + resourceName + "'")));
+            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "Exports.get: export '" + exportName + "' not found in resource '" + resourceName + "'")));
             return;
         }
 

--- a/code/framework/src/scripting/builtins/exports.h
+++ b/code/framework/src/scripting/builtins/exports.h
@@ -19,9 +19,10 @@ namespace Framework::Scripting::Builtins {
 
     class Exports final {
       public:
+        // Exposed as `Exports`, not `exports`: Node's CommonJS module scope would shadow the latter.
         static void Register(v8::Isolate *isolate,
                             v8::Local<v8::Context> context,
-                            v8::Local<v8::Object> frameworkObj,
+                            v8::Local<v8::Object> target,
                             ResourceManager *resourceManager);
 
       private:

--- a/code/framework/src/scripting/builtins/imports.cpp
+++ b/code/framework/src/scripting/builtins/imports.cpp
@@ -6,7 +6,7 @@
  * See LICENSE file in the source repository for information regarding licensing.
  */
 
-#include "Imports.h"
+#include "imports.h"
 #include "../resource/resource.h"
 #include "../resource/resource_manager.h"
 #include "../scripting_catalog.h"

--- a/code/framework/src/scripting/builtins/imports.cpp
+++ b/code/framework/src/scripting/builtins/imports.cpp
@@ -6,7 +6,7 @@
  * See LICENSE file in the source repository for information regarding licensing.
  */
 
-#include "imports.h"
+#include "Imports.h"
 #include "../resource/resource.h"
 #include "../resource/resource_manager.h"
 #include "../scripting_catalog.h"
@@ -15,7 +15,7 @@
 
 namespace Framework::Scripting::Builtins {
 
-    void Imports::Register(v8::Isolate *isolate, v8::Local<v8::Context> context, v8::Local<v8::Object> frameworkObj, ResourceManager *resourceManager) {
+    void Imports::Register(v8::Isolate *isolate, v8::Local<v8::Context> context, v8::Local<v8::Object> target, ResourceManager *resourceManager) {
         v8::Local<v8::Object> importsObj = v8::Object::New(isolate);
 
         // Store resource manager as external data for callbacks
@@ -25,9 +25,9 @@ namespace Framework::Scripting::Builtins {
         v8::Local<v8::FunctionTemplate> getTmpl = v8::FunctionTemplate::New(isolate, GetCallback, managerData);
         importsObj->Set(context, v8pp::to_v8(isolate, "get"), getTmpl->GetFunction(context).ToLocalChecked()).Check();
 
-        frameworkObj->Set(context, v8pp::to_v8(isolate, "imports"), importsObj).Check();
+        target->Set(context, v8pp::to_v8(isolate, "Imports"), importsObj).Check();
 
-        auto &metadata = GetScriptingCatalog(isolate).global_object("imports", "Bulk access to values exported by another running resource through Framework.imports.");
+        auto &metadata = GetScriptingCatalog(isolate).global_object("Imports", "Bulk access to values exported by another running resource through the global Imports object.");
         metadata.record(v8pp::metadata::function_of<v8::FunctionCallback>("get",
             v8pp::metadata::docs("Record<string, unknown>",
                 {
@@ -42,18 +42,18 @@ namespace Framework::Scripting::Builtins {
         v8::Local<v8::Context> context = isolate->GetCurrentContext();
 
         if (args.Length() < 1) {
-            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "imports.get requires 1 argument: resourceName")));
+            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "Imports.get requires 1 argument: resourceName")));
             return;
         }
 
         if (!args[0]->IsString()) {
-            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "imports.get: resourceName must be a string")));
+            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "Imports.get: resourceName must be a string")));
             return;
         }
 
         ResourceManager *manager = static_cast<ResourceManager *>(args.Data().As<v8::External>()->Value());
         if (!manager) {
-            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "imports.get: resource manager not available")));
+            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "Imports.get: resource manager not available")));
             return;
         }
 
@@ -63,13 +63,13 @@ namespace Framework::Scripting::Builtins {
         // Check if target resource exists
         const Resource *resource = manager->GetResource(resourceName);
         if (!resource) {
-            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "imports.get: resource '" + resourceName + "' not found")));
+            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "Imports.get: resource '" + resourceName + "' not found")));
             return;
         }
 
         // Check if target resource is running
         if (!resource->IsRunning()) {
-            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "imports.get: resource '" + resourceName + "' is not running")));
+            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "Imports.get: resource '" + resourceName + "' is not running")));
             return;
         }
 
@@ -85,7 +85,7 @@ namespace Framework::Scripting::Builtins {
         // Mirrors Exports::GetCallback: V8 values cannot be shared across isolates.
         v8::Isolate *resourceIsolate = resource->GetIsolate();
         if (resourceIsolate != isolate) {
-            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "imports.get: cannot access exports from resource '" + resourceName + "' - cross-isolate access is not supported. Both resources must share the same isolate.")));
+            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "Imports.get: cannot access exports from resource '" + resourceName + "' - cross-isolate access is not supported. Both resources must share the same isolate.")));
             return;
         }
 

--- a/code/framework/src/scripting/builtins/imports.h
+++ b/code/framework/src/scripting/builtins/imports.h
@@ -21,23 +21,12 @@ namespace Framework::Scripting {
 
 namespace Framework::Scripting::Builtins {
 
-    /**
-     * Resource imports system for accessing exports from other resources.
-     * Provides Framework.imports API:
-     * - get(resourceName) - Returns exports from another resource
-     */
+    // Global Imports: get(resourceName) -> every export registered by another running resource.
     class Imports final {
       public:
-        /**
-         * Register the Framework.imports object in a context.
-         * @param isolate V8 isolate
-         * @param context Target context
-         * @param frameworkObj Framework global object to attach to
-         * @param resourceManager Resource manager for getting exports
-         */
         static void Register(v8::Isolate *isolate,
                             v8::Local<v8::Context> context,
-                            v8::Local<v8::Object> frameworkObj,
+                            v8::Local<v8::Object> target,
                             ResourceManager *resourceManager);
 
         /**

--- a/code/framework/src/scripting/builtins/messages.cpp
+++ b/code/framework/src/scripting/builtins/messages.cpp
@@ -6,7 +6,7 @@
  * See LICENSE file in the source repository for information regarding licensing.
  */
 
-#include "Messages.h"
+#include "messages.h"
 #include "../resource/resource_manager.h"
 #include "../scripting_catalog.h"
 

--- a/code/framework/src/scripting/builtins/messages.cpp
+++ b/code/framework/src/scripting/builtins/messages.cpp
@@ -6,7 +6,7 @@
  * See LICENSE file in the source repository for information regarding licensing.
  */
 
-#include "messages.h"
+#include "Messages.h"
 #include "../resource/resource_manager.h"
 #include "../scripting_catalog.h"
 
@@ -22,7 +22,7 @@ namespace Framework::Scripting::Builtins {
     std::mutex Messages::_responseQueueMutex;
     uint64_t Messages::_nextRequestId = 1;
 
-    void Messages::Register(v8::Isolate *isolate, v8::Local<v8::Context> context, v8::Local<v8::Object> frameworkObj, ResourceManager *resourceManager) {
+    void Messages::Register(v8::Isolate *isolate, v8::Local<v8::Context> context, v8::Local<v8::Object> target, ResourceManager *resourceManager) {
         v8::Local<v8::Object> messagesObj = v8::Object::New(isolate);
 
         // Store resource manager as external data for callbacks
@@ -40,9 +40,9 @@ namespace Framework::Scripting::Builtins {
         v8::Local<v8::FunctionTemplate> sendTmpl = v8::FunctionTemplate::New(isolate, SendCallback, managerData);
         messagesObj->Set(context, v8pp::to_v8(isolate, "send"), sendTmpl->GetFunction(context).ToLocalChecked()).Check();
 
-        frameworkObj->Set(context, v8pp::to_v8(isolate, "messages"), messagesObj).Check();
+        target->Set(context, v8pp::to_v8(isolate, "Messages"), messagesObj).Check();
 
-        auto &metadata = GetScriptingCatalog(isolate).global_object("messages", "Typed request and notification channel between local resources through Framework.messages.");
+        auto &metadata = GetScriptingCatalog(isolate).global_object("Messages", "Typed request and notification channel between local resources through the global Messages object.");
         metadata.record(v8pp::metadata::function_of<v8::FunctionCallback>("handle",
             v8pp::metadata::docs("void",
                 {
@@ -71,23 +71,23 @@ namespace Framework::Scripting::Builtins {
         v8::HandleScope handleScope(isolate);
 
         if (args.Length() < 2) {
-            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "messages.handle requires 2 arguments: messageType, handler")));
+            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "Messages.handle requires 2 arguments: messageType, handler")));
             return;
         }
 
         if (!args[0]->IsString()) {
-            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "messages.handle: messageType must be a string")));
+            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "Messages.handle: messageType must be a string")));
             return;
         }
 
         if (!args[1]->IsFunction()) {
-            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "messages.handle: handler must be a function")));
+            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "Messages.handle: handler must be a function")));
             return;
         }
 
         ResourceManager *manager = static_cast<ResourceManager *>(args.Data().As<v8::External>()->Value());
         if (!manager) {
-            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "messages.handle: resource manager not available")));
+            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "Messages.handle: resource manager not available")));
             return;
         }
 
@@ -95,7 +95,7 @@ namespace Framework::Scripting::Builtins {
         std::string resourceName = manager->GetCurrentResourceContext();
 
         if (resourceName.empty()) {
-            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "messages.handle: must be called from within a resource")));
+            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "Messages.handle: must be called from within a resource")));
             return;
         }
 
@@ -115,23 +115,23 @@ namespace Framework::Scripting::Builtins {
         v8::Local<v8::Context> context = isolate->GetCurrentContext();
 
         if (args.Length() < 2) {
-            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "messages.request requires at least 2 arguments: resourceName, messageType")));
+            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "Messages.request requires at least 2 arguments: resourceName, messageType")));
             return;
         }
 
         if (!args[0]->IsString()) {
-            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "messages.request: resourceName must be a string")));
+            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "Messages.request: resourceName must be a string")));
             return;
         }
 
         if (!args[1]->IsString()) {
-            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "messages.request: messageType must be a string")));
+            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "Messages.request: messageType must be a string")));
             return;
         }
 
         ResourceManager *manager = static_cast<ResourceManager *>(args.Data().As<v8::External>()->Value());
         if (!manager) {
-            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "messages.request: resource manager not available")));
+            isolate->ThrowException(v8::Exception::Error(v8pp::to_v8(isolate, "Messages.request: resource manager not available")));
             return;
         }
 
@@ -167,7 +167,7 @@ namespace Framework::Scripting::Builtins {
             // Getting it from a different isolate crashes, so reject cross-isolate requests
             // (mirrors the Exports.get isolate-ownership guard).
             if (handlerIt->second.isolate != isolate) {
-                resolver->Reject(context, v8pp::to_v8(isolate, "messages.request: cannot invoke handler '" + messageType + "' in resource '" + targetResource + "' - cross-isolate access is not supported. Both resources must share the same isolate.")).Check();
+                resolver->Reject(context, v8pp::to_v8(isolate, "Messages.request: cannot invoke handler '" + messageType + "' in resource '" + targetResource + "' - cross-isolate access is not supported. Both resources must share the same isolate.")).Check();
                 args.GetReturnValue().Set(promise);
                 return;
             }
@@ -257,17 +257,17 @@ namespace Framework::Scripting::Builtins {
         v8::Local<v8::Context> context = isolate->GetCurrentContext();
 
         if (args.Length() < 2) {
-            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "messages.send requires at least 2 arguments: resourceName, messageType")));
+            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "Messages.send requires at least 2 arguments: resourceName, messageType")));
             return;
         }
 
         if (!args[0]->IsString()) {
-            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "messages.send: resourceName must be a string")));
+            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "Messages.send: resourceName must be a string")));
             return;
         }
 
         if (!args[1]->IsString()) {
-            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "messages.send: messageType must be a string")));
+            isolate->ThrowException(v8::Exception::TypeError(v8pp::to_v8(isolate, "Messages.send: messageType must be a string")));
             return;
         }
 
@@ -295,7 +295,7 @@ namespace Framework::Scripting::Builtins {
             // Cross-isolate handler: Getting its Global<Function> from this isolate would
             // crash. Skip delivery (send is fire-and-forget) and warn (mirrors Exports.get).
             if (handlerIt->second.isolate != isolate) {
-                Logging::GetLogger(FRAMEWORK_INNER_SCRIPTING)->warn("messages.send to '{}' skipped: handler '{}' lives in a different isolate", targetResource, messageType);
+                Logging::GetLogger(FRAMEWORK_INNER_SCRIPTING)->warn("Messages.send to '{}' skipped: handler '{}' lives in a different isolate", targetResource, messageType);
                 return;
             }
 
@@ -381,7 +381,7 @@ namespace Framework::Scripting::Builtins {
                     // settles and erases atomically under this same mutex — so rejecting always
                     // moves the awaiting Promise out of pending (and V8 ignores a reject on an
                     // already-settled promise anyway). After erasing, a late reply() finds nothing.
-                    req.resolver.Get(isolate)->Reject(context, v8pp::to_v8(isolate, "messages.request: resource '" + resourceName + "' stopped before reply")).Check();
+                    req.resolver.Get(isolate)->Reject(context, v8pp::to_v8(isolate, "Messages.request: resource '" + resourceName + "' stopped before reply")).Check();
                     it = _pendingRequests.erase(it);
                 }
                 else {

--- a/code/framework/src/scripting/builtins/messages.h
+++ b/code/framework/src/scripting/builtins/messages.h
@@ -24,21 +24,13 @@ namespace Framework::Scripting {
 
 namespace Framework::Scripting::Builtins {
 
-    /**
-     * JavaScript messages system for request/response communication.
-     * Provides Framework.messages API:
-     * - handle(messageType, handler) - Register handler
-     * - request(resourceName, messageType, payload) - Returns Promise
-     * - send(resourceName, messageType, payload) - Fire and forget
-     */
+    // Global Messages: request/response and fire-and-forget channel between local resources.
+    //   handle(messageType, handler) / request(resource, type, payload) -> Promise / send(...)
     class Messages final {
       public:
-        /**
-         * Register the Framework.messages object in a context.
-         */
         static void Register(v8::Isolate *isolate,
                             v8::Local<v8::Context> context,
-                            v8::Local<v8::Object> frameworkObj,
+                            v8::Local<v8::Object> target,
                             ResourceManager *resourceManager);
 
         /**

--- a/code/framework/src/scripting/engine.cpp
+++ b/code/framework/src/scripting/engine.cpp
@@ -61,23 +61,6 @@ namespace Framework::Scripting {
         return true;
     }
 
-    v8::Local<v8::Object> Engine::GetFrameworkObject() const {
-        v8::Local<v8::Context> context = GetContext();
-        if (context.IsEmpty()) {
-            return v8::Local<v8::Object>();
-        }
-        v8::Isolate *isolate = GetIsolate();
-        v8::Local<v8::Value> frameworkValue;
-        if (!context->Global()
-                ->Get(context, v8::String::NewFromUtf8(isolate, "Framework").ToLocalChecked())
-                .ToLocal(&frameworkValue) ||
-            !frameworkValue->IsObject()) {
-            Logging::GetLogger(FRAMEWORK_INNER_SCRIPTING)->error("globalThis.Framework is missing or not an object");
-            return v8::Local<v8::Object>();
-        }
-        return frameworkValue.As<v8::Object>();
-    }
-
     v8::Local<v8::Object> Engine::GetCoreObject() const {
         v8::Local<v8::Context> context = GetContext();
         if (context.IsEmpty()) {

--- a/code/framework/src/scripting/engine.h
+++ b/code/framework/src/scripting/engine.h
@@ -100,11 +100,6 @@ namespace Framework::Scripting {
         virtual v8::Local<v8::Context> GetContext() const = 0;
 
         /**
-         * Get the Framework global object for binding APIs.
-         */
-        v8::Local<v8::Object> GetFrameworkObject() const;
-
-        /**
          * Get the Core global object for builtin types and events.
          */
         v8::Local<v8::Object> GetCoreObject() const;

--- a/code/framework/src/scripting/node_engine.cpp
+++ b/code/framework/src/scripting/node_engine.cpp
@@ -208,7 +208,6 @@ namespace Framework::Scripting {
             _env,
             "const publicRequire = require('node:module').createRequire(process.cwd() + '/');"
             "globalThis.require = publicRequire;"
-            "globalThis.Framework = {};"
             "globalThis.Core = {};"
             // Capture the real require.cache before sandboxing hides it, so
             // C++ can evict a resource's modules on reload.

--- a/code/framework/src/scripting/v8_engine.cpp
+++ b/code/framework/src/scripting/v8_engine.cpp
@@ -269,12 +269,6 @@ namespace Framework::Scripting {
         v8::Local<v8::Context> context = _context.Get(_isolate);
         v8::Local<v8::Object> global = context->Global();
 
-        // Create globalThis.Framework = {}
-        v8::Local<v8::Object> frameworkObj = v8::Object::New(_isolate);
-        global->Set(context,
-            v8::String::NewFromUtf8Literal(_isolate, "Framework"),
-            frameworkObj).Check();
-
         // Create globalThis.Core = {}
         v8::Local<v8::Object> coreObj = v8::Object::New(_isolate);
         global->Set(context,

--- a/code/tests/modules/js_features_ut.h
+++ b/code/tests/modules/js_features_ut.h
@@ -910,9 +910,7 @@ MODULE(js_features, {
         v8::HandleScope handleScope(isolate);
         v8::Local<v8::Context> context = engine.GetContext();
         v8::Context::Scope contextScope(context);
-        v8::Local<v8::Object> frameworkObj = v8::Object::New(isolate);
-        context->Global()->Set(context, v8pp::to_v8(isolate, "Framework"), frameworkObj).Check();
-        Messages::Register(isolate, context, frameworkObj, &manager);
+        Messages::Register(isolate, context, context->Global(), &manager);
     };
 
     auto pumpMessages = [](NodeEngine &engine) {
@@ -943,20 +941,20 @@ MODULE(js_features, {
 
         // Arg-shape failures throw TypeError (convention), before any state checks.
         std::string margErr;
-        margErr = RunJSErrorName(engine, "Framework.messages.request(123)");
+        margErr = RunJSErrorName(engine, "Messages.request(123)");
         STREQUALS(margErr.c_str(), "TypeError");
-        margErr = RunJSErrorName(engine, "Framework.messages.send('r')");
+        margErr = RunJSErrorName(engine, "Messages.send('r')");
         STREQUALS(margErr.c_str(), "TypeError");
 
         // Register the handler as resource 'provider'.
         manager.SetCurrentResourceContext("provider");
-        RunJS(engine, "Framework.messages.handle('ping', (payload, reply) => { reply(payload + 1); }); 0");
+        RunJS(engine, "Messages.handle('ping', (payload, reply) => { reply(payload + 1); }); 0");
 
         // Issue a request as resource 'consumer'.
         manager.SetCurrentResourceContext("consumer");
         RunJS(engine, R"(
             globalThis.__reply = 0;
-            Framework.messages.request('provider', 'ping', 41).then(v => { globalThis.__reply = v; },
+            Messages.request('provider', 'ping', 41).then(v => { globalThis.__reply = v; },
                                                                     () => { globalThis.__reply = -1; });
             0
         )");
@@ -965,11 +963,11 @@ MODULE(js_features, {
 
         // A request whose target hasn't replied yet stays pending...
         manager.SetCurrentResourceContext("provider");
-        RunJS(engine, "Framework.messages.handle('slow', (payload, reply) => { globalThis.__saved = reply; }); 0");
+        RunJS(engine, "Messages.handle('slow', (payload, reply) => { globalThis.__saved = reply; }); 0");
         manager.SetCurrentResourceContext("consumer");
         RunJS(engine, R"(
             globalThis.__inflight = 0;
-            Framework.messages.request('provider', 'slow', 1).then(() => { globalThis.__inflight = 1; },
+            Messages.request('provider', 'slow', 1).then(() => { globalThis.__inflight = 1; },
                                                                    () => { globalThis.__inflight = 2; });
             0
         )");
@@ -993,7 +991,7 @@ MODULE(js_features, {
         // A new request after cleanup also rejects: no handler remains for the target resource.
         RunJS(engine, R"(
             globalThis.__after = 0;
-            Framework.messages.request('provider', 'ping', 1).then(() => { globalThis.__after = 1; },
+            Messages.request('provider', 'ping', 1).then(() => { globalThis.__after = 1; },
                                                                    () => { globalThis.__after = 2; });
             0
         )");
@@ -1045,11 +1043,10 @@ MODULE(js_features, {
     // ========================================
     // JS-FACING NAMING
     // ========================================
-    // The Framework.* namespace group uses one casing: exports joins the lowercase imports/messages
-    // (was Framework.Exports). The runtime-flags global is ExecutionEnvironment (was Environment) at
-    // the root, with camelCase isClient/isServer (were IsClient/IsServer). Guards the breaking
-    // renames; the old names must be gone.
-    IT("Framework.exports is lowercase and ExecutionEnvironment flags are camelCase", {
+    // Guards the breaking renames — the old names must be gone. Everything the Framework namespace
+    // object carried now sits at the global root, and the object itself is deleted. The runtime-flags
+    // global is ExecutionEnvironment (was Environment) with camelCase isClient/isServer.
+    IT("Framework namespace bindings moved to the global root", {
         EventsTestHelper::Setup();
         NodeEngine engine({});
         EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
@@ -1064,18 +1061,15 @@ MODULE(js_features, {
             v8::HandleScope handleScope(isolate);
             v8::Local<v8::Context> context = engine.GetContext();
             v8::Context::Scope contextScope(context);
-            v8::Local<v8::Object> frameworkObj = v8::Object::New(isolate);
-            context->Global()->Set(context, v8pp::to_v8(isolate, "Framework"), frameworkObj).Check();
-            Exports::Register(isolate, context, frameworkObj, &manager);
             // Registered at the global root, as production does.
+            Exports::Register(isolate, context, context->Global(), &manager);
             ExecutionEnvironment::Register(isolate, context, context->Global(), /*isClient*/ true);
         }
 
-        // exports: lowercase, matching imports/messages; the capitalized name is gone.
-        EQUALS(RunJSBool(engine, "typeof Framework.exports === 'object' && Framework.exports !== null"), true);
-        EQUALS(RunJSBool(engine, "typeof Framework.exports.register === 'function'"), true);
-        EQUALS(RunJSBool(engine, "typeof Framework.exports.get === 'function'"), true);
-        EQUALS(RunJSBool(engine, "Framework.Exports === undefined"), true);
+        EQUALS(RunJSBool(engine, "typeof Exports === 'object' && Exports !== null"), true);
+        EQUALS(RunJSBool(engine, "typeof Exports.register === 'function'"), true);
+        EQUALS(RunJSBool(engine, "typeof Exports.get === 'function'"), true);
+        EQUALS(RunJSBool(engine, "typeof Framework === 'undefined'"), true);
 
         // ExecutionEnvironment at root, camelCase flags; old Environment name and PascalCase are gone.
         EQUALS(RunJSBool(engine, "ExecutionEnvironment.isClient === true"), true);

--- a/docs/chat.md
+++ b/docs/chat.md
@@ -180,13 +180,13 @@ keeping the same networking:
 ```js
 // client resource
 Chat.setUIVisible(false);                              // hide the built-in overlay
-const view = Framework.Web.create("chat.html");
+const view = Web.create("chat.html");
 Core.Events.on("chatMessage", (msg) => view.emit("chat:add", msg)); // {author,text,color}
-Framework.Web.on(view, "chat:send", (text) => Chat.send(text));     // input box → server
+Web.on(view, "chat:send", (text) => Chat.send(text));     // input box → server
 ```
 
 The CEF view's keyboard focus already participates in the client's input gate
-(`Framework.Web.focusView`), so movement/keybinds pause while the box is
+(`Web.focusView`), so movement/keybinds pause while the box is
 focused, exactly as with the built-in overlay.
 
 On the server, format lines yourself from `playerChat` and — if the mod exposes

--- a/docs/scripting_keybindings.md
+++ b/docs/scripting_keybindings.md
@@ -1,20 +1,20 @@
-# Client Keybindings (`Framework.Key`)
+# Client Keybindings (`Key`)
 
 The client scripting layer lets a resource bind physical keys to handlers via
-the `Framework.Key` API. It is the framework's answer to MTA:SA's `bindKey` and
+the `Key` API. It is the framework's answer to MTA:SA's `bindKey` and
 FiveM's `RegisterKeyMapping`: a resource asks for a key, and a callback fires
 when that key goes down and/or up.
 
-`Framework.Key` is **client-side only** — it does not exist on the server. Put
+`Key` is **client-side only** — it does not exist on the server. Put
 your `Key.bind` calls in a resource's client script.
 
 ## API
 
 ```ts
-Framework.Key.bind(key, state, handler)   // state: "down" | "up" | "both"
-Framework.Key.bind(key, handler)           // state defaults to "down"
-Framework.Key.unbind(key, state?, handler?)
-Framework.Key.isDown(key) -> boolean
+Key.bind(key, state, handler)   // state: "down" | "up" | "both"
+Key.bind(key, handler)           // state defaults to "down"
+Key.unbind(key, state?, handler?)
+Key.isDown(key) -> boolean
 ```
 
 - **`bind(key, state, handler)`** — registers `handler`. It is called as
@@ -34,27 +34,27 @@ Framework.Key.isDown(key) -> boolean
 
 ```js
 // Toggle a HUD panel on F6:
-Framework.Key.bind("f6", "down", () => toggleHud());
+Key.bind("f6", "down", () => toggleHud());
 
 // Hold-to-aim: one handler, both edges. `state` tells you which edge.
-Framework.Key.bind("b", "both", (key, state) => {
+Key.bind("b", "both", (key, state) => {
     setAiming(state === "down");
 });
 
 // Fire-and-forget on key-down (state omitted):
-Framework.Key.bind("h", () => honk());
+Key.bind("h", () => honk());
 
 // Poll a modifier from inside another handler:
-Framework.Key.bind("e", "down", () => {
-    if (Framework.Key.isDown("lshift")) openContextMenu();
+Key.bind("e", "down", () => {
+    if (Key.isDown("lshift")) openContextMenu();
     else interact();
 });
 
 // Remove a specific bind later:
 const onJump = () => jump();
-Framework.Key.bind("space", "down", onJump);
+Key.bind("space", "down", onJump);
 // ...
-Framework.Key.unbind("space", "down", onJump);
+Key.unbind("space", "down", onJump);
 ```
 
 ## Key names
@@ -81,7 +81,7 @@ Handlers fire only when the player is actually in control of the game:
 
 - the client is in an active session,
 - no UI is capturing input — chat box open, a menu open, or a focused web view
-  (`Framework.Web.focusView`), and
+  (`Web.focusView`), and
 - the game window is in the foreground.
 
 While any of those hold, key edges are **swallowed** — a key pressed with the
@@ -102,7 +102,7 @@ its binds are removed automatically — you do not need to `unbind` them in a
 
 - Binds are dispatched by polling once per frame, so this is edge detection on
   the game's frame rate — fine for gameplay actions, not for text entry (use a
-  `Framework.Web` view for typed input).
+  `Web` view for typed input).
 - There is no user-facing rebinding UI yet: the key a resource asks for is the
   key it gets. A default-plus-rebind model (FiveM-style) may be added later.
 - Server-driven binds (a server telling a specific client to bind a key) are

--- a/types/framework/discord.d.ts
+++ b/types/framework/discord.d.ts
@@ -1,153 +1,151 @@
-declare namespace Framework {
-    /** Activity verb shown before the app name. Name or the numeric Discord enum. */
-    type DiscordActivityType = "playing" | "streaming" | "listening" | "watching" | number;
+/** Activity verb shown before the app name. Name or the numeric Discord enum. */
+type DiscordActivityType = "playing" | "streaming" | "listening" | "watching" | number;
 
-    /** Party join privacy. Name or the numeric Discord enum. */
-    type DiscordPartyPrivacy = "private" | "public" | number;
+/** Party join privacy. Name or the numeric Discord enum. */
+type DiscordPartyPrivacy = "private" | "public" | number;
 
-    /** Options accepted by {@link Discord.setPresence}. Every field is optional. */
-    interface DiscordPresenceOptions {
-        /** Activity verb; defaults to `"playing"`. */
-        type?: DiscordActivityType;
-        /** Activity name. */
-        name?: string;
-        /** Top line of the presence. */
-        details?: string;
-        /** Bottom line of the presence. */
-        state?: string;
-        /** Elapsed-time anchor, unix seconds. `0` clears it. */
-        startTimestamp?: number;
-        /** Countdown anchor, unix seconds. `0` clears it. */
-        endTimestamp?: number;
-        /** Asset key of the large image. */
-        largeImage?: string;
-        /** Tooltip for the large image. */
-        largeText?: string;
-        /** Asset key of the small image (overlaps the large one). */
-        smallImage?: string;
-        /** Tooltip for the small image. */
-        smallText?: string;
-        /** Party grouping — enables Discord "X of Y" and, with a join secret, invites. */
-        party?: {
-            id?: string;
-            /** `[current, max]` party size. */
-            size?: [number, number];
-            privacy?: DiscordPartyPrivacy;
-        };
-        /** Invite/spectate secrets (opaque strings your game round-trips). */
-        secrets?: {
-            match?: string;
-            join?: string;
-            spectate?: string;
-        };
-        /** Whether this is an instanced (session) activity. */
-        instance?: boolean;
-        /** Supported-platform bitmask (Desktop = 1, Android = 2, iOS = 4). */
-        supportedPlatforms?: number;
-    }
+/** Options accepted by {@link Discord.setPresence}. Every field is optional. */
+interface DiscordPresenceOptions {
+    /** Activity verb; defaults to `"playing"`. */
+    type?: DiscordActivityType;
+    /** Activity name. */
+    name?: string;
+    /** Top line of the presence. */
+    details?: string;
+    /** Bottom line of the presence. */
+    state?: string;
+    /** Elapsed-time anchor, unix seconds. `0` clears it. */
+    startTimestamp?: number;
+    /** Countdown anchor, unix seconds. `0` clears it. */
+    endTimestamp?: number;
+    /** Asset key of the large image. */
+    largeImage?: string;
+    /** Tooltip for the large image. */
+    largeText?: string;
+    /** Asset key of the small image (overlaps the large one). */
+    smallImage?: string;
+    /** Tooltip for the small image. */
+    smallText?: string;
+    /** Party grouping — enables Discord "X of Y" and, with a join secret, invites. */
+    party?: {
+        id?: string;
+        /** `[current, max]` party size. */
+        size?: [number, number];
+        privacy?: DiscordPartyPrivacy;
+    };
+    /** Invite/spectate secrets (opaque strings your game round-trips). */
+    secrets?: {
+        match?: string;
+        join?: string;
+        spectate?: string;
+    };
+    /** Whether this is an instanced (session) activity. */
+    instance?: boolean;
+    /** Supported-platform bitmask (Desktop = 1, Android = 2, iOS = 4). */
+    supportedPlatforms?: number;
+}
+
+/**
+ * Client-side Discord rich presence API. **Client only** — not available on
+ * the server.
+ *
+ * Field setters *stage* changes onto a pending activity; nothing is shown
+ * until {@link Discord.update} (or the batch {@link Discord.setPresence}) is
+ * called. This mirrors Discord's model — an activity is published as one whole
+ * object and updates are rate-limited — so compose, then commit once. All
+ * calls no-op (setters silently, commits return `false`) when Discord presence
+ * is disabled or unavailable.
+ *
+ * @example
+ * // Batch form — apply several fields and publish in one call:
+ * Discord.setPresence({
+ *     details: "In the city",
+ *     state: "Freeroam",
+ *     largeImage: "map-city",
+ *     startTimestamp: Math.floor(Date.now() / 1000),
+ *     party: { size: [4, 32] },
+ * });
+ *
+ * @example
+ * // Granular form — stage, then commit:
+ * Discord.setDetails("Racing");
+ * Discord.setPartySize(2, 8);
+ * Discord.update();
+ */
+declare const Discord: {
+    /** Stage the activity {@link DiscordActivityType type}. */
+    setType(type: DiscordActivityType): void;
+    /** Stage the activity name. */
+    setName(name: string): void;
+    /** Stage the top line. */
+    setDetails(details: string): void;
+    /** Stage the bottom line. */
+    setState(state: string): void;
+
+    /** Stage the elapsed-time anchor (unix seconds; `0` clears). */
+    setStartTimestamp(seconds: number): void;
+    /** Stage the countdown anchor (unix seconds; `0` clears). */
+    setEndTimestamp(seconds: number): void;
+
+    /** Stage the large image asset key. */
+    setLargeImage(assetKey: string): void;
+    /** Stage the large image tooltip. */
+    setLargeText(text: string): void;
+    /** Stage the small image asset key. */
+    setSmallImage(assetKey: string): void;
+    /** Stage the small image tooltip. */
+    setSmallText(text: string): void;
+    /** Stage several asset fields at once. */
+    setAssets(assets: { largeImage?: string; largeText?: string; smallImage?: string; smallText?: string }): void;
+
+    /** Stage the party id. */
+    setPartyId(id: string): void;
+    /** Stage the party size (current of max). */
+    setPartySize(current: number, max: number): void;
+    /** Stage the party join privacy. */
+    setPartyPrivacy(privacy: DiscordPartyPrivacy): void;
+    /** Stage several party fields at once. */
+    setParty(party: { id?: string; size?: [number, number]; privacy?: DiscordPartyPrivacy }): void;
+
+    /** Stage the match secret. */
+    setMatchSecret(secret: string): void;
+    /** Stage the join secret (enables Ask to Join). */
+    setJoinSecret(secret: string): void;
+    /** Stage the spectate secret. */
+    setSpectateSecret(secret: string): void;
+    /** Stage several secret fields at once. */
+    setSecrets(secrets: { match?: string; join?: string; spectate?: string }): void;
+
+    /** Stage the instanced flag. */
+    setInstance(instance: boolean): void;
+    /** Stage the supported-platform bitmask (Desktop = 1, Android = 2, iOS = 4). */
+    setSupportedPlatforms(flags: number): void;
 
     /**
-     * Client-side Discord rich presence API. **Client only** — not available on
-     * the server.
-     *
-     * Field setters *stage* changes onto a pending activity; nothing is shown
-     * until {@link Discord.update} (or the batch {@link Discord.setPresence}) is
-     * called. This mirrors Discord's model — an activity is published as one whole
-     * object and updates are rate-limited — so compose, then commit once. All
-     * calls no-op (setters silently, commits return `false`) when Discord presence
-     * is disabled or unavailable.
-     *
-     * @example
-     * // Batch form — apply several fields and publish in one call:
-     * Framework.Discord.setPresence({
-     *     details: "In the city",
-     *     state: "Freeroam",
-     *     largeImage: "map-city",
-     *     startTimestamp: Math.floor(Date.now() / 1000),
-     *     party: { size: [4, 32] },
-     * });
-     *
-     * @example
-     * // Granular form — stage, then commit:
-     * Framework.Discord.setDetails("Racing");
-     * Framework.Discord.setPartySize(2, 8);
-     * Framework.Discord.update();
+     * Apply a batch of fields and publish immediately (a merge of the matching
+     * setters followed by {@link Discord.update}).
+     * @returns `true` if the update was dispatched, `false` if unavailable.
      */
-    const Discord: {
-        /** Stage the activity {@link DiscordActivityType type}. */
-        setType(type: DiscordActivityType): void;
-        /** Stage the activity name. */
-        setName(name: string): void;
-        /** Stage the top line. */
-        setDetails(details: string): void;
-        /** Stage the bottom line. */
-        setState(state: string): void;
+    setPresence(options: DiscordPresenceOptions): boolean;
 
-        /** Stage the elapsed-time anchor (unix seconds; `0` clears). */
-        setStartTimestamp(seconds: number): void;
-        /** Stage the countdown anchor (unix seconds; `0` clears). */
-        setEndTimestamp(seconds: number): void;
+    /**
+     * Publish the currently staged activity.
+     * @returns `true` if dispatched, `false` if unavailable.
+     */
+    update(): boolean;
 
-        /** Stage the large image asset key. */
-        setLargeImage(assetKey: string): void;
-        /** Stage the large image tooltip. */
-        setLargeText(text: string): void;
-        /** Stage the small image asset key. */
-        setSmallImage(assetKey: string): void;
-        /** Stage the small image tooltip. */
-        setSmallText(text: string): void;
-        /** Stage several asset fields at once. */
-        setAssets(assets: { largeImage?: string; largeText?: string; smallImage?: string; smallText?: string }): void;
+    /**
+     * Clear the activity on Discord and reset the staged state.
+     * @returns `true` if dispatched, `false` if unavailable.
+     */
+    clear(): boolean;
 
-        /** Stage the party id. */
-        setPartyId(id: string): void;
-        /** Stage the party size (current of max). */
-        setPartySize(current: number, max: number): void;
-        /** Stage the party join privacy. */
-        setPartyPrivacy(privacy: DiscordPartyPrivacy): void;
-        /** Stage several party fields at once. */
-        setParty(party: { id?: string; size?: [number, number]; privacy?: DiscordPartyPrivacy }): void;
+    /** Reset the staged state without publishing. */
+    reset(): void;
 
-        /** Stage the match secret. */
-        setMatchSecret(secret: string): void;
-        /** Stage the join secret (enables Ask to Join). */
-        setJoinSecret(secret: string): void;
-        /** Stage the spectate secret. */
-        setSpectateSecret(secret: string): void;
-        /** Stage several secret fields at once. */
-        setSecrets(secrets: { match?: string; join?: string; spectate?: string }): void;
+    /** Snowflake of the signed-in Discord user, or `""` until known. */
+    getUserId(): string;
 
-        /** Stage the instanced flag. */
-        setInstance(instance: boolean): void;
-        /** Stage the supported-platform bitmask (Desktop = 1, Android = 2, iOS = 4). */
-        setSupportedPlatforms(flags: number): void;
-
-        /**
-         * Apply a batch of fields and publish immediately (a merge of the matching
-         * setters followed by {@link Discord.update}).
-         * @returns `true` if the update was dispatched, `false` if unavailable.
-         */
-        setPresence(options: DiscordPresenceOptions): boolean;
-
-        /**
-         * Publish the currently staged activity.
-         * @returns `true` if dispatched, `false` if unavailable.
-         */
-        update(): boolean;
-
-        /**
-         * Clear the activity on Discord and reset the staged state.
-         * @returns `true` if dispatched, `false` if unavailable.
-         */
-        clear(): boolean;
-
-        /** Reset the staged state without publishing. */
-        reset(): void;
-
-        /** Snowflake of the signed-in Discord user, or `""` until known. */
-        getUserId(): string;
-
-        /** Whether the Discord client is connected and presence can be published. */
-        isAvailable(): boolean;
-    };
-}
+    /** Whether the Discord client is connected and presence can be published. */
+    isAvailable(): boolean;
+};

--- a/types/framework/exports.d.ts
+++ b/types/framework/exports.d.ts
@@ -1,21 +1,19 @@
-declare namespace Framework {
-    const Exports: {
-        /**
-         * Register a value or function from the calling resource.
-         * @param name Export name, preferably declared in the resource manifest.
-         * @param value JavaScript value retained for dependent resources.
-         * @returns `true` when registration succeeds.
-         */
-        register(name: string, value: any): boolean;
+declare const Exports: {
+    /**
+     * Register a value or function from the calling resource.
+     * @param name Export name, preferably declared in the resource manifest.
+     * @param value JavaScript value retained for dependent resources.
+     * @returns `true` when registration succeeds.
+     */
+    register(name: string, value: any): boolean;
 
-        /**
-         * Get a specific export from another resource.
-         * Throws if the resource is not found, not running, or the export
-         * does not exist.
-         * @param resourceName Name of the running resource that owns the export.
-         * @param exportName Registered export name.
-         * @returns The exported value with its original JavaScript identity.
-         */
-        get(resourceName: string, exportName: string): any;
-    };
-}
+    /**
+     * Get a specific export from another resource.
+     * Throws if the resource is not found, not running, or the export
+     * does not exist.
+     * @param resourceName Name of the running resource that owns the export.
+     * @param exportName Registered export name.
+     * @returns The exported value with its original JavaScript identity.
+     */
+    get(resourceName: string, exportName: string): any;
+};

--- a/types/framework/imports.d.ts
+++ b/types/framework/imports.d.ts
@@ -1,12 +1,10 @@
-declare namespace Framework {
-    const imports: {
-        /**
-         * Get the exports object from another resource.
-         * Throws if the resource is not found or not running.
-         * Importing without a declared dependency produces a warning.
-         * @param resourceName Name of the running resource whose exports should be read.
-         * @returns An object keyed by export name, or an empty object when none are registered.
-         */
-        get(resourceName: string): Record<string, any>;
-    };
-}
+declare const Imports: {
+    /**
+     * Get the exports object from another resource.
+     * Throws if the resource is not found or not running.
+     * Importing without a declared dependency produces a warning.
+     * @param resourceName Name of the running resource whose exports should be read.
+     * @returns An object keyed by export name, or an empty object when none are registered.
+     */
+    get(resourceName: string): Record<string, any>;
+};

--- a/types/framework/key.d.ts
+++ b/types/framework/key.d.ts
@@ -1,57 +1,55 @@
-declare namespace Framework {
+/**
+ * Client-side keybinding API. **Client only** — not available on the server.
+ *
+ * Binds a physical key to a handler that fires on key-down, key-up, or both
+ * edges. Binds are resource-owned: they are cleared automatically when the
+ * resource stops. Handlers only fire while the game is in the foreground and
+ * no UI (chat box, menu, focused web view) is capturing input.
+ *
+ * Key names are case-insensitive. Recognised names:
+ * - Letters `a`–`z`, digits `0`–`9`
+ * - Function keys `f1`–`f12`
+ * - Arrows `up` `down` `left` `right`
+ * - Modifiers `shift` `lshift` `rshift`, `ctrl`/`control` `lctrl` `rctrl`,
+ *   `alt` `lalt` `ralt`
+ * - Editing `space` `enter`/`return` `escape`/`esc` `tab` `backspace`
+ *   `insert` `delete` `home` `end` `pageup` `pagedown` `capslock`
+ * - Numpad `numpad0`–`numpad9` (aliases `num0`–`num9`)
+ * - Mouse `mouse1` (left) `mouse2` (right) `mouse3` (middle) `mouse4` `mouse5`
+ *
+ * @example
+ * // Toggle a HUD on key-down:
+ * Key.bind("f6", "down", () => toggleHud());
+ *
+ * // Hold-to-act (fires on both edges); state is "down" then "up":
+ * Key.bind("b", "both", (key, state) => setAiming(state === "down"));
+ *
+ * // State omitted defaults to "down":
+ * Key.bind("h", () => honk());
+ */
+declare const Key: {
     /**
-     * Client-side keybinding API. **Client only** — not available on the server.
-     *
-     * Binds a physical key to a handler that fires on key-down, key-up, or both
-     * edges. Binds are resource-owned: they are cleared automatically when the
-     * resource stops. Handlers only fire while the game is in the foreground and
-     * no UI (chat box, menu, focused web view) is capturing input.
-     *
-     * Key names are case-insensitive. Recognised names:
-     * - Letters `a`–`z`, digits `0`–`9`
-     * - Function keys `f1`–`f12`
-     * - Arrows `up` `down` `left` `right`
-     * - Modifiers `shift` `lshift` `rshift`, `ctrl`/`control` `lctrl` `rctrl`,
-     *   `alt` `lalt` `ralt`
-     * - Editing `space` `enter`/`return` `escape`/`esc` `tab` `backspace`
-     *   `insert` `delete` `home` `end` `pageup` `pagedown` `capslock`
-     * - Numpad `numpad0`–`numpad9` (aliases `num0`–`num9`)
-     * - Mouse `mouse1` (left) `mouse2` (right) `mouse3` (middle) `mouse4` `mouse5`
-     *
-     * @example
-     * // Toggle a HUD on key-down:
-     * Framework.Key.bind("f6", "down", () => toggleHud());
-     *
-     * // Hold-to-act (fires on both edges); state is "down" then "up":
-     * Framework.Key.bind("b", "both", (key, state) => setAiming(state === "down"));
-     *
-     * // State omitted defaults to "down":
-     * Framework.Key.bind("h", () => honk());
+     * Bind a handler to a key.
+     * @param key Case-insensitive key name (see the {@link Key} table).
+     * @param state `"down"`, `"up"`, or `"both"`. If omitted, defaults to `"down"`.
+     * @param handler Called as `handler(key, state)` where `state` is the actual
+     *   edge that fired (`"down"` or `"up"`).
+     * @returns `true` once bound. Throws on an unknown key name or bad state.
      */
-    const Key: {
-        /**
-         * Bind a handler to a key.
-         * @param key Case-insensitive key name (see the {@link Key} table).
-         * @param state `"down"`, `"up"`, or `"both"`. If omitted, defaults to `"down"`.
-         * @param handler Called as `handler(key, state)` where `state` is the actual
-         *   edge that fired (`"down"` or `"up"`).
-         * @returns `true` once bound. Throws on an unknown key name or bad state.
-         */
-        bind(key: string, state: "down" | "up" | "both", handler: (key: string, state: "down" | "up") => void): boolean;
-        bind(key: string, handler: (key: string, state: "down" | "up") => void): boolean;
+    bind(key: string, state: "down" | "up" | "both", handler: (key: string, state: "down" | "up") => void): boolean;
+    bind(key: string, handler: (key: string, state: "down" | "up") => void): boolean;
 
-        /**
-         * Remove binds for a key. With no filters, removes every handler on that key.
-         * @param state Optional: only remove binds registered with this state.
-         * @param handler Optional: only remove this exact handler function.
-         * @returns `true` if at least one bind was removed.
-         */
-        unbind(key: string, state?: "down" | "up" | "both", handler?: (key: string, state: "down" | "up") => void): boolean;
+    /**
+     * Remove binds for a key. With no filters, removes every handler on that key.
+     * @param state Optional: only remove binds registered with this state.
+     * @param handler Optional: only remove this exact handler function.
+     * @returns `true` if at least one bind was removed.
+     */
+    unbind(key: string, state?: "down" | "up" | "both", handler?: (key: string, state: "down" | "up") => void): boolean;
 
-        /**
-         * Live physical state of a key. Returns `false` while UI owns input or the
-         * game window is in the background (same gate as bind dispatch).
-         */
-        isDown(key: string): boolean;
-    };
-}
+    /**
+     * Live physical state of a key. Returns `false` while UI owns input or the
+     * game window is in the background (same gate as bind dispatch).
+     */
+    isDown(key: string): boolean;
+};

--- a/types/framework/messages.d.ts
+++ b/types/framework/messages.d.ts
@@ -1,32 +1,30 @@
-declare namespace Framework {
-    const messages: {
-        /**
-         * Register or replace a handler owned by the calling resource.
-         * @param messageType Message type unique within the receiving resource.
-         * @param handler Receives `(payload, reply)`. Call `reply(value)`
-         *   once to resolve a request; replies are ignored for fire-and-forget messages.
-         */
-        handle(
-            messageType: string,
-            handler: (payload: any, reply: (value: any) => void) => void,
-        ): void;
+declare const Messages: {
+    /**
+     * Register or replace a handler owned by the calling resource.
+     * @param messageType Message type unique within the receiving resource.
+     * @param handler Receives `(payload, reply)`. Call `reply(value)`
+     *   once to resolve a request; replies are ignored for fire-and-forget messages.
+     */
+    handle(
+        messageType: string,
+        handler: (payload: any, reply: (value: any) => void) => void,
+    ): void;
 
-        /**
-         * Send a request to another resource and await a reply.
-         * Rejects if the target resource has no handler or the handler throws.
-         * @param resourceName Destination running resource.
-         * @param messageType Handler type registered by the destination.
-         * @param payload Optional value delivered to the handler.
-         * @returns A promise resolved with the value passed to `reply`.
-         */
-        request(resourceName: string, messageType: string, payload?: any): Promise<any>;
+    /**
+     * Send a request to another resource and await a reply.
+     * Rejects if the target resource has no handler or the handler throws.
+     * @param resourceName Destination running resource.
+     * @param messageType Handler type registered by the destination.
+     * @param payload Optional value delivered to the handler.
+     * @returns A promise resolved with the value passed to `reply`.
+     */
+    request(resourceName: string, messageType: string, payload?: any): Promise<any>;
 
-        /**
-         * Send a fire-and-forget message to another local resource.
-         * @param resourceName Destination running resource.
-         * @param messageType Handler type registered by the destination.
-         * @param payload Optional value delivered to the handler.
-         */
-        send(resourceName: string, messageType: string, payload?: any): void;
-    };
-}
+    /**
+     * Send a fire-and-forget message to another local resource.
+     * @param resourceName Destination running resource.
+     * @param messageType Handler type registered by the destination.
+     * @param payload Optional value delivered to the handler.
+     */
+    send(resourceName: string, messageType: string, payload?: any): void;
+};


### PR DESCRIPTION
Removes the `Framework` namespace object from the scripting layer. Everything it carried is now a bare global.

## What moved

| Before | After |
| --- | --- |
| `Framework.Web` | `Web` |
| `Framework.Key` | `Key` |
| `Framework.Discord` | `Discord` |
| `Framework.exports` | `Exports` |
| `Framework.imports` | `Imports` |
| `Framework.messages` | `Messages` |

`exports`/`imports`/`messages` are **capitalized** on the way out. Node's CommonJS wrapper binds `exports` in every server resource's module scope, so a lowercase global would be shadowed and unreachable from any `require()`d file. The other two follow for consistency.

This is a breaking change for scripts: `Framework.Web.createView()` becomes `Web.createView()`, `Framework.exports.register()` becomes `Exports.register()`, and so on.

## Changes

- `V8Engine::InstallGlobals` and the `NodeEngine` bootstrap no longer create `globalThis.Framework`; `Engine::GetFrameworkObject()` is deleted. `Core` is untouched.
- Every builtin's `Register` now takes the context's global root as `target` (`Exports`, `Imports`, `Messages`, `Web`, `Keybinds`, `Discord`, `Chat`).
- Thrown-error strings and scripting-catalog descriptions follow the new names. The catalog already declared these via `global_object(...)`, so generated typings and docs now match the runtime.
- `types/framework/*.d.ts` flattened from `declare namespace Framework` to global `declare const`.
- Dead `coreObj` get-or-create removed from the server module (the value was never used; the Node bootstrap already creates `Core`).

## Downstream

MafiaMP and Hogwarts fetched `Framework` off the global and registered their entity classes onto it behind an `if` — they would have silently stopped registering. Both now register at the global root; committed separately in those repos, along with the resource/typing/doc renames there.

## Verification

- `FrameworkTests` 158/158, `HogwartsMPTests` 41/41.
- `HogwartsMPServer`, `HogwartsMPClient` and `FrameworkClient` build and link clean.
- `MafiaMPServer` still fails to build, from breakage pre-existing on `develop` and unrelated to this change (missing `scripting/builtins/property.h` in `human.cpp`/`vehicle.cpp`, `Chat::SendToPlayer` in `player.cpp`). The file touched here, `server.cpp`, compiles.
