### PR TITLE
Logging: fix spdlog integration (shared sinks, races, shutdown, hot-path cost)

### DIFF
--- a/code/framework/src/external/imgui/widgets/console.cpp
+++ b/code/framework/src/external/imgui/widgets/console.cpp
@@ -18,7 +18,7 @@
 #include <logging/logger.h>
 
 namespace Framework::External::ImGUI::Widgets {
-    Console::Console(std::shared_ptr<Utils::CommandProcessor> commandProcessor): _commandProcessor(commandProcessor), _logger(Logging::GetLogger("Console").get()) {}
+    Console::Console(std::shared_ptr<Utils::CommandProcessor> commandProcessor): _commandProcessor(commandProcessor), _logger(Logging::GetLogger("Console")) {}
 
     void Console::OnOpen() {
         _focusOnInput = true;
@@ -83,9 +83,9 @@ namespace Framework::External::ImGUI::Widgets {
             const float reservedHeight = AreControlsLocked() ? -(ImGui::GetStyle().ItemSpacing.y + ImGui::GetFrameHeightWithSpacing()) : 0;
             ImGui::BeginChild("##logs", ImVec2(0, reservedHeight), 0, AreControlsLocked() ? ImGuiWindowFlags_HorizontalScrollbar : ImGuiWindowFlags_NoScrollbar);
             if (ringBuffer != nullptr) {
-                std::vector<std::string> log_message = ringBuffer->last_formatted();
-                for (std::string &log : log_message) {
-                    FormatLog(log);
+                RefreshLogCache(ringBuffer);
+                for (const LogLine &line : _cachedLogLines) {
+                    DrawLog(line);
                 }
             }
 
@@ -273,51 +273,79 @@ namespace Framework::External::ImGUI::Widgets {
         }
     }
 
-    void Console::FormatLog(std::string log) {
-        std::regex brackets_regex("\\[.*?\\]", std::regex_constants::ECMAScript);
+    void Console::RefreshLogCache(const std::shared_ptr<spdlog::sinks::ringbuffer_sink_mt> &ringBuffer) {
+        const auto logEventCount = Logging::GetInstance()->GetLogEventCount();
+        if (_logCacheValid && logEventCount == _cachedLogEventCount) {
+            return;
+        }
+
+        _cachedLogLines.clear();
+        for (const std::string &log : ringBuffer->last_formatted()) {
+            _cachedLogLines.push_back(ParseLog(log));
+        }
+        _cachedLogEventCount = logEventCount;
+        _logCacheValid       = true;
+    }
+
+    Console::LogLine Console::ParseLog(const std::string &log) {
+        static const std::regex brackets_regex("\\[.*?\\]", std::regex_constants::ECMAScript);
 
         auto brackets_begin = std::sregex_iterator(log.begin(), log.end(), brackets_regex);
         auto brackets_end   = std::sregex_iterator();
 
+        LogLine line;
         int logCount = 1;
         for (std::sregex_iterator i = brackets_begin; i != brackets_end; ++i) {
             const std::smatch &match = *i;
             std::string match_str    = match.str();
 
             if (logCount == 1) {
-                ImGui::TextColored(ImVec4(0.5f, 1, 1, 1), "%s", match_str.c_str());
-                ImGui::SameLine();
+                line.push_back({ImVec4(0.5f, 1, 1, 1), true, match_str});
             }
 
             if (logCount == 2) {
-                ImGui::TextColored(ImVec4(0.5f, 0.5f, 1, 1), "%s", match_str.c_str());
-                ImGui::SameLine();
+                line.push_back({ImVec4(0.5f, 0.5f, 1, 1), true, match_str});
             }
 
             if (logCount == 3) {
+                ImVec4 levelColor(1, 0, 0.5f, 1);
                 if (match_str == "[info]")
-                    ImGui::TextColored(ImVec4(0, 1, 0, 1), "%s", match_str.c_str());
+                    levelColor = ImVec4(0, 1, 0, 1);
                 else if (match_str == "[debug]")
-                    ImGui::TextColored(ImVec4(0, 0, 1, 1), "%s", match_str.c_str());
+                    levelColor = ImVec4(0, 0, 1, 1);
                 else if (match_str == "[error]")
-                    ImGui::TextColored(ImVec4(1, 0, 0, 1), "%s", match_str.c_str());
+                    levelColor = ImVec4(1, 0, 0, 1);
                 else if (match_str == "[warning]")
-                    ImGui::TextColored(ImVec4(1, 1, 0, 1), "%s", match_str.c_str());
+                    levelColor = ImVec4(1, 1, 0, 1);
                 else if (match_str == "[trace]")
-                    ImGui::TextColored(ImVec4(0.5f, 0, 1, 1), "%s", match_str.c_str());
+                    levelColor = ImVec4(0.5f, 0, 1, 1);
                 else if (match_str == "[critical]")
-                    ImGui::TextColored(ImVec4(1, 0.5f, 0, 1), "%s", match_str.c_str());
-                else
-                    ImGui::TextColored(ImVec4(1, 0, 0.5f, 1), "%s", match_str.c_str());
+                    levelColor = ImVec4(1, 0.5f, 0, 1);
+                line.push_back({levelColor, true, match_str});
 
-                ImGui::SameLine();
                 const auto &suffix = match.suffix();
                 if (suffix.length() > 0) {
-                    ImGui::Text("%s", suffix.str().c_str());
+                    line.push_back({ImVec4(), false, suffix.str()});
                 }
             }
 
             logCount++;
+        }
+        return line;
+    }
+
+    void Console::DrawLog(const LogLine &line) {
+        for (size_t i = 0; i < line.size(); i++) {
+            if (i > 0) {
+                ImGui::SameLine();
+            }
+            const LogSegment &segment = line[i];
+            if (segment.colored) {
+                ImGui::TextColored(segment.color, "%s", segment.text.c_str());
+            }
+            else {
+                ImGui::Text("%s", segment.text.c_str());
+            }
         }
     }
 } // namespace Framework::External::ImGUI::Widgets

--- a/code/framework/src/external/imgui/widgets/console.h
+++ b/code/framework/src/external/imgui/widgets/console.h
@@ -14,6 +14,7 @@
 
 #include <function2.hpp>
 #include <memory>
+#include <spdlog/sinks/ringbuffer_sink.h>
 #include <spdlog/spdlog.h>
 #include <vector>
 
@@ -23,9 +24,22 @@ namespace Framework::External::ImGUI::Widgets {
         using MenuBarProc = fu2::function<void() const>;
 
       protected:
+        struct LogSegment {
+            ImVec4 color;
+            bool colored;
+            std::string text;
+        };
+        using LogLine = std::vector<LogSegment>;
+
         std::shared_ptr<Utils::CommandProcessor> _commandProcessor;
 
-        spdlog::logger *_logger;
+        std::shared_ptr<spdlog::logger> _logger;
+
+        std::vector<LogLine> _cachedLogLines;
+
+        uint64_t _cachedLogEventCount = 0;
+
+        bool _logCacheValid = false;
 
         bool _autoScroll = true;
 
@@ -53,7 +67,11 @@ namespace Framework::External::ImGUI::Widgets {
 
         void SendCommand(const std::string &command) const;
 
-        static void FormatLog(std::string log);
+        void RefreshLogCache(const std::shared_ptr<spdlog::sinks::ringbuffer_sink_mt> &ringBuffer);
+
+        static LogLine ParseLog(const std::string &log);
+
+        static void DrawLog(const LogLine &line);
 
       public:
         explicit Console(std::shared_ptr<Utils::CommandProcessor> commandProcessor);

--- a/code/framework/src/integrations/client/instance.cpp
+++ b/code/framework/src/integrations/client/instance.cpp
@@ -479,6 +479,10 @@ namespace Framework::Integrations::Client {
         CoreModules::Reset();
 
         Lifecycle::Shutdown();
+
+        // Last: flush and tear down the async logging thread pool before static
+        // destruction can race it.
+        Logging::GetInstance()->Shutdown();
     }
 
     void Instance::Update() {

--- a/code/framework/src/integrations/server/instance.cpp
+++ b/code/framework/src/integrations/server/instance.cpp
@@ -939,6 +939,10 @@ namespace Framework::Integrations::Server {
         CoreModules::Reset();
 
         Lifecycle::Shutdown();
+
+        // Last: flush and tear down the async logging thread pool before static
+        // destruction can race it.
+        Logging::GetInstance()->Shutdown();
     }
 
     void Instance::Update() {

--- a/code/framework/src/logging/logger.cpp
+++ b/code/framework/src/logging/logger.cpp
@@ -10,10 +10,13 @@
 
 #include <spdlog/async.h>
 #include <spdlog/details/log_msg.h>
+#include <spdlog/details/null_mutex.h>
 #include <spdlog/sinks/base_sink.h>
 #include <spdlog/sinks/null_sink.h>
 #include <spdlog/sinks/rotating_file_sink.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
+
+#include <vector>
 
 namespace Framework::Logging {
     namespace {
@@ -31,6 +34,22 @@ namespace Framework::Logging {
           private:
             Logger *_owner;
         };
+
+        // Only touches an atomic, so no locking is needed.
+        class CountingSink final : public spdlog::sinks::base_sink<spdlog::details::null_mutex> {
+          public:
+            explicit CountingSink(Logger *owner): _owner(owner) {}
+
+          protected:
+            void sink_it_(const spdlog::details::log_msg &) override {
+                _owner->CountLogEvent();
+            }
+
+            void flush_() override {}
+
+          private:
+            Logger *_owner;
+        };
     } // namespace
 
     Logger::Logger() {
@@ -39,11 +58,35 @@ namespace Framework::Logging {
         spdlog::flush_on(spdlog::level::err);
         spdlog::flush_every(std::chrono::seconds(2));
 
-        // Support for async logging
-        spdlog::init_thread_pool(10000, 4); // queue with 10K items and 4 backing threads.
+        // Support for async logging. A single worker keeps messages in order; more
+        // workers may dequeue and write them out of order.
+        spdlog::init_thread_pool(10000, 1); // queue with 10K items and 1 backing thread.
 
         _forwardingSink = std::make_shared<ForwardingSink>(this);
-        _forwardingSink->set_level(spdlog::level::trace);
+        _forwardingSink->set_level(spdlog::level::off); // opened by SetLogForwarder
+    }
+
+    void Logger::EnsureSharedSinks() {
+        if (_consoleSink) {
+            return;
+        }
+
+        const auto consoleSink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
+        consoleSink->set_level(spdlog::level::debug);
+        consoleSink->set_pattern("[%H:%M:%S] [%^%l%$] [%n] %v");
+        _consoleSink = consoleSink;
+
+        const auto fileLogName = _logFolder + "/" + _logName + ".log";
+        _fileSink              = std::make_shared<spdlog::sinks::rotating_file_sink_mt>(fileLogName, _maxFileSize, _maxFileCount);
+        _fileSink->set_level(spdlog::level::trace);
+
+        if (!_ringbufferSink) {
+            _ringbufferSink = std::make_shared<spdlog::sinks::ringbuffer_sink_mt>(_maxRingBufferSize);
+            _ringbufferSink->set_level(spdlog::level::debug);
+        }
+
+        _countingSink = std::make_shared<CountingSink>(this);
+        _countingSink->set_level(spdlog::level::trace);
     }
 
     std::shared_ptr<spdlog::logger> Logger::Get(const char *logName, bool async) {
@@ -54,9 +97,11 @@ namespace Framework::Logging {
                 return logger;
             }
 
-            auto dummyLogger = spdlog::create<spdlog::sinks::null_sink_mt>(suppressedLogger);
-            _loggers.emplace(suppressedLogger, dummyLogger);
-            return dummyLogger;
+            std::lock_guard lock(_creationMutex);
+            if (auto logger = spdlog::get(suppressedLogger)) {
+                return logger;
+            }
+            return spdlog::create<spdlog::sinks::null_sink_mt>(suppressedLogger);
         }
 
         // If the logger already exists, return it
@@ -64,27 +109,22 @@ namespace Framework::Logging {
             return logger;
         }
 
-        // Build the different sinks
-        const auto consoleLogger = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
-        consoleLogger->set_level(spdlog::level::debug);
-        consoleLogger->set_pattern("[%H:%M:%S] [%^%l%$] [%n] %v");
-
-        const auto fileLogName = _logFolder + "/" + _logName + ".log";
-        const auto fileLogger  = std::make_shared<spdlog::sinks::rotating_file_sink_mt>(fileLogName, _maxFileSize, _maxFileCount);
-        fileLogger->set_level(spdlog::level::trace);
-
-        if (!_ringbufferSink) {
-            _ringbufferSink = std::make_shared<spdlog::sinks::ringbuffer_sink_mt>(_maxRingBufferSize);
-            _ringbufferSink->set_level(spdlog::level::debug);
+        std::lock_guard lock(_creationMutex);
+        if (auto logger = spdlog::get(logName)) {
+            return logger;
         }
-        std::vector<spdlog::sink_ptr> sinks {consoleLogger, fileLogger, _ringbufferSink, _forwardingSink};
+
+        EnsureSharedSinks();
+        std::vector<spdlog::sink_ptr> sinks {_consoleSink, _fileSink, _ringbufferSink, _countingSink, _forwardingSink};
 
         // Create our logging instance
         std::shared_ptr<spdlog::logger> spdLogger;
 
-        // Create the logger depending on the type we want
-        if (async) {
-            spdLogger = std::make_shared<spdlog::async_logger>(logName, sinks.begin(), sinks.end(), spdlog::thread_pool(), spdlog::async_overflow_policy::block);
+        // Create the logger depending on the type we want. After Shutdown() the thread
+        // pool is gone, so late loggers silently fall back to synchronous.
+        const auto threadPool = spdlog::thread_pool();
+        if (async && threadPool) {
+            spdLogger = std::make_shared<spdlog::async_logger>(logName, sinks.begin(), sinks.end(), threadPool, spdlog::async_overflow_policy::block);
         }
         else {
             spdLogger = std::make_shared<spdlog::logger>(logName, sinks.begin(), sinks.end());
@@ -95,19 +135,30 @@ namespace Framework::Logging {
         try {
             spdlog::register_logger(spdLogger);
         }
-        catch (std::exception &ex) {
-            return nullptr;
+        catch (std::exception &) {
+            if (auto existing = spdlog::get(logName)) {
+                return existing;
+            }
+            // Unregistered but functional; callers must never receive nullptr.
         }
 
-        _loggers.emplace(logName, spdLogger);
-
         return spdLogger;
+    }
+
+    void Logger::Shutdown() {
+        _cacheGeneration.fetch_add(1, std::memory_order_relaxed);
+        spdlog::apply_all([](const std::shared_ptr<spdlog::logger> &logger) {
+            logger->flush();
+        });
+        spdlog::shutdown();
     }
 
     void Logger::SetLogForwarder(LogForwarder forwarder, int threshold) {
         std::lock_guard lock(_forwarderMutex);
         _forwarder          = std::move(forwarder);
         _forwarderThreshold = threshold;
+        // Filter at the sink so sub-threshold messages skip the mutex and string copies.
+        _forwardingSink->set_level(_forwarder ? static_cast<spdlog::level::level_enum>(threshold) : spdlog::level::off);
     }
 
     void Logger::ForwardLog(int level, const std::string &name, const std::string &message) {
@@ -128,6 +179,29 @@ namespace Framework::Logging {
     }
 
     std::shared_ptr<spdlog::logger> GetLogger(const char *name, bool async) {
-        return GetInstance()->Get(name, async);
+        // spdlog::get locks the global registry per call, so cache handles per thread.
+        struct CacheEntry {
+            const char *name;
+            bool async;
+            uint32_t generation;
+            std::shared_ptr<spdlog::logger> logger;
+        };
+        thread_local std::vector<CacheEntry> cache;
+
+        const auto generation = Logger::GetCacheGeneration();
+        for (const auto &entry : cache) {
+            if (entry.name == name && entry.async == async && entry.generation == generation) {
+                return entry.logger;
+            }
+        }
+
+        auto logger = GetInstance()->Get(name, async);
+        if (logger) {
+            std::erase_if(cache, [generation](const CacheEntry &entry) {
+                return entry.generation != generation;
+            });
+            cache.push_back({name, async, generation, logger});
+        }
+        return logger;
     }
 } // namespace Framework::Logging

--- a/code/framework/src/logging/logger.cpp
+++ b/code/framework/src/logging/logger.cpp
@@ -142,7 +142,7 @@ namespace Framework::Logging {
     void Logger::Shutdown() {
         // Ordered against Get() so no logger can bind the thread pool mid-teardown.
         std::lock_guard lock(_creationMutex);
-        _cacheGeneration.fetch_add(1, std::memory_order_relaxed);
+        _cacheGeneration.fetch_add(1, std::memory_order_release);
         spdlog::apply_all([](const std::shared_ptr<spdlog::logger> &logger) {
             logger->flush();
         });

--- a/code/framework/src/logging/logger.cpp
+++ b/code/framework/src/logging/logger.cpp
@@ -20,7 +20,7 @@
 
 namespace Framework::Logging {
     namespace {
-        class ForwardingSink final : public spdlog::sinks::base_sink<std::mutex> {
+        class ForwardingSink final: public spdlog::sinks::base_sink<std::mutex> {
           public:
             explicit ForwardingSink(Logger *owner): _owner(owner) {}
 
@@ -36,7 +36,7 @@ namespace Framework::Logging {
         };
 
         // Only touches an atomic, so no locking is needed.
-        class CountingSink final : public spdlog::sinks::base_sink<spdlog::details::null_mutex> {
+        class CountingSink final: public spdlog::sinks::base_sink<spdlog::details::null_mutex> {
           public:
             explicit CountingSink(Logger *owner): _owner(owner) {}
 
@@ -90,14 +90,13 @@ namespace Framework::Logging {
     }
 
     std::shared_ptr<spdlog::logger> Logger::Get(const char *logName, bool async) {
-        // Handle pause mode logs
-        if (_loggingPaused) {
-            constexpr auto suppressedLogger = "_suppressed_logger";
-            if (auto logger = spdlog::get(suppressedLogger)) {
-                return logger;
-            }
+        // The per-thread cache in GetLogger absorbs the hot path, so this can hold the
+        // mutex throughout; that also keeps creation ordered against Shutdown().
+        std::lock_guard lock(_creationMutex);
 
-            std::lock_guard lock(_creationMutex);
+        // Handle pause mode logs
+        if (_loggingPaused.load(std::memory_order_relaxed)) {
+            constexpr auto suppressedLogger = "_suppressed_logger";
             if (auto logger = spdlog::get(suppressedLogger)) {
                 return logger;
             }
@@ -105,11 +104,6 @@ namespace Framework::Logging {
         }
 
         // If the logger already exists, return it
-        if (auto logger = spdlog::get(logName)) {
-            return logger;
-        }
-
-        std::lock_guard lock(_creationMutex);
         if (auto logger = spdlog::get(logName)) {
             return logger;
         }
@@ -146,6 +140,8 @@ namespace Framework::Logging {
     }
 
     void Logger::Shutdown() {
+        // Ordered against Get() so no logger can bind the thread pool mid-teardown.
+        std::lock_guard lock(_creationMutex);
         _cacheGeneration.fetch_add(1, std::memory_order_relaxed);
         spdlog::apply_all([](const std::shared_ptr<spdlog::logger> &logger) {
             logger->flush();
@@ -180,8 +176,9 @@ namespace Framework::Logging {
 
     std::shared_ptr<spdlog::logger> GetLogger(const char *name, bool async) {
         // spdlog::get locks the global registry per call, so cache handles per thread.
+        // Keyed by name value, not pointer: callers may pass transient buffers.
         struct CacheEntry {
-            const char *name;
+            std::string name;
             bool async;
             uint32_t generation;
             std::shared_ptr<spdlog::logger> logger;

--- a/code/framework/src/logging/logger.h
+++ b/code/framework/src/logging/logger.h
@@ -8,14 +8,13 @@
 
 #pragma once
 
+#include <atomic>
 #include <chrono>
 #include <functional>
-#include <map>
 #include <mutex>
 #include <spdlog/sinks/ringbuffer_sink.h>
 #include <spdlog/spdlog.h>
 #include <string>
-#include <unordered_map>
 
 #define FRAMEWORK_INNER_NETWORKING   "Networking"
 #define FRAMEWORK_INNER_SCRIPTING    "Scripting"
@@ -37,7 +36,8 @@ namespace Framework::Logging {
     class Logger final {
       private:
         [[maybe_unused]] std::chrono::time_point<std::chrono::system_clock> _sessionStart;
-        std::unordered_map<const char *, std::shared_ptr<spdlog::logger>> _loggers;
+        // Serializes logger/sink creation; the fast path (already-registered logger) never takes it.
+        std::mutex _creationMutex;
         std::string _logName   = "framework";
         std::string _logFolder = "logs";
         size_t _maxFileSize    = 1024 * 1024 * 10;
@@ -46,20 +46,39 @@ namespace Framework::Logging {
         std::shared_ptr<spdlog::sinks::ringbuffer_sink_mt> _ringbufferSink;
         static inline size_t _maxRingBufferSize = 128;
 
+        // Loggers writing to the same file must share one sink instance (each rotating
+        // sink tracks its size and rotates on its own file handle), so all module
+        // loggers share these.
+        std::shared_ptr<spdlog::sinks::sink> _consoleSink;
+        std::shared_ptr<spdlog::sinks::sink> _fileSink;
+        std::shared_ptr<spdlog::sinks::sink> _countingSink;
+        std::atomic<uint64_t> _logEventCount {0};
+
         std::shared_ptr<spdlog::sinks::sink> _forwardingSink;
         std::mutex _forwarderMutex;
         LogForwarder _forwarder;
         int _forwarderThreshold = spdlog::level::warn;
 
+        // Bumped whenever cached logger handles become stale (pause toggles, shutdown).
+        static inline std::atomic<uint32_t> _cacheGeneration {0};
+
+        void EnsureSharedSinks();
+
       public:
         Logger();
         ~Logger() = default;
 
-        std::shared_ptr<spdlog::logger> Get(const char *moduleName, bool async = false);
+        std::shared_ptr<spdlog::logger> Get(const char *moduleName, bool async = true);
+
+        // Flushes all loggers and tears spdlog down. Must run before static destruction
+        // begins (async loggers rely on the global thread pool being alive).
+        void Shutdown();
 
         void SetLogForwarder(LogForwarder forwarder, int threshold = spdlog::level::warn);
         void ForwardLog(int level, const std::string &name, const std::string &message);
 
+        // The name/folder/size settings only apply to loggers created afterwards; call
+        // them before the first Get().
         void SetLogName(const std::string &name) {
             _logName = name;
         }
@@ -90,6 +109,7 @@ namespace Framework::Logging {
 
         void PauseLogging(bool state) {
             _loggingPaused = state;
+            _cacheGeneration.fetch_add(1, std::memory_order_relaxed);
         }
 
         void SetMaxFileCount(size_t count) {
@@ -106,6 +126,19 @@ namespace Framework::Logging {
 
         std::shared_ptr<spdlog::sinks::ringbuffer_sink_mt> GetRingBuffer() const {
             return _ringbufferSink;
+        }
+
+        // Total messages emitted through any logger; cheap change signal for UI consumers.
+        uint64_t GetLogEventCount() const {
+            return _logEventCount.load(std::memory_order_relaxed);
+        }
+
+        void CountLogEvent() {
+            _logEventCount.fetch_add(1, std::memory_order_relaxed);
+        }
+
+        static uint32_t GetCacheGeneration() {
+            return _cacheGeneration.load(std::memory_order_relaxed);
         }
     };
 

--- a/code/framework/src/logging/logger.h
+++ b/code/framework/src/logging/logger.h
@@ -42,7 +42,7 @@ namespace Framework::Logging {
         std::string _logFolder = "logs";
         size_t _maxFileSize    = 1024 * 1024 * 10;
         size_t _maxFileCount   = 10;
-        bool _loggingPaused    = false;
+        std::atomic<bool> _loggingPaused {false};
         std::shared_ptr<spdlog::sinks::ringbuffer_sink_mt> _ringbufferSink;
         static inline size_t _maxRingBufferSize = 128;
 
@@ -104,11 +104,11 @@ namespace Framework::Logging {
         }
 
         bool IsLoggingPaused() const {
-            return _loggingPaused;
+            return _loggingPaused.load(std::memory_order_relaxed);
         }
 
         void PauseLogging(bool state) {
-            _loggingPaused = state;
+            _loggingPaused.store(state, std::memory_order_relaxed);
             _cacheGeneration.fetch_add(1, std::memory_order_relaxed);
         }
 

--- a/code/framework/src/logging/logger.h
+++ b/code/framework/src/logging/logger.h
@@ -108,8 +108,12 @@ namespace Framework::Logging {
         }
 
         void PauseLogging(bool state) {
+            // The mutex orders the flag against Get(); the release increment publishes
+            // it to the lock-free cache path, whose acquire generation load then cannot
+            // pair a new generation with a stale pause flag.
+            std::lock_guard lock(_creationMutex);
             _loggingPaused.store(state, std::memory_order_relaxed);
-            _cacheGeneration.fetch_add(1, std::memory_order_relaxed);
+            _cacheGeneration.fetch_add(1, std::memory_order_release);
         }
 
         void SetMaxFileCount(size_t count) {
@@ -138,7 +142,7 @@ namespace Framework::Logging {
         }
 
         static uint32_t GetCacheGeneration() {
-            return _cacheGeneration.load(std::memory_order_relaxed);
+            return _cacheGeneration.load(std::memory_order_acquire);
         }
     };
 


### PR DESCRIPTION
## Summary

Fixes the findings from an audit of the spdlog integration, verified against the spdlog wiki. All changes are internal to the logging layer — no peer sync or scripting surface is touched (PATCH per version semantics).

### Correctness
- **Shared sinks** — every module logger used to construct its *own* `rotating_file_sink_mt` on the same `logs/<name>.log`. spdlog requires loggers writing to one file to share a single sink instance; independent sinks each track rotation size on their own handle and clobber/truncate each other's rotated files (the rename mid-rotation outright fails on Windows while another sink holds the file open). Console, file, ring buffer and forwarding sinks are now created once and shared by all loggers.
- **No more nullptr loggers** — `Logger::Get` returned `nullptr` when `register_logger` threw (reachable via a create/create race), and none of the ~800 `GetLogger(...)->info(...)` call sites check. The loser of the race now returns the winner's registry entry.
- **Thread-safe creation** — the wrapper's own state (lazy sink init, bookkeeping) was unsynchronized while loggers are created lazily from arbitrary threads; creation is now under a mutex. The write-only `_loggers` map (keyed by `const char *` pointer identity) is gone.
- **Explicit shutdown** — `spdlog::shutdown()` was never called. With async loggers, spdlog documents this as mandatory before exit under Visual Studio; skipping it risks exit-time deadlock and drops the last ~2 s of queued messages — exactly the lines needed after a crash. Both server and client instances now flush and shut logging down as the last shutdown step; loggers requested afterwards fall back to synchronous.

### Performance
- **Per-thread logger cache** — every log call went through `spdlog::get()`, which locks the global registry per call (the wiki explicitly warns against this in hot paths; we do it per packet and per frame). `GetLogger` now keeps a per-thread cache, invalidated by generation when pause mode toggles or logging shuts down. No call-site changes needed.
- **Ordered async logging** — the thread pool drops from 4 workers to 1; spdlog documents that multiple workers dequeue out of order, which shuffled timelines in the shared log file. One worker is ample for logging throughput.
- **Forwarding sink filters at its level** — previously attached at `trace`, so every message (debug spam included) paid the sink mutex plus two string copies before being discarded by the threshold check. The sink level now mirrors the forwarder threshold (`off` when no forwarder is set).
- **ImGui console no longer re-formats per frame** — it called `last_formatted()` (lock + full re-materialization of the ring) and ran a per-call-constructed `std::regex` over every line, every frame. A new lock-free message counter (`Logger::GetLogEventCount()`) gates a cached, pre-parsed segment list; drawing just replays segments. The widget also holds its logger by `shared_ptr` instead of a raw pointer into the registry.

Also unifies the `async` default (`Logger::Get` said `false`, the free `GetLogger` said `true`; both are now `true`).

### Follow-up (not in this PR)
`HogwartsMP`'s HUD `PollLogs()` probes `last_raw(1)` to detect ring changes; it can now use `Logging::GetInstance()->GetLogEventCount()` instead.

## Testing
- macOS: `Framework`, `FrameworkServer` build clean; `RunFrameworkTests` passes 196/196 (exercises the pause-mode + cache-generation path).
- The client-only files (ImGui console widget, client instance) don't build on macOS; the console TU was syntax-checked with clang (the only errors are the pre-existing MSVC-only `_Starts_with` calls in the untouched autocomplete code). A Windows CI/build pass should confirm those targets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved console log rendering with colored metadata and message text.
  * Added more responsive log updates by refreshing displayed content only when new events are available.
  * Added reliable asynchronous logging support with automatic fallback when unavailable.

* **Bug Fixes**
  * Ensured logs are flushed and logging services shut down cleanly during application exit.
  * Improved logger reuse and consistency across application components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->