### PR TITLE
Scripting: honour optional resource dependencies

### DIFF
--- a/code/framework/src/scripting/resource/package_manifest.cpp
+++ b/code/framework/src/scripting/resource/package_manifest.cpp
@@ -8,6 +8,7 @@
 
 #include "package_manifest.h"
 
+#include <logging/logger.h>
 #include <utils/vfs.h>
 
 #include <fstream>
@@ -115,9 +116,15 @@ namespace Framework::Scripting {
                         rd.name = dep.get<std::string>();
                         rd.version = "*";
                     } else if (dep.is_object()) {
-                        rd.name = dep.value("name", "");
-                        rd.version = dep.value("version", "*");
-                        rd.optional = dep.value("optional", false);
+                        // value() throws type_error.302 on a mismatch, which would drop the whole resource over one mistyped field.
+                        const auto str = [&](const char *key, const char *fallback) { const auto it = dep.find(key); return (it != dep.end() && it->is_string()) ? it->get<std::string>() : fallback; };
+                        rd.name = str("name", "");
+                        rd.version = str("version", "*");
+                        const auto optionalIt = dep.find("optional");
+                        rd.optional = optionalIt != dep.end() && optionalIt->is_boolean() && optionalIt->get<bool>();
+                        if (optionalIt != dep.end() && !optionalIt->is_boolean()) {
+                            Logging::GetLogger(FRAMEWORK_INNER_SCRIPTING)->warn("Dependency '{}': 'optional' must be a boolean; treating it as required", rd.name);
+                        }
                     }
                     if (!rd.name.empty()) {
                         _mafiahubConfig.resourceDependencies.push_back(rd);

--- a/code/framework/src/scripting/resource/resource.cpp
+++ b/code/framework/src/scripting/resource/resource.cpp
@@ -121,6 +121,22 @@ namespace Framework::Scripting {
         return false;
     }
 
+    bool Resource::IsOptionalDependency(std::string_view resourceName) const {
+        const auto &deps = _manifest.GetMafiaHubConfig().resourceDependencies;
+        bool found       = false;
+        for (const auto &dep : deps) {
+            if (dep.name != resourceName) {
+                continue;
+            }
+            // A duplicate declaration that omits the flag makes the whole dependency required.
+            if (!dep.optional) {
+                return false;
+            }
+            found = true;
+        }
+        return found;
+    }
+
     std::string Resource::ResolvePath(const std::string &relative) const {
         if (relative.empty()) {
             return "";

--- a/code/framework/src/scripting/resource/resource.h
+++ b/code/framework/src/scripting/resource/resource.h
@@ -99,6 +99,9 @@ namespace Framework::Scripting {
         bool HasExport(std::string_view exportName) const;
         bool DependsOn(std::string_view resourceName) const;
 
+        // True only if every declaration of this dependency is marked optional.
+        bool IsOptionalDependency(std::string_view resourceName) const;
+
         // Resolved against the resource root, in execution order: shared scripts first.
         std::vector<std::string> GetServerScripts() const;
         std::vector<std::string> GetClientScripts() const;

--- a/code/framework/src/scripting/resource/resource_manager.cpp
+++ b/code/framework/src/scripting/resource/resource_manager.cpp
@@ -500,15 +500,21 @@ namespace Framework::Scripting {
         // Start dependencies first
         auto deps = GetDependencies(name);
         for (const auto &depName : deps) {
-            // Uninstalled optional dependency: ValidateDependencies already let it through, so
-            // recursing here would fail the dependent with "Resource not found".
-            if (!HasResource(depName) && IsDependencyOptional(name, depName)) {
+            const bool optional = IsDependencyOptional(name, depName);
+
+            // ValidateDependencies already let this one through; recursing would undo that with "Resource not found".
+            if (!HasResource(depName) && (optional || _config.warnOnMissingDependency)) {
                 continue;
             }
 
             if (!IsResourceRunning(depName)) {
                 auto result = StartResource(depName);
                 if (!result) {
+                    // Installed-but-broken has to degrade like missing, or 'optional' means two things.
+                    if (optional) {
+                        Logging::GetLogger(FRAMEWORK_INNER_SCRIPTING)->warn("Resource '{}' continues without optional dependency '{}': {}", name, depName, result.GetError());
+                        continue;
+                    }
                     return ResourceOperationResult("Failed to start dependency '" + depName + "': " + result.GetError());
                 }
             }

--- a/code/framework/src/scripting/resource/resource_manager.cpp
+++ b/code/framework/src/scripting/resource/resource_manager.cpp
@@ -303,19 +303,39 @@ namespace Framework::Scripting {
         }
     }
 
+    bool ResourceManager::IsDependencyOptionalUnlocked(std::string_view name, std::string_view depName) const {
+        auto it = _resources.find(name);
+        if (it == _resources.end() || !it->second) {
+            return false;
+        }
+        return it->second->IsOptionalDependency(depName);
+    }
+
+    bool ResourceManager::IsDependencyOptional(std::string_view name, std::string_view depName) const {
+        std::scoped_lock resourceLock(_resourcesMutex);
+        return IsDependencyOptionalUnlocked(name, depName);
+    }
+
     bool ResourceManager::ValidateDependencies(std::string &outError) const {
         std::scoped_lock graphLock(_graphMutex);
         std::scoped_lock resourceLock(_resourcesMutex);
 
         for (const auto &[name, deps] : _dependencies) {
             for (const auto &depName : deps) {
-                if (!_resources.contains(depName)) {
-                    if (_config.warnOnMissingDependency) {
-                        Logging::GetLogger(FRAMEWORK_INNER_SCRIPTING)->warn("Resource '{}' depends on missing resource '{}'", name, depName);
-                    } else {
-                        outError = "Resource '" + name + "' depends on missing resource '" + depName + "'";
-                        return false;
-                    }
+                if (_resources.contains(depName)) {
+                    continue;
+                }
+
+                if (IsDependencyOptionalUnlocked(name, depName)) {
+                    Logging::GetLogger(FRAMEWORK_INNER_SCRIPTING)->warn("Resource '{}' skips missing optional dependency '{}'", name, depName);
+                    continue;
+                }
+
+                if (_config.warnOnMissingDependency) {
+                    Logging::GetLogger(FRAMEWORK_INNER_SCRIPTING)->warn("Resource '{}' depends on missing resource '{}'", name, depName);
+                } else {
+                    outError = "Resource '" + name + "' depends on missing resource '" + depName + "'";
+                    return false;
                 }
             }
         }
@@ -480,6 +500,12 @@ namespace Framework::Scripting {
         // Start dependencies first
         auto deps = GetDependencies(name);
         for (const auto &depName : deps) {
+            // Uninstalled optional dependency: ValidateDependencies already let it through, so
+            // recursing here would fail the dependent with "Resource not found".
+            if (!HasResource(depName) && IsDependencyOptional(name, depName)) {
+                continue;
+            }
+
             if (!IsResourceRunning(depName)) {
                 auto result = StartResource(depName);
                 if (!result) {

--- a/code/framework/src/scripting/resource/resource_manager.h
+++ b/code/framework/src/scripting/resource/resource_manager.h
@@ -395,6 +395,10 @@ namespace Framework::Scripting {
         // Compute topological sort for load order
         std::vector<std::string> ComputeLoadOrder() const;
 
+        // Manifest lookup for optionality; the graph only carries names, not the flag.
+        bool IsDependencyOptional(std::string_view name, std::string_view depName) const;
+        bool IsDependencyOptionalUnlocked(std::string_view name, std::string_view depName) const;
+
         // True if the dependency graph has a cycle (can't fully topo-sort).
         bool HasDependencyCycle() const;
 

--- a/code/tests/modules/resource_manager_ut.h
+++ b/code/tests/modules/resource_manager_ut.h
@@ -14,6 +14,7 @@
 #include <cppfs/FileHandle.h>
 #include <cppfs/fs.h>
 
+#include <algorithm>
 #include <cstdlib>
 #include <fstream>
 
@@ -483,6 +484,132 @@ MODULE(resource_manager, {
 
         auto dependents = manager.GetDependents("parent-res");
         EQUALS(dependents.count("child-res"), 1u);
+
+        engine.Shutdown();
+        TestManagerHelper::Cleanup();
+    });
+
+    IT("StartAll skips a missing optional dependency", {
+        TestManagerHelper::Cleanup();
+        TestManagerHelper::CreateTestResource("opt-user", R"({
+            "name": "opt-user",
+            "version": "1.0.0",
+            "mafiahub": {
+                "resourceDependencies": [{"name": "opt-absent", "optional": true}]
+            }
+        })");
+
+        NodeEngine engine;
+
+        EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
+
+        ResourceManagerConfig config;
+        config.resourcesPath = TestManagerHelper::GetTestResourcePath();
+
+        ResourceManager manager(&engine, config);
+        manager.DiscoverResources();
+
+        auto result = manager.StartAll();
+        EQUALS(static_cast<bool>(result), true);
+        // StartAll reports Ok even when a resource fails to start, so assert on the resource itself.
+        EQUALS(manager.IsResourceRunning("opt-user"), true);
+
+        engine.Shutdown();
+        TestManagerHelper::Cleanup();
+    });
+
+    IT("StartAll fails on a missing required dependency", {
+        TestManagerHelper::Cleanup();
+        TestManagerHelper::CreateTestResource("req-user", R"({
+            "name": "req-user",
+            "version": "1.0.0",
+            "mafiahub": {
+                "resourceDependencies": [{"name": "req-absent"}]
+            }
+        })");
+
+        NodeEngine engine;
+
+        EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
+
+        ResourceManagerConfig config;
+        config.resourcesPath = TestManagerHelper::GetTestResourcePath();
+
+        ResourceManager manager(&engine, config);
+        manager.DiscoverResources();
+
+        auto result = manager.StartAll();
+        EQUALS(static_cast<bool>(result), false);
+        EQUALS(result.GetError(), std::string("Resource 'req-user' depends on missing resource 'req-absent'"));
+
+        engine.Shutdown();
+        TestManagerHelper::Cleanup();
+    });
+
+    IT("optional dependency still orders the load when it is installed", {
+        TestManagerHelper::Cleanup();
+        TestManagerHelper::CreateTestResource("opt-present", R"({
+            "name": "opt-present",
+            "version": "1.0.0"
+        })");
+        TestManagerHelper::CreateTestResource("opt-consumer", R"({
+            "name": "opt-consumer",
+            "version": "1.0.0",
+            "mafiahub": {
+                "resourceDependencies": [{"name": "opt-present", "optional": true}]
+            }
+        })");
+
+        NodeEngine engine;
+
+        EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
+
+        ResourceManagerConfig config;
+        config.resourcesPath = TestManagerHelper::GetTestResourcePath();
+
+        ResourceManager manager(&engine, config);
+        manager.DiscoverResources();
+
+        auto order      = manager.GetLoadOrder();
+        auto providerIt = std::find(order.begin(), order.end(), "opt-present");
+        auto consumerIt = std::find(order.begin(), order.end(), "opt-consumer");
+        EQUALS(providerIt != order.end(), true);
+        EQUALS(consumerIt != order.end(), true);
+        EQUALS(providerIt < consumerIt, true);
+
+        manager.StartAll();
+        EQUALS(manager.IsResourceRunning("opt-present"), true);
+        EQUALS(manager.IsResourceRunning("opt-consumer"), true);
+
+        engine.Shutdown();
+        TestManagerHelper::Cleanup();
+    });
+
+    IT("a dependency declared both optional and required stays required", {
+        TestManagerHelper::Cleanup();
+        TestManagerHelper::CreateTestResource("dup-user", R"({
+            "name": "dup-user",
+            "version": "1.0.0",
+            "mafiahub": {
+                "resourceDependencies": [
+                    {"name": "dup-absent", "optional": true},
+                    {"name": "dup-absent"}
+                ]
+            }
+        })");
+
+        NodeEngine engine;
+
+        EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
+
+        ResourceManagerConfig config;
+        config.resourcesPath = TestManagerHelper::GetTestResourcePath();
+
+        ResourceManager manager(&engine, config);
+        manager.DiscoverResources();
+
+        auto result = manager.StartAll();
+        EQUALS(static_cast<bool>(result), false);
 
         engine.Shutdown();
         TestManagerHelper::Cleanup();

--- a/code/tests/modules/resource_manager_ut.h
+++ b/code/tests/modules/resource_manager_ut.h
@@ -681,6 +681,36 @@ MODULE(resource_manager, {
         TestManagerHelper::Cleanup();
     });
 
+    IT("a mistyped optional flag keeps the resource and treats the dependency as required", {
+        TestManagerHelper::Cleanup();
+        TestManagerHelper::CreateTestResource("badflag-user", R"({
+            "name": "badflag-user",
+            "version": "1.0.0",
+            "mafiahub": {
+                "resourceDependencies": [{"name": "badflag-absent", "optional": "true"}]
+            }
+        })");
+
+        NodeEngine engine;
+
+        EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
+
+        ResourceManagerConfig config;
+        config.resourcesPath = TestManagerHelper::GetTestResourcePath();
+
+        ResourceManager manager(&engine, config);
+        manager.DiscoverResources();
+
+        // The manifest still parses, so the resource is discovered rather than dropped.
+        EQUALS(manager.HasResource("badflag-user"), true);
+
+        auto result = manager.StartAll();
+        EQUALS(static_cast<bool>(result), false);
+
+        engine.Shutdown();
+        TestManagerHelper::Cleanup();
+    });
+
     // ==================== Statistics ====================
 
     IT("GetRunningResourceCount returns zero when no resources running", {

--- a/code/tests/modules/resource_manager_ut.h
+++ b/code/tests/modules/resource_manager_ut.h
@@ -615,6 +615,72 @@ MODULE(resource_manager, {
         TestManagerHelper::Cleanup();
     });
 
+    IT("an installed optional dependency that fails to start does not fail the dependent", {
+        TestManagerHelper::Cleanup();
+        // No server/main.js is written, so this one fails with "Script not found".
+        TestManagerHelper::CreateTestResource("opt-broken", R"({
+            "name": "opt-broken",
+            "version": "1.0.0",
+            "mafiahub": {
+                "serverScripts": ["server/main.js"]
+            }
+        })");
+        TestManagerHelper::CreateTestResource("opt-tolerant", R"({
+            "name": "opt-tolerant",
+            "version": "1.0.0",
+            "mafiahub": {
+                "resourceDependencies": [{"name": "opt-broken", "optional": true}]
+            }
+        })");
+
+        NodeEngine engine;
+
+        EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
+
+        ResourceManagerConfig config;
+        config.resourcesPath = TestManagerHelper::GetTestResourcePath();
+
+        ResourceManager manager(&engine, config);
+        manager.DiscoverResources();
+
+        manager.StartAll();
+        EQUALS(manager.IsResourceRunning("opt-broken"), false);
+        EQUALS(manager.IsResourceRunning("opt-tolerant"), true);
+
+        engine.Shutdown();
+        TestManagerHelper::Cleanup();
+    });
+
+    IT("warnOnMissingDependency starts a resource whose required dependency is absent", {
+        TestManagerHelper::Cleanup();
+        TestManagerHelper::CreateTestResource("warn-user", R"({
+            "name": "warn-user",
+            "version": "1.0.0",
+            "mafiahub": {
+                "resourceDependencies": [{"name": "warn-absent"}]
+            }
+        })");
+
+        NodeEngine engine;
+
+        EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
+
+        ResourceManagerConfig config;
+        config.resourcesPath            = TestManagerHelper::GetTestResourcePath();
+        config.warnOnMissingDependency  = true;
+
+        ResourceManager manager(&engine, config);
+        manager.DiscoverResources();
+
+        auto result = manager.StartAll();
+        EQUALS(static_cast<bool>(result), true);
+        // Validation only warns, so the start gate has to let the dependency through too.
+        EQUALS(manager.IsResourceRunning("warn-user"), true);
+
+        engine.Shutdown();
+        TestManagerHelper::Cleanup();
+    });
+
     // ==================== Statistics ====================
 
     IT("GetRunningResourceCount returns zero when no resources running", {


### PR DESCRIPTION
`optional` was parsed onto `ResourceDependency` and never read, so a missing dependency always blocked the boot. `warnOnMissingDependency` was the only escape and is global, so declaring a real-but-optional dependency would make a partial install fail to start.

`ValidateDependencies` now skips a missing dependency its declarer marked optional, and `StartResource` stops recursing into one -- that second gate would otherwise fail the dependent with 'Resource not found' right after validation let it through.

A dependency declared twice stays required unless every declaration is optional. `ComputeLoadOrder` is untouched: it already ignores deps absent from `_resource`s, and changing it would break cycle detection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resources can now declare dependencies as optional.
  * Installed optional dependencies continue to load in the correct order.
  * Resource startup continues when an installed optional dependency fails to start.

* **Bug Fixes**
  * Missing optional dependencies are skipped with a warning instead of preventing resource startup.
  * Required missing dependencies continue to trigger the appropriate warning or error.
  * Duplicate dependency declarations are treated as required when any declaration is non-optional.
  * Invalid optional-dependency values no longer discard the resource and are treated as required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->