### PR TITLE
Replication: gate entity destruction on owner authority

### DIFF
--- a/code/framework/src/networking/replication/network_entity.cpp
+++ b/code/framework/src/networking/replication/network_entity.cpp
@@ -106,7 +106,17 @@ namespace Framework::Networking::Replication {
 
     void NetworkEntity::SerializeDestruction(MafiaNet::BitStream *, MafiaNet::Connection_RM3 *) {}
 
-    bool NetworkEntity::DeserializeDestruction(MafiaNet::BitStream *, MafiaNet::Connection_RM3 *) {
+    bool NetworkEntity::DeserializeDestruction(MafiaNet::BitStream *, MafiaNet::Connection_RM3 *sourceConnection) {
+        // Server authority gate (mirrors Deserialize): the base ReplicaManager3 destruction dispatch
+        // resolves the target by a NetworkID taken straight from the packet body and deletes it the
+        // moment this returns true, with no ownership check of its own. Without this gate any client
+        // could despawn arbitrary entities — other players' avatars, server-owned objects — and, via
+        // QueryRelayDestruction, have the server relay that deletion to everyone. Only honour a
+        // destruction from the entity's current owner; fail closed on a missing connection. Returning
+        // false keeps the entity alive. Clients still accept the server's authoritative destructions.
+        if (IsServerPeer() && (!sourceConnection || MafiaNet::ToPeerGuid(sourceConnection->GetRakNetGUID()) != ownerGUID)) {
+            return false;
+        }
         return true;
     }
 

--- a/code/tests/framework_ut.cpp
+++ b/code/tests/framework_ut.cpp
@@ -6,7 +6,7 @@
  * See LICENSE file in the source repository for information regarding licensing.
  */
 
-#define UNIT_MAX_MODULES 16
+#define UNIT_MAX_MODULES 24
 #include "logging/logger.h"
 #include "unit.h"
 
@@ -15,6 +15,7 @@
 #include "modules/interpolator_ut.h"
 #include "modules/result_ut.h"
 #include "modules/network_packets_ut.h"
+#include "modules/replication_authority_ut.h"
 #include "modules/state_machine_ut.h"
 #include "modules/persistent_config_ut.h"
 #include "modules/snapshot_buffer_ut.h"
@@ -38,6 +39,7 @@ int main() {
     UNIT_MODULE(interpolator);
     UNIT_MODULE(result);
     UNIT_MODULE(network_packets);
+    UNIT_MODULE(replication_authority);
     UNIT_MODULE(state_machine);
     UNIT_MODULE(persistent_config);
     UNIT_MODULE(snapshot_buffer);

--- a/code/tests/modules/replication_authority_ut.h
+++ b/code/tests/modules/replication_authority_ut.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "networking/network_client.h"
+#include "networking/network_server.h"
 #include "networking/replication/network_entity.h"
 #include "networking/replication/replication_manager.h"
 
@@ -24,16 +24,18 @@
 // (true -> the base deletes + relays the destruction, false -> the entity is kept), so a return of
 // true for a non-owner connection reproduces the vulnerability and a return of false proves the fix.
 MODULE(replication_authority, {
-    using Framework::Networking::NetworkClient;
+    using Framework::Networking::NetworkServer;
     using Framework::Networking::Replication::NetworkEntity;
     using Framework::Networking::Replication::ReplicationManager;
 
     // Two in-memory peers, never started (no socket bound): one manager put into server mode, one
-    // into client mode. Only ReplicationManager::IsServer() is exercised by the gate, and Init()
-    // just flips that flag, records the peer's guid, and attaches the plugin — none of which needs a
-    // live connection.
-    NetworkClient serverPeer;
-    NetworkClient clientPeer;
+    // into client mode. NetworkServer is used for both because the tests link Framework +
+    // FrameworkServer (NetworkClient lives in FrameworkClient, which they do not link); the server
+    // vs client role is decided by ReplicationManager::Init's flag, not by the peer type. Only
+    // ReplicationManager::IsServer() is exercised by the gate, and Init() just flips that flag,
+    // records the peer's guid, and attaches the plugin — none of which needs a live connection.
+    NetworkServer serverPeer;
+    NetworkServer clientPeer;
     auto *serverManager = serverPeer.GetReplicationManager();
     auto *clientManager = clientPeer.GetReplicationManager();
     serverManager->Init(&serverPeer, true);

--- a/code/tests/modules/replication_authority_ut.h
+++ b/code/tests/modules/replication_authority_ut.h
@@ -1,0 +1,105 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2026, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
+#pragma once
+
+#include "networking/network_client.h"
+#include "networking/replication/network_entity.h"
+#include "networking/replication/replication_manager.h"
+
+#include <mafianet/BitStream.h>
+#include <mafianet/ReplicaManager3.h>
+#include <mafianet/types.h>
+
+// Server authority over entity destruction. The base ReplicaManager3 destruction dispatch resolves
+// the target replica by a NetworkID read straight from the packet body and deletes it the moment
+// NetworkEntity::DeserializeDestruction returns true, doing no ownership check of its own. That hook
+// used to return true unconditionally, so any connected client could despawn arbitrary entities.
+// These tests pin the owner gate directly: DeserializeDestruction's return value IS the decision
+// (true -> the base deletes + relays the destruction, false -> the entity is kept), so a return of
+// true for a non-owner connection reproduces the vulnerability and a return of false proves the fix.
+MODULE(replication_authority, {
+    using Framework::Networking::NetworkClient;
+    using Framework::Networking::Replication::NetworkEntity;
+    using Framework::Networking::Replication::ReplicationManager;
+
+    // Two in-memory peers, never started (no socket bound): one manager put into server mode, one
+    // into client mode. Only ReplicationManager::IsServer() is exercised by the gate, and Init()
+    // just flips that flag, records the peer's guid, and attaches the plugin — none of which needs a
+    // live connection.
+    NetworkClient serverPeer;
+    NetworkClient clientPeer;
+    auto *serverManager = serverPeer.GetReplicationManager();
+    auto *clientManager = clientPeer.GetReplicationManager();
+    serverManager->Init(&serverPeer, true);
+    clientManager->Init(&clientPeer, false);
+
+    // Distinct, stable guids: one owns the entity, one is the "attacker" that owns nothing.
+    const MafiaNet::RakNetGUID ownerGuid(1000);
+    const MafiaNet::RakNetGUID attackerGuid(2000);
+    const MafiaNet::SystemAddress noAddress;
+
+    // Fresh connection objects carrying the chosen guid; GetRakNetGUID() (what the gate reads)
+    // returns exactly what we pass here. Allocated through the manager so they are real
+    // ReplicationConnection instances, freed at the end of each case.
+    MafiaNet::Connection_RM3 *ownerConn    = serverManager->AllocConnection(noAddress, ownerGuid);
+    MafiaNet::Connection_RM3 *attackerConn = serverManager->AllocConnection(noAddress, attackerGuid);
+
+    IT("lets the server delete an entity when the request comes from its owner", {
+        NetworkEntity entity;
+        entity.replicaManager = serverManager;
+        entity.ownerGUID      = MafiaNet::ToPeerGuid(ownerGuid);
+
+        MafiaNet::BitStream bs;
+        EQUALS(entity.DeserializeDestruction(&bs, ownerConn), true);
+    });
+
+    IT("refuses a client's attempt to destroy an entity it does not own", {
+        // The exploit: a non-owner names another entity's NetworkID in a construction packet's
+        // destruction sublist. Before the fix this returned true and the server deleted it.
+        NetworkEntity entity;
+        entity.replicaManager = serverManager;
+        entity.ownerGUID      = MafiaNet::ToPeerGuid(ownerGuid);
+
+        MafiaNet::BitStream bs;
+        EQUALS(entity.DeserializeDestruction(&bs, attackerConn), false);
+    });
+
+    IT("refuses any client's attempt to destroy a server-owned entity", {
+        // A server-owned entity has no client owner, so no client connection may destroy it.
+        NetworkEntity entity;
+        entity.replicaManager = serverManager;
+        entity.ownerGUID      = MafiaNet::UNASSIGNED_PEER_GUID;
+
+        MafiaNet::BitStream bs;
+        EQUALS(entity.DeserializeDestruction(&bs, attackerConn), false);
+    });
+
+    IT("fails closed when the server sees a destruction with no source connection", {
+        NetworkEntity entity;
+        entity.replicaManager = serverManager;
+        entity.ownerGUID      = MafiaNet::ToPeerGuid(ownerGuid);
+
+        MafiaNet::BitStream bs;
+        EQUALS(entity.DeserializeDestruction(&bs, nullptr), false);
+    });
+
+    IT("still accepts the server's authoritative destruction on a client", {
+        // On a client every destruction originates from the server and must be honoured, regardless
+        // of the entity's owner — otherwise the client could never despawn anything.
+        NetworkEntity entity;
+        entity.replicaManager = clientManager;
+        entity.ownerGUID      = MafiaNet::ToPeerGuid(ownerGuid);
+
+        MafiaNet::BitStream bs;
+        EQUALS(entity.DeserializeDestruction(&bs, attackerConn), true);
+    });
+
+    serverManager->DeallocConnection(ownerConn);
+    serverManager->DeallocConnection(attackerConn);
+});


### PR DESCRIPTION
## Summary

Any connected client can currently **destroy any entity on the server** — another player's avatar, a server-owned object, a text label — and the server relays that deletion to every peer. This PR closes the hole by gating entity destruction on owner authority, mirroring the existing per-tick update gate.

## Root cause

The vendored `ReplicaManager3` destruction dispatch does **no ownership check** of its own. For an inbound `ID_REPLICA_MANAGER_CONSTRUCTION` (processed on the server from any connection — `ReplicaManager3::OnReceive` → `OnConstruction`, no role guard), the destruction sublist:

1. reads a `networkId` **straight from the packet body**,
2. resolves *any* replica via `GET_OBJECT_FROM_ID`,
3. deletes it the instant `DeserializeDestruction` returns `true`, then
4. relays the deletion to all other peers via `QueryRelayDestruction` (framework doesn't override it → base default `true`).

`NetworkEntity::DeserializeDestruction` returned `true` unconditionally, so that step-3 gate was wide open. The per-tick update path (`NetworkEntity::Deserialize`) already gates correctly on the authenticated owner — the destruction path simply omitted the mirror gate.

**Exploit:** a modified client sends a construction packet with an empty construction list and a destruction list naming any NetworkID. NetworkIDs are small and monotonic, so targets are trivially enumerable. Impact: remote griefing / world-desync DoS, amplified server-wide by the relay.

## Fix

On the server, only honour a destruction from the entity's **current owner**, failing closed on a missing connection. Clients still accept the server's authoritative destructions (`IsServerPeer()` is false there, so the path returns `true` as before). This is a direct mirror of the owner gate at `network_entity.cpp:190`.

```cpp
if (IsServerPeer() && (!sourceConnection || MafiaNet::ToPeerGuid(sourceConnection->GetRakNetGUID()) != ownerGUID)) {
    return false; // keep the entity alive
}
return true;
```

Returning `false` takes the base "do not delete" branch, so the entity survives.

## Scope / compatibility

- Server-side acceptance logic only — **no wire-format change**, no client update required (client behaviour is unchanged).
- Preserves the existing authority model: an owner already fully controls its own entity's state via updates, so an owner-initiated destruction of its own entity remains allowed and consistent.

## Testing

Added a `replication_authority` unit module (`code/tests/modules/replication_authority_ut.h`, wired into `framework_ut.cpp`) that pins the gate on a server-mode and a client-mode `ReplicationManager`, asserting `NetworkEntity::DeserializeDestruction`:

- **owner connection → `true`** (server honours the owner),
- **non-owner connection → `false`** — this case returns `true` without the fix, so it reproduces the "despawn any entity" vulnerability and proves the fix,
- **server-owned entity + any client → `false`**,
- **null source connection on the server → `false`** (fail-closed),
- **client peer + non-owner connection → `true`** (clients still accept the server's authoritative destructions).

The module type-checks cleanly against the framework/MafiaNet headers (`clang++ -std=c++20 -fsyntax-only`). I could not run the full `FrameworkTests` binary locally (unrelated toolchain issue building the tree on my machine: AppleClang + bundled fmt), so CI is the runtime validation — please confirm the new module is green there.

## Context

Found during a netcode security audit (packet forging / auth-bypass focus). This was the one concrete, exploitable memory/authority bug; the transport layer also ships without encryption (`LIBCAT_SECURITY 0`, `InitializeSecurity()` never called) and the "build token" is a public version string rather than real authentication — reported separately as design-level findings.
