### PR TITLE
Voice: attenuate from the character, pan from the camera

### DIFF
--- a/code/framework/src/voice/client/mixer.cpp
+++ b/code/framework/src/voice/client/mixer.cpp
@@ -48,8 +48,8 @@ namespace Framework::Voice {
     SpeakerGain ComputeGain(const ListenerTransform &listener, const glm::vec3 &speakerPos, float range) {
         SpeakerGain gain;
 
-        const glm::vec3 delta = speakerPos - listener.position;
-        const float distance  = glm::length(delta);
+        const glm::vec3 attenuationFrom = glm::dot(listener.attenuationPosition, listener.attenuationPosition) > 0.0f ? listener.attenuationPosition : listener.position;
+        const float distance            = glm::length(speakerPos - attenuationFrom);
 
         if (range <= 0.0f || distance > range) {
             return gain; // silent
@@ -63,9 +63,13 @@ namespace Framework::Voice {
         const float edgeFade    = 1.0f - (distance / range);
         const float attenuation = std::clamp(rolloff * edgeFade, 0.0f, 1.0f);
 
-        // Pan on the listener's right axis. Degenerate transforms fall back to centred.
+        // Pan on the listener's right axis, measured from the pan origin rather than the distance
+        // origin: direction should follow what the player is looking from.
+        const glm::vec3 panDelta = speakerPos - listener.position;
+        const float panDistance  = glm::length(panDelta);
+
         float pan = 0.0f;
-        if (distance > 0.0001f) {
+        if (panDistance > 0.0001f) {
             glm::vec3 right = listener.right;
             if (glm::dot(right, right) <= 0.0001f) {
                 right = glm::cross(listener.forward, listener.up);
@@ -73,7 +77,7 @@ namespace Framework::Voice {
 
             const float rightLen = glm::length(right);
             if (rightLen > 0.0001f) {
-                pan = glm::dot(delta / distance, right / rightLen) * kMaxPan;
+                pan = glm::dot(panDelta / panDistance, right / rightLen) * kMaxPan;
             }
         }
 

--- a/code/framework/src/voice/client/mixer.h
+++ b/code/framework/src/voice/client/mixer.h
@@ -21,6 +21,11 @@ namespace Framework::Voice {
         glm::vec3 forward {0.0f, 0.0f, -1.0f};
         glm::vec3 up {0.0f, 1.0f, 0.0f};
         glm::vec3 right {0.0f}; // zero -> derived from forward and up
+
+        // Distance origin, when it differs from the pan origin above: a third-person game puts the
+        // camera in `position` and the character here, or two touching characters sound a boom
+        // apart. Zero -> use position, as with `right`.
+        glm::vec3 attenuationPosition {0.0f};
     };
 
     // Per-ear linear gain for one speaker, in [0, 1].


### PR DESCRIPTION
A third-person game could only publish one listener position, so distance was measured from the camera. With a camera boom of a few meters -- 3.4m as measured in Hogwarts Legacy -- two characters standing on top of each other sound a boom apart, and any whisper tier is smaller than the error. FiveM ships the same behavior and [documents it as a known issue](docs.fivem.net/docs/scripting-manual/voice/): `Currently, directional audio's position is relative to the game camera, a solution is being worked on so directional audio is relative to the player's ped entity instead.`

Another blog detailing different approaches to third-person listener position: teedteed.wordpress.com/2018/02/01/third-person-audio-listener-position/

`ListenerTransform` gains `attenuationPosition`: distance is measured from it, direction still from position, so loudness follows where the body stands while panning follows what the player sees. Zero means unset and falls back to position, the same convention `right` already uses, so existing games are unaffected until they publish one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a separate audio attenuation origin from the listener’s panning position.
  * Distance-based volume now uses the configured attenuation origin when provided, while stereo panning remains based on the listener’s primary position.
  * If no attenuation origin is set, the listener’s primary position is used as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->