### PR TITLE
Networking: derive RPC identifiers from a keyed compile-time hash

### DIFF
--- a/code/framework/CMakeLists.txt
+++ b/code/framework/CMakeLists.txt
@@ -210,6 +210,17 @@ endif()
 # Custom defines
 target_compile_definitions(Framework PUBLIC MG_ENABLE_LOG=0)
 
+# Per-build key for RPC identifiers (see networking/rpc/rpc_identifier.h). A cache variable alone
+# never reaches the preprocessor, so release CI passing -DFW_RPC_IDENTIFIER_SALT=<uint64> would
+# silently keep the default; turn it into a define here. PUBLIC because every peer -- framework,
+# server, client and downstream projects -- must derive the same identifiers.
+set(FW_RPC_IDENTIFIER_SALT "" CACHE STRING "64-bit salt keying every RPC identifier; must match on client and server")
+if(NOT FW_RPC_IDENTIFIER_SALT STREQUAL "")
+    # Accept the value with or without an integer suffix; the header needs it unsigned 64-bit.
+    string(REGEX REPLACE "[uUlL]+$" "" FW_RPC_IDENTIFIER_SALT_VALUE "${FW_RPC_IDENTIFIER_SALT}")
+    target_compile_definitions(Framework PUBLIC FW_RPC_IDENTIFIER_SALT=${FW_RPC_IDENTIFIER_SALT_VALUE}ULL)
+endif()
+
 # External libraries & other stuff
 macro(link_shared_deps target_name)
     # Framework source directories (PUBLIC for dependent projects)

--- a/code/framework/src/integrations/shared/rpc/emit_script_event.h
+++ b/code/framework/src/integrations/shared/rpc/emit_script_event.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <networking/rpc/rpc_identifier.h>
+
 #include <mafianet/BitStream.h>
 #include <mafianet/string.h>
 
@@ -17,7 +19,7 @@ namespace Framework::Integrations::Shared::RPC {
     // RPC payload forwarding a named scripting event (with a JSON payload) to the other peer's
     // resource layer. See networking/rpc/rpc.h for the dispatch model.
     struct EmitScriptEvent {
-        static constexpr const char *kIdentifier = "Framework::EmitScriptEvent";
+        static constexpr const char *kIdentifier = FW_RPC_IDENTIFIER("Framework::EmitScriptEvent");
 
         MafiaNet::RakString eventName;
         MafiaNet::RakString payload;

--- a/code/framework/src/networking/network_peer.h
+++ b/code/framework/src/networking/network_peer.h
@@ -99,8 +99,11 @@ namespace Framework::Networking {
         // must not lock out peers that have not rebuilt. The game version is kept whole — it tracks
         // the game executable, not our release cadence, and a different game build shifts the
         // pattern addresses the mod is compiled against.
+        //
+        // The RPC identifier salt rides along (see rpc/rpc_identifier.h): peers built with different
+        // salts derive different slot keys, and a mismatch has no other error path.
         static std::string BuildToken(const std::string &gameName, const std::string &gameVersion, const std::string &fwVersion, const std::string &modVersion) {
-            return gameName + '|' + gameVersion + '|' + Utils::Version::Major(fwVersion) + '|' + Utils::Version::Major(modVersion);
+            return gameName + '|' + gameVersion + '|' + Utils::Version::Major(fwVersion) + '|' + Utils::Version::Major(modVersion) + '|' + RPC::IdentifierSaltTag();
         }
 
         // Register the local build token (see BuildToken). Call before connecting/accepting.

--- a/code/framework/src/networking/replication/replication_manager.cpp
+++ b/code/framework/src/networking/replication/replication_manager.cpp
@@ -10,6 +10,7 @@
 
 #include "../channels.h"
 #include "../network_peer.h"
+#include "../rpc/rpc_identifier.h"
 #include "entity_registry.h"
 #include "replication_connection.h"
 
@@ -18,10 +19,10 @@
 namespace Framework::Networking::Replication {
     namespace {
         // Raw RPC: the tail is the entity's polymorphic SerializeForcedState payload.
-        constexpr const char *kForceStateId = "Framework::ForceState";
+        constexpr const char *kForceStateId = FW_RPC_IDENTIFIER("Framework::ForceState");
 
         struct SetOwnerRPC {
-            static constexpr const char *kIdentifier = "Framework::SetOwner";
+            static constexpr const char *kIdentifier = FW_RPC_IDENTIFIER("Framework::SetOwner");
 
             MafiaNet::NetworkID networkId;
             MafiaNet::PeerGuid ownerGUID {};

--- a/code/framework/src/networking/rpc/chat_message.h
+++ b/code/framework/src/networking/rpc/chat_message.h
@@ -19,7 +19,7 @@ namespace Framework::Networking::RPC {
     // author empty = notice line; color is packed 0xRRGGBBAA, 0 = client theme default.
     // '/'-prefixed lines are parsed into a command on the server.
     struct ChatMessage {
-        static constexpr const char *kIdentifier = "Framework::ChatMessage";
+        static constexpr const char *kIdentifier = FW_RPC_IDENTIFIER("Framework::ChatMessage");
 
         std::string text;
         std::string author;

--- a/code/framework/src/networking/rpc/client_identity.h
+++ b/code/framework/src/networking/rpc/client_identity.h
@@ -16,7 +16,7 @@ namespace Framework::Networking::RPC {
     // Client -> server after assets download: announces the player. Only honoured for an
     // authenticated connection (NetworkServer::IsAuthenticated).
     struct ClientIdentity {
-        static constexpr const char *kIdentifier = "Framework::ClientIdentity";
+        static constexpr const char *kIdentifier = FW_RPC_IDENTIFIER("Framework::ClientIdentity");
 
         std::string name;
         std::string steamId;

--- a/code/framework/src/networking/rpc/resource_refresh.h
+++ b/code/framework/src/networking/rpc/resource_refresh.h
@@ -20,7 +20,7 @@ namespace Framework::Networking::RPC {
     // Server -> client: these client resources were (re)started; the client
     // re-syncs their files (delta) and reloads/starts them.
     struct ResourceRefresh {
-        static constexpr const char *kIdentifier = "Framework::ResourceRefresh";
+        static constexpr const char *kIdentifier = FW_RPC_IDENTIFIER("Framework::ResourceRefresh");
         static constexpr uint16_t kMaxResources  = 1000; // bound untrusted input
 
         std::vector<ResourceInfo> resources;
@@ -51,7 +51,7 @@ namespace Framework::Networking::RPC {
     // Server -> client: stop these resources (no files). Sent when a client
     // resource stops at runtime.
     struct ResourceStop {
-        static constexpr const char *kIdentifier = "Framework::ResourceStop";
+        static constexpr const char *kIdentifier = FW_RPC_IDENTIFIER("Framework::ResourceStop");
         static constexpr uint16_t kMaxResources  = 1000;
 
         std::vector<ResourceInfo> resources;

--- a/code/framework/src/networking/rpc/rpc.h
+++ b/code/framework/src/networking/rpc/rpc.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include "rpc_identifier.h"
+
 #include <mafianet/BitStream.h>
 
 #include <concepts>

--- a/code/framework/src/networking/rpc/rpc_identifier.h
+++ b/code/framework/src/networking/rpc/rpc_identifier.h
@@ -1,0 +1,129 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2026, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <string_view>
+
+// Per-build key for every RPC identifier. Both peers derive the token they key RPC4 slots on from it,
+// so a mismatch means no RPC ever dispatches -- NetworkPeer::BuildToken folds IdentifierSaltTag() into
+// the TwoWayAuthentication challenge so that fails the connection gate instead of hanging silently.
+// Changing it is netcode-breaking (MAJOR). Release CI overrides it per shipped build with
+// `cmake -DFW_RPC_IDENTIFIER_SALT=<uint64>`, which code/framework/CMakeLists.txt turns into this
+// define (a bare cache variable would never reach the preprocessor); the default keeps local dev
+// builds deterministic and interoperable.
+#ifndef FW_RPC_IDENTIFIER_SALT
+#define FW_RPC_IDENTIFIER_SALT 0x9E3779B97F4A7C15ULL
+#endif
+
+namespace Framework::Networking::RPC {
+    inline constexpr std::uint64_t kIdentifierSalt = FW_RPC_IDENTIFIER_SALT;
+
+    // Token alphabet, in ascending RakNet StringCompressor cost. RPC4 writes the identifier with
+    // WriteCompressed, i.e. Huffman-coded against RakNet's fixed English table, where digits cost
+    // 10-16 bits and these letters 3-6. A hex rendering would put the token at ~151 bits, above the
+    // readable names it replaces (110-158); these 16 cap it at 96.
+    inline constexpr char kIdentifierAlphabet[] = "eaintoshlrudbcfg";
+
+    constexpr std::uint64_t SplitMix64(std::uint64_t x) {
+        x += 0x9E3779B97F4A7C15ULL;
+        x = (x ^ (x >> 30)) * 0xBF58476D1CE4E5B9ULL;
+        x = (x ^ (x >> 27)) * 0x94D049BB133111EBULL;
+        return x ^ (x >> 31);
+    }
+
+    namespace detail {
+        constexpr std::uint64_t Rotl(std::uint64_t x, int b) { return (x << b) | (x >> (64 - b)); }
+
+        struct SipState {
+            std::uint64_t v0, v1, v2, v3;
+
+            constexpr void Round() {
+                v0 += v1; v1 = Rotl(v1, 13); v1 ^= v0; v0 = Rotl(v0, 32);
+                v2 += v3; v3 = Rotl(v3, 16); v3 ^= v2;
+                v0 += v3; v3 = Rotl(v3, 21); v3 ^= v0;
+                v2 += v1; v1 = Rotl(v1, 17); v1 ^= v2; v2 = Rotl(v2, 32);
+            }
+
+            constexpr void Absorb(std::uint64_t m) {
+                v3 ^= m;
+                Round();
+                Round();
+                v0 ^= m;
+            }
+        };
+
+        // SipHash-2-4, matching the reference implementation (pinned against its published test
+        // vectors in code/tests/modules/rpc_identifier_ut.h).
+        constexpr std::uint64_t SipHash24(std::uint64_t k0, std::uint64_t k1, std::string_view data) {
+            SipState s {k0 ^ 0x736F6D6570736575ULL, k1 ^ 0x646F72616E646F6DULL, k0 ^ 0x6C7967656E657261ULL, k1 ^ 0x7465646279746573ULL};
+
+            const std::size_t length = data.size();
+            std::size_t offset       = 0;
+            for (; offset + 8 <= length; offset += 8) {
+                std::uint64_t block = 0;
+                for (std::size_t i = 0; i < 8; ++i) { block |= static_cast<std::uint64_t>(static_cast<std::uint8_t>(data[offset + i])) << (8 * i); }
+                s.Absorb(block);
+            }
+
+            std::uint64_t tail = static_cast<std::uint64_t>(length & 0xFF) << 56;
+            for (std::size_t i = 0; offset + i < length; ++i) { tail |= static_cast<std::uint64_t>(static_cast<std::uint8_t>(data[offset + i])) << (8 * i); }
+            s.Absorb(tail);
+
+            s.v2 ^= 0xFF;
+            s.Round();
+            s.Round();
+            s.Round();
+            s.Round();
+            return s.v0 ^ s.v1 ^ s.v2 ^ s.v3;
+        }
+    } // namespace detail
+
+    // SipHash-2-4 of the readable name under a key derived from the build salt. Deliberately not a
+    // salted FNV-1a: that is invertible (multiply by the prime's modular inverse and unwind the name
+    // backwards), so one token plus its name -- and every framework name is public in this repo --
+    // recovers the salt and with it the whole table, which would leave the per-build rotation above
+    // worthless. A keyed PRF has no such shortcut.
+    constexpr std::uint64_t HashIdentifierWith(std::uint64_t salt, std::string_view name) { return detail::SipHash24(SplitMix64(salt), SplitMix64(SplitMix64(salt)), name); }
+
+    // The name reaches this exclusively through FW_RPC_IDENTIFIER's template argument (mandatory
+    // constant evaluation), so it is never referenced at runtime and does not ship in the binary --
+    // only the token below does. 64 bits keeps collisions across the identifier set negligible.
+    constexpr std::uint64_t HashIdentifier(std::string_view name) { return HashIdentifierWith(kIdentifierSalt, name); }
+
+    // Stable, NUL-terminated 16-character rendering of a hashed identifier (4 bits per character),
+    // held in static storage so it can back a plain const char*. RPC4 keys its slots by, and
+    // transmits, identifiers as C strings, so this drops in wherever a readable name used to sit.
+    template <std::uint64_t Hash>
+    struct IdentifierToken {
+        static constexpr std::array<char, 17> Render() {
+            std::array<char, 17> out {};
+            std::uint64_t value = Hash;
+            for (int i = 15; i >= 0; --i) {
+                out[static_cast<std::size_t>(i)] = kIdentifierAlphabet[value & 0xFULL];
+                value >>= 4;
+            }
+            out[16] = '\0';
+            return out;
+        }
+        static constexpr std::array<char, 17> value = Render();
+    };
+
+    // Fingerprint of the build salt, folded into NetworkPeer::BuildToken. A salt mismatch otherwise
+    // has no error path: RPC4 Signal to an unregistered slot is a no-op, so the peers would connect
+    // and then silently dispatch nothing.
+    inline constexpr const char *IdentifierSaltTag() { return IdentifierToken<HashIdentifier("Framework::IdentifierSalt")>::value.data(); }
+} // namespace Framework::Networking::RPC
+
+// Turn a readable RPC name into an opaque, per-build wire identifier. Use in place of a string
+// literal, e.g. `static constexpr const char *kIdentifier = FW_RPC_IDENTIFIER("Framework::ChatMessage");`.
+// The readable name stays here for developers; only the token reaches the binary and the wire.
+#define FW_RPC_IDENTIFIER(name) (::Framework::Networking::RPC::IdentifierToken<::Framework::Networking::RPC::HashIdentifier(name)>::value.data())

--- a/code/framework/src/networking/rpc/server_resources.h
+++ b/code/framework/src/networking/rpc/server_resources.h
@@ -38,7 +38,7 @@ namespace Framework::Networking::RPC {
     // per-connection ReadyEvent id both peers use as the spawn barrier; tickRate is the serialize
     // interval (s) the client applies once that barrier completes.
     struct ServerResources {
-        static constexpr const char *kIdentifier = "Framework::ServerResources";
+        static constexpr const char *kIdentifier = FW_RPC_IDENTIFIER("Framework::ServerResources");
         static constexpr uint16_t kMaxResources  = 1000; // bound untrusted input
 
         int32_t readyEventId = 0;

--- a/code/framework/src/networking/rpc/voice_settings.h
+++ b/code/framework/src/networking/rpc/voice_settings.h
@@ -16,7 +16,7 @@ namespace Framework::Networking::RPC {
     // Server->client: the radius the router culls on, so the client mixer fades a talker out
     // where the frames stop arriving rather than at its own compile-time default.
     struct VoiceSettings {
-        static constexpr const char *kIdentifier = "Framework::VoiceSettings";
+        static constexpr const char *kIdentifier = FW_RPC_IDENTIFIER("Framework::VoiceSettings");
 
         float proximityRange = 0.0f;
 
@@ -28,7 +28,7 @@ namespace Framework::Networking::RPC {
     // Server->client: one talker's override of the radius above, keyed by peer GUID. 0
     // restores the default.
     struct VoiceSpeakerRange {
-        static constexpr const char *kIdentifier = "Framework::VoiceSpeakerRange";
+        static constexpr const char *kIdentifier = FW_RPC_IDENTIFIER("Framework::VoiceSpeakerRange");
 
         uint64_t player = 0;
         float range     = 0.0f;
@@ -43,7 +43,7 @@ namespace Framework::Networking::RPC {
     // fan-out for a client that discards every frame. A preference, deliberately separate
     // from the router's mute and deaf flags, which are the server's to set.
     struct VoicePreference {
-        static constexpr const char *kIdentifier = "Framework::VoicePreference";
+        static constexpr const char *kIdentifier = FW_RPC_IDENTIFIER("Framework::VoicePreference");
 
         bool enabled = true;
 

--- a/code/tests/framework_ut.cpp
+++ b/code/tests/framework_ut.cpp
@@ -6,7 +6,7 @@
  * See LICENSE file in the source repository for information regarding licensing.
  */
 
-#define UNIT_MAX_MODULES 27
+#define UNIT_MAX_MODULES 28
 #include "logging/logger.h"
 #include "unit.h"
 
@@ -18,6 +18,7 @@
 #include "modules/replication_authority_ut.h"
 #include "modules/replication_rate_ut.h"
 #include "modules/interest_grid_ut.h"
+#include "modules/rpc_identifier_ut.h"
 #include "modules/state_machine_ut.h"
 #include "modules/persistent_config_ut.h"
 #include "modules/server_config_ut.h"
@@ -49,6 +50,7 @@ int main() {
     UNIT_MODULE(replication_authority);
     UNIT_MODULE(replication_rate);
     UNIT_MODULE(interest_grid);
+    UNIT_MODULE(rpc_identifier);
     UNIT_MODULE(state_machine);
     UNIT_MODULE(persistent_config);
     UNIT_MODULE(server_config);

--- a/code/tests/modules/rpc_identifier_ut.h
+++ b/code/tests/modules/rpc_identifier_ut.h
@@ -1,0 +1,183 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2026, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
+#pragma once
+
+#include "integrations/shared/rpc/emit_script_event.h"
+#include "networking/rpc/chat_message.h"
+#include "networking/rpc/client_identity.h"
+#include "networking/rpc/resource_refresh.h"
+#include "networking/rpc/rpc_identifier.h"
+#include "networking/rpc/server_resources.h"
+#include "networking/rpc/voice_settings.h"
+
+#include <mafianet/BitStream.h>
+#include <mafianet/StringCompressor.h>
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <string_view>
+
+// RPC identifiers are derived at compile time from a keyed hash of the readable name (see
+// rpc_identifier.h): the wire and the binary carry only an opaque token, never "Framework::ChatMessage".
+// These tests pin the properties the RPC layer depends on -- a correct keyed hash, opacity,
+// distinctness, determinism, non-recoverability of the salt, and that the token never costs more on
+// the wire than the name it replaced.
+MODULE(rpc_identifier, {
+    namespace RPC = Framework::Networking::RPC;
+
+    // Every readable name converted to FW_RPC_IDENTIFIER, paired with the token that ships instead.
+    // Kept in sync by hand: a new framework RPC belongs here so the sweeps below cover it.
+    struct Identifier {
+        const char *name;
+        const char *token;
+    };
+    static const Identifier kIdentifiers[] = {
+        {"Framework::ClientIdentity", RPC::ClientIdentity::kIdentifier},
+        {"Framework::ChatMessage", RPC::ChatMessage::kIdentifier},
+        {"Framework::ServerResources", RPC::ServerResources::kIdentifier},
+        {"Framework::ResourceRefresh", RPC::ResourceRefresh::kIdentifier},
+        {"Framework::ResourceStop", RPC::ResourceStop::kIdentifier},
+        {"Framework::VoiceSettings", RPC::VoiceSettings::kIdentifier},
+        {"Framework::VoiceSpeakerRange", RPC::VoiceSpeakerRange::kIdentifier},
+        {"Framework::VoicePreference", RPC::VoicePreference::kIdentifier},
+        {"Framework::EmitScriptEvent", Framework::Integrations::Shared::RPC::EmitScriptEvent::kIdentifier},
+        {"Framework::ForceState", FW_RPC_IDENTIFIER("Framework::ForceState")},
+        {"Framework::SetOwner", FW_RPC_IDENTIFIER("Framework::SetOwner")},
+    };
+    static constexpr size_t kIdentifierCount = sizeof(kIdentifiers) / sizeof(kIdentifiers[0]);
+
+    // Bits WriteCompressed spends on a C string, i.e. exactly what RPC4::Signal pays to name the slot.
+    const auto encodedBits = [](const char *value) {
+        MafiaNet::BitStream bs;
+        bs.WriteCompressed(value);
+        return static_cast<uint32_t>(bs.GetNumberOfBitsUsed());
+    };
+
+    IT("matches the published SipHash-2-4 test vectors", {
+        // The identifier hash is only as good as the primitive under it, and this one is hand-rolled
+        // for constexpr. Reference key 000102..0f over inputs 00..len-1, the standard vectors.
+        static const uint64_t expected[16] = {
+            0x726fdb47dd0e0e31ULL, 0x74f839c593dc67fdULL, 0x0d6c8009d9a94f5aULL, 0x85676696d7fb7e2dULL,
+            0xcf2794e0277187b7ULL, 0x18765564cd99a68dULL, 0xcbc9466e58fee3ceULL, 0xab0200f58b01d137ULL,
+            0x93f5f5799a932462ULL, 0x9e0082df0ba9e4b0ULL, 0x7a5dbbc594ddb9f3ULL, 0xf4b32f46226bada7ULL,
+            0x751e8fbc860ee5fbULL, 0x14ea5627c0843d90ULL, 0xf723ca908e7af2eeULL, 0xa129ca6149be45e5ULL,
+        };
+        char input[16] = {0};
+        for (size_t length = 0; length < 16; ++length) {
+            input[length] = static_cast<char>(length);
+            UEQUALS(RPC::detail::SipHash24(0x0706050403020100ULL, 0x0f0e0d0c0b0a0908ULL, std::string_view(input, length)), expected[length]);
+        }
+    });
+
+    IT("renders an opaque 16-character token that does not embed the readable name", {
+        for (const auto &entry : kIdentifiers) {
+            EQUALS(strlen(entry.token), static_cast<size_t>(16));
+            EQUALS(strspn(entry.token, RPC::kIdentifierAlphabet), static_cast<size_t>(16));
+            EQUALS(strstr(entry.token, "Framework") == nullptr, true);
+            EQUALS(strstr(entry.name, entry.token) == nullptr, true);
+        }
+    });
+
+    IT("draws tokens from an alphabet of sixteen distinct characters", {
+        // Fewer than sixteen would silently fold hash nibbles together and lose entropy.
+        EQUALS(strlen(RPC::kIdentifierAlphabet), static_cast<size_t>(16));
+        for (size_t i = 0; i < 16; ++i) {
+            for (size_t j = i + 1; j < 16; ++j) { NEQUALS(RPC::kIdentifierAlphabet[i], RPC::kIdentifierAlphabet[j]); }
+        }
+    });
+
+    IT("assigns a distinct identifier to every framework RPC", {
+        // A collision would make two payloads share an RPC4 slot, silently misrouting one of them.
+        for (size_t i = 0; i < kIdentifierCount; ++i) {
+            for (size_t j = i + 1; j < kIdentifierCount; ++j) { STRNEQUALS(kIdentifiers[i].token, kIdentifiers[j].token); }
+        }
+    });
+
+    IT("derives the token as the alphabet rendering of the name's hash", {
+        // Ties the on-wire token to the hash, so an independent implementation can reproduce it.
+        for (const auto &entry : kIdentifiers) {
+            char expected[17];
+            uint64_t value = RPC::HashIdentifier(entry.name);
+            for (int i = 15; i >= 0; --i) {
+                expected[i] = RPC::kIdentifierAlphabet[value & 0xFULL];
+                value >>= 4;
+            }
+            expected[16] = '\0';
+            STREQUALS(entry.token, expected);
+        }
+    });
+
+    IT("derives the same identifier for a given name every time", {
+        // Both peers must agree, so the mapping has to be a pure function of name + salt.
+        UEQUALS(RPC::HashIdentifier("Framework::ChatMessage"), RPC::HashIdentifier("Framework::ChatMessage"));
+        UEQUALS(RPC::HashIdentifierWith(1234ULL, "Framework::ChatMessage"), RPC::HashIdentifierWith(1234ULL, "Framework::ChatMessage"));
+        NEQUALS(RPC::HashIdentifier("Framework::ChatMessage"), RPC::HashIdentifier("Framework::ClientIdentity"));
+    });
+
+    IT("rotates every identifier when the build salt changes", {
+        // The point of the salt: a table lifted from one build must not map onto the next.
+        for (const auto &entry : kIdentifiers) {
+            const uint64_t a = RPC::HashIdentifierWith(0x0123456789ABCDEFULL, entry.name);
+            const uint64_t b = RPC::HashIdentifierWith(0x0123456789ABCDF0ULL, entry.name);
+            NEQUALS(a, b);
+            // A near-identical salt must still scatter the output, not nudge it.
+            uint64_t differing = 0;
+            for (uint64_t bit = a ^ b; bit; bit >>= 1) { differing += bit & 1ULL; }
+            GREATER(differing, static_cast<uint64_t>(16));
+        }
+    });
+
+    IT("scatters the hash when a single character of the name changes", {
+        const uint64_t a = RPC::HashIdentifier("Framework::ChatMessage");
+        const uint64_t b = RPC::HashIdentifier("Framework::ChatMessagf");
+        uint64_t differing = 0;
+        for (uint64_t bit = a ^ b; bit; bit >>= 1) { differing += bit & 1ULL; }
+        GREATER(differing, static_cast<uint64_t>(16));
+    });
+
+    IT("does not leak the build salt to anyone holding a token and its public name", {
+        // Regression guard. A salted FNV-1a token is invertible: multiply by the prime's modular
+        // inverse and unwind the name backwards to recover the seed, hence the salt. Every framework
+        // name is public, so that alone would have undone the rotation above. Run exactly that attack
+        // against the current construction and require it to fail.
+        const uint64_t salt         = 0xDEADBEEFCAFEF00DULL;
+        const uint64_t fnvBasis     = 14695981039346656037ULL;
+        const uint64_t fnvInvPrime  = 0xCE965057AFF6957BULL; // modular inverse of the FNV prime mod 2^64
+        const std::string_view name = "Framework::ChatMessage";
+
+        uint64_t state = RPC::HashIdentifierWith(salt, name);
+        for (size_t i = name.size(); i-- > 0;) {
+            state *= fnvInvPrime;
+            state ^= static_cast<uint8_t>(name[i]);
+        }
+        const uint64_t recovered = state ^ fnvBasis;
+        NEQUALS(recovered, salt);
+    });
+
+    IT("never costs more on the wire than the readable name it replaced", {
+        // RPC4::Signal writes the identifier with WriteCompressed, Huffman-coded against RakNet's
+        // fixed English table. Hex tokens cost ~151 bits there, above most of these names; the
+        // alphabet in rpc_identifier.h is chosen to stay under every one of them.
+        MafiaNet::StringCompressor::AddReference();
+        for (const auto &entry : kIdentifiers) { LESSER(encodedBits(entry.token), encodedBits(entry.name)); }
+        MafiaNet::StringCompressor::RemoveReference();
+    });
+
+    IT("resolves identifiers entirely at compile time", {
+        // The readable name must never reach the binary, which only holds while it stays inside a
+        // constant expression.
+        static_assert(RPC::HashIdentifier("Framework::ChatMessage") == RPC::HashIdentifierWith(RPC::kIdentifierSalt, "Framework::ChatMessage"));
+        static_assert(RPC::HashIdentifier("Framework::ChatMessage") != RPC::HashIdentifier("Framework::ClientIdentity"));
+        static_assert(RPC::IdentifierToken<RPC::HashIdentifier("Framework::ChatMessage")>::value[16] == '\0');
+        static_assert(RPC::detail::SipHash24(0x0706050403020100ULL, 0x0f0e0d0c0b0a0908ULL, std::string_view("", 0)) == 0x726fdb47dd0e0e31ULL);
+        EQUALS(true, true);
+    });
+});

--- a/docs/rpc_identifiers.md
+++ b/docs/rpc_identifiers.md
@@ -26,10 +26,13 @@ static constexpr const char *kIdentifier = FW_RPC_IDENTIFIER("M2O::PlayerReload"
 
 Nothing else about writing an RPC changes.
 
-> **Framework vs host mod.** Every framework RPC is already converted. Mod
-> identifiers (`M2O::*`, `HogwartsMP::*`, …) are **opt-in** — they still travel
-> in plaintext until a mod adopts the macro, which is what the rest of this
-> document is about.
+> **Opt-in for mods.** Every framework RPC is already converted. Mod identifiers
+> (`M2O::*`, `HogwartsMP::*`, …) are **not touched** — they keep travelling as
+> plaintext, and keep working, until a mod adopts the macro itself. A mod that
+> does nothing needs no changes and **cannot** end up with mismatched identifiers
+> or dropped RPCs. Section [2.6](#26-if-a-mod-does-nothing) spells out why that is
+> structural rather than a promise, and covers the two things that change whether
+> a mod opts in or not.
 
 ---
 
@@ -169,9 +172,54 @@ netServer->SignalExcept(Shared::RPC::PlayerReload::kIdentifier, bs, packet->guid
 
 Identifiers are independent of each other — each one only has to match itself on
 the other peer. A mod can convert one header at a time, as long as **client and
-server ship together**, which a netcode change already requires. There is no
-mixed-mode compatibility: a converted identifier and an unconverted one are
-simply two different slot names.
+server ship together**, which a netcode change already requires.
+
+The constraint is per identifier, not per mod: converting `M2O::PlayerShoot`
+while leaving `M2O::PlayerReload` alone is fine, and the untouched one keeps
+working. What does not work is converting a *single* identifier on one peer only
+— the two ends then key different slots and that one RPC stops dispatching. Since
+the macro sits in a shared header both peers compile, that only happens if client
+and server are built from different revisions.
+
+### 2.6 If a mod does nothing
+
+Adoption is optional and per-identifier. A mod that never touches the macro is
+unaffected — and that is structural, not a promise to be careful. **The hash is
+applied only at declaration sites.** Nothing in the send or register path
+transforms an identifier:
+
+```cpp
+RegisterRPC<T>(…)   →  RegisterRawRPC(T::kIdentifier, …)  →  _rpc.RegisterSlot(identifier, …)
+BroadcastRPC(T&)    →  _rpc.Signal(T::kIdentifier, …)
+SendRPC(T&, guid)   →  _rpc.Signal(T::kIdentifier, …)
+```
+
+`T::kIdentifier` reaches RPC4 verbatim. An unconverted `"M2O::PlayerReload"`
+therefore registers and signals under that exact string, on both peers, byte for
+byte as before. There is no path by which an identifier could be hashed on one
+side and not the other, so **unconverted RPCs cannot go missing or arrive
+unhandled**. Had the hashing lived inside `RegisterRawRPC`/`Signal` instead, it
+would have been mandatory for everyone; it deliberately does not.
+
+Two things change regardless of whether a mod opts in. Neither can fail silently:
+
+- **Framework RPCs are converted unconditionally** — `ChatMessage`,
+  `ClientIdentity`, `ServerResources`, `EmitScriptEvent`, `ForceState`,
+  `SetOwner` and the voice RPCs. This is safe because both peers take those
+  identifiers from the same framework build. It is also why the change is a
+  MAJOR bump: an old client against a new server was already broken, and the
+  build token rejects that pairing on the framework major version alone.
+- **`BuildToken` gained the salt fingerprint** (see
+  [§3](#salt-mismatch-is-caught-at-connect-time)). A matched pair computes the
+  same string and notices nothing. A mismatched pair is refused at the gate
+  rather than connecting and going quiet.
+
+> **The one way a mod can break.** Passing a framework identifier as a *string
+> literal* to a raw call — `RegisterRawRPC("Framework::ForceState", …)` — now
+> registers a slot nothing will ever signal. Go through the constant instead
+> (`Framework::Networking::RPC::ChatMessage::kIdentifier`), which is what every
+> raw call site in the tree already does. No project in this repository is
+> affected.
 
 ---
 
@@ -293,6 +341,14 @@ Mods get this for free — they already call `BuildToken`:
 net->SetBuildToken(Framework::Networking::NetworkPeer::BuildToken(
     _opts.gameName, _opts.gameVersion, Utils::Version::rel, _opts.modVersion));
 ```
+
+> **The gate is off when `verifyBuildToken` is `false`.** That option makes both
+> peers register the fixed `kBuildVerificationDisabledToken` instead, so the
+> challenge passes without comparing anything — including the salt. Two builds
+> with different salts would then connect cleanly and silently dispatch nothing,
+> which is exactly the failure the fingerprint exists to prevent. If you turn
+> verification off, do not also rotate the salt: keep the default, or keep every
+> build in that deployment on one value.
 
 ---
 

--- a/docs/rpc_identifiers.md
+++ b/docs/rpc_identifiers.md
@@ -1,0 +1,290 @@
+# RPC identifiers
+
+Every RPC the framework sends is named. RPC4 keys its slots by that name and
+puts it on the wire, so before this feature a packet capture read like a table
+of contents:
+
+```
+Framework::ChatMessage
+Framework::ClientIdentity
+M2O::PlayerShoot
+M2O::VehicleExplodeRequest
+```
+
+The same literals sat in the shipped binary, one `strings` away. With transport
+encryption off in the current build, that hands anyone watching the connection —
+or holding the DLL — the complete RPC surface, including which calls exist that
+a client is never supposed to send.
+
+`FW_RPC_IDENTIFIER` replaces the readable name with an opaque, per-build token.
+The source keeps the name; only the token reaches the binary and the wire.
+
+```cpp
+static constexpr const char *kIdentifier = FW_RPC_IDENTIFIER("M2O::PlayerReload");
+// ships and transmits as "baabatlnofbdftgr"
+```
+
+Nothing else about writing an RPC changes.
+
+> **Framework vs host mod.** Every framework RPC is already converted. Mod
+> identifiers (`M2O::*`, `HogwartsMP::*`, …) are **opt-in** — they still travel
+> in plaintext until a mod adopts the macro, which is what the rest of this
+> document is about.
+
+---
+
+## 1. How it works
+
+```
+"M2O::PlayerReload"  ──►  SipHash-2-4 keyed by FW_RPC_IDENTIFIER_SALT  ──►  64-bit hash
+                                                                              │
+                                     4 bits per character, 16 characters      ▼
+                          RPC4 slot key + wire  ◄──  "baabatlnofbdftgr"  ◄──  token
+```
+
+The name is only ever an argument to a template parameter, which C++ must
+evaluate at compile time. It therefore has no runtime existence: the compiler
+emits the finished token and nothing else. The token is a `static constexpr`
+array in the class template, so `.data()` hands back a plain `const char *` with
+static storage duration — exactly what RPC4's string-keyed API already wanted.
+
+Two design choices are worth knowing about, because both look arbitrary until
+you hit the thing they avoid.
+
+**The hash is keyed, not salted.** The obvious cheap construction is FNV-1a with
+the salt mixed into the initial state. It is also invertible: multiply by the
+modular inverse of the FNV prime and unwind the name backwards, and you recover
+the initial state, hence the salt. Every framework identifier name is public in
+this repository, so one observed token next to its known name would give up the
+salt and with it every other identifier in the build — which is precisely what
+the salt exists to prevent. SipHash-2-4 offers no such shortcut. It is pinned
+against its published reference vectors in `code/tests/modules/rpc_identifier_ut.h`.
+
+**The token is not hex.** RPC4 writes the identifier with `WriteCompressed`,
+which Huffman-codes it against RakNet's fixed *English* frequency table. Digits
+are expensive there — `0`–`9` cost 10 to 16 bits each — so a 16-character hex
+token would cost about 151 bits, *more* than most of the readable names it
+replaces. The alphabet is instead the sixteen cheapest characters in that table:
+
+```cpp
+inline constexpr char kIdentifierAlphabet[] = "eaintoshlrudbcfg";
+```
+
+That caps a token at 96 bits, below the cheapest name it replaces (110 bits for
+`Framework::SetOwner`), so hashing an identifier always makes the packet
+smaller. A unit test enforces this through the real `WriteCompressed` path, so
+editing the alphabet cannot silently regress it.
+
+---
+
+## 2. Using it in a mod
+
+### 2.1 Declare the payload
+
+Mod RPC headers usually include only `<mafianet/BitStream.h>`. Add the
+identifier header — or `<networking/rpc/rpc.h>`, which pulls it in — and wrap
+the name:
+
+```cpp
+#pragma once
+
+#include <networking/rpc/rpc_identifier.h>
+
+#include <mafianet/BitStream.h>
+
+#include <cstdint>
+
+namespace M2O::Shared::RPC {
+
+    // Event-driven weapon reload: client -> server, relayed to the other clients.
+    struct PlayerReload {
+        static constexpr const char *kIdentifier = FW_RPC_IDENTIFIER("M2O::PlayerReload");
+
+        uint64_t networkId = 0; // reloading avatar entity
+
+        void Serialize(MafiaNet::BitStream *bs, bool write) {
+            bs->Serialize(write, networkId);
+        }
+    };
+
+} // namespace M2O::Shared::RPC
+```
+
+That is the entire change. `kIdentifier` is still a `static constexpr const char *`,
+so the payload still satisfies the `Framework::Networking::RPC::Payload` concept
+and every existing call site keeps compiling.
+
+The header must live in the mod's **shared** tree. Client and server derive the
+token independently from the same source line, and they only agree because they
+compile the same string.
+
+### 2.2 Register the handler
+
+Unchanged — `RegisterRPC<T>` reads `T::kIdentifier` for you:
+
+```cpp
+// client/src/core/modules/human.cpp
+net->RegisterRPC<Shared::RPC::PlayerReload>([](const Shared::RPC::PlayerReload &reload, MafiaNet::Packet *) {
+    auto *human = Replication()->GetEntityByNetworkID(reload.networkId);
+    // ... replay the reload on the remote ped
+});
+```
+
+### 2.3 Send
+
+Unchanged, in all three flavours:
+
+```cpp
+Shared::RPC::PlayerReload reload;
+reload.networkId = GetNetworkID();
+
+net->BroadcastRPC(reload);                                    // to everyone
+net->SendRPC(reload, MafiaNet::ToGuid(human->ownerGUID));     // to one peer
+```
+
+Raw sends that pass the identifier themselves keep working too, because the
+macro still produces a `const char *`:
+
+```cpp
+// server/src/core/rpc/player_handlers.cpp — relay to everyone but the sender
+MafiaNet::BitStream bs;
+relayed.Serialize(&bs, true);
+netServer->SignalExcept(Shared::RPC::PlayerReload::kIdentifier, bs, packet->guid);
+```
+
+### 2.4 Naming rules
+
+- **Keep names unique and prefixed** (`M2O::PlayerReload`, not `PlayerReload`).
+  Two identical names now collide as one token instead of one string — the same
+  bug, equally silent, but no longer visible in a capture.
+- **Renaming an identifier is a wire break.** The token is derived from the exact
+  bytes of the name, so `M2O::PlayerReload` → `M2O::PlayerReloaded` re-keys the
+  slot and old peers stop dispatching it. Treat a rename like any other netcode
+  change.
+- **The argument must be a literal**, or at least a constant expression. A
+  runtime `std::string` will not compile, which is deliberate: it is the same
+  rule that keeps the readable name out of the binary.
+
+### 2.5 Convert a mod incrementally
+
+Identifiers are independent of each other — each one only has to match itself on
+the other peer. A mod can convert one header at a time, as long as **client and
+server ship together**, which a netcode change already requires. There is no
+mixed-mode compatibility: a converted identifier and an unconverted one are
+simply two different slot names.
+
+---
+
+## 3. The build salt
+
+```cpp
+#ifndef FW_RPC_IDENTIFIER_SALT
+#define FW_RPC_IDENTIFIER_SALT 0x9E3779B97F4A7C15ULL
+#endif
+```
+
+The salt keys the hash, so changing it re-derives *every* identifier at once. A
+name table someone recovered by reverse-engineering one release is worthless
+against the next.
+
+The default is a fixed constant, so local dev builds are deterministic and
+interoperate with each other without anyone configuring anything. Release CI
+overrides it per build:
+
+```bash
+cmake -B build -DFW_RPC_IDENTIFIER_SALT=0x8F2A17C4D9B3E051
+```
+
+`code/framework/CMakeLists.txt` turns that cache variable into a `PUBLIC`
+compile definition on the `Framework` target, so it reaches the preprocessor and
+propagates to every downstream target automatically. A `ULL` suffix is accepted
+but not required.
+
+> Setting it as a bare CMake cache variable is not enough on its own — a cache
+> variable never reaches the compiler by itself. This is why the wiring exists;
+> do not try to route around it with `add_definitions` in a mod's own
+> `CMakeLists.txt`, which would apply to the mod's targets but not to the
+> framework's.
+
+### Salt mismatch is caught at connect time
+
+Both peers must derive identical tokens, and a mismatch has no error path of its
+own: `Signal` to a slot the other side never registered is a no-op, so two peers
+with different salts would complete the handshake and then silently exchange
+nothing at all.
+
+`NetworkPeer::BuildToken` therefore folds `RPC::IdentifierSaltTag()` into the
+`TwoWayAuthentication` challenge, alongside the game and framework versions. A
+salt mismatch is refused at the gate, the same way a version mismatch already is.
+Mods get this for free — they already call `BuildToken`:
+
+```cpp
+net->SetBuildToken(Framework::Networking::NetworkPeer::BuildToken(
+    _opts.gameName, _opts.gameVersion, Utils::Version::rel, _opts.modVersion));
+```
+
+---
+
+## 4. Debugging
+
+The cost of opacity is that logs and captures show `baabatlnofbdftgr` instead of
+`M2O::PlayerReload`. The mapping is one-way at runtime, so recover it from the
+source side rather than trying to invert a token.
+
+Dump your own table in a dev build, right where the handlers are registered:
+
+```cpp
+#ifdef _DEBUG
+    Framework::Logging::GetLogger("RPC")->debug("{} -> {}", "M2O::PlayerReload", Shared::RPC::PlayerReload::kIdentifier);
+#endif
+```
+
+To test a hunch about a token seen in a capture, hash the candidate name in
+place — it costs nothing at runtime and resolves at compile time:
+
+```cpp
+FW_RPC_IDENTIFIER("M2O::PlayerShoot")   // compare against the token you captured
+```
+
+Both approaches need the salt the build in question used, which is the point:
+the mapping is only reconstructible by whoever can rebuild it.
+
+---
+
+## 5. Version semantics
+
+Hashing an identifier changes the wire format, so it is a **MAJOR** bump under
+the rules in `AGENTS.md` — client and server must be rebuilt together. For
+framework changes that happens automatically: `.github/bump_version.sh` lists
+`code/framework/src/networking/rpc` and `.../networking/replication` under
+`major_paths`. A mod converting its own identifiers is responsible for its own
+version bump.
+
+---
+
+## 6. What this does and does not protect
+
+**It does:**
+
+- remove readable RPC names from the shipped binary and from every packet,
+- make the mapping rotate per release, so a table recovered once does not keep
+  working,
+- cost less on the wire than the names it replaced.
+
+**It does not:**
+
+- encrypt anything. Payload *contents* are still plaintext on the wire; the fix
+  for that is enabling transport encryption (`LIBCAT_SECURITY` is currently `0`),
+  which is tracked separately. Identifier hashing narrows the surface, it does
+  not replace encryption.
+- make an identifier secret at runtime. Anyone who can run the client can
+  observe which token carries which behaviour by correlating traffic with what
+  happens in game. The goal is removing the free, offline table — not preventing
+  a determined attacker from rebuilding one.
+- authenticate anything. An identifier is a routing key, never a permission
+  check. A handler that trusts its sender was wrong before this change and is
+  still wrong after it — validate `packet->guid` against the sender's entity, the
+  way the framework's own handlers do.
+- cover application data. `EmitScriptEvent`'s script-defined event *name* is a
+  payload field, not an identifier, and stays readable. Entity type ids are a
+  separate unsalted CRC32.

--- a/docs/rpc_identifiers.md
+++ b/docs/rpc_identifiers.md
@@ -206,6 +206,77 @@ but not required.
 > `CMakeLists.txt`, which would apply to the mod's targets but not to the
 > framework's.
 
+### Rotating it in CI
+
+Three properties make a rotation worth doing. They are what to reproduce on
+whatever CI you use; the GitHub Actions shape below is just one way to get them.
+
+**Rotate on release builds, not on every build.** Every distinct salt produces a
+mutually incompatible build. Regenerating it per commit or per PR would leave CI
+artifacts unable to talk to anything at all — not to each other, not to a
+developer's local build, not to a running test server. The default in the header
+exists precisely so that everything not deliberately rotated agrees. Gate the
+override on your release job.
+
+**One value per release, shared by every target.** Derive it once and feed the
+same value to every build in that release — client and server both. Deriving it
+independently in two jobs is how you ship a client that cannot talk to its own
+server.
+
+**Make it unpredictable.** Deriving the salt from the version tag alone is
+pointless: the tag is public, so anyone can recompute the mapping and the
+rotation buys nothing. Key the derivation with a CI secret. HMAC of the tag under
+that secret is the useful shape — unpredictable without the key, yet reproducible
+from the tag once you have it, so you can rebuild a shipped release months later
+to debug it without having stored anything.
+
+```yaml
+jobs:
+  salt:
+    runs-on: ubuntu-latest
+    outputs:
+      value: ${{ steps.derive.outputs.value }}
+    steps:
+      - id: derive
+        run: |
+          SALT=$(printf '%s' "${{ github.ref_name }}" \
+            | openssl dgst -sha256 -hmac "${{ secrets.RPC_SALT_KEY }}" -r \
+            | cut -c1-16)
+          echo "::add-mask::0x${SALT}"
+          echo "value=0x${SALT}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: salt
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        target: [MyModClient, MyModServer]   # one salt, every target
+    steps:
+      - uses: actions/checkout@v5
+      # add-mask is per-job: without this the salt appears in this job's log.
+      - run: echo "::add-mask::${{ needs.salt.outputs.value }}"
+      - run: cmake -B build -DFW_RPC_IDENTIFIER_SALT=${{ needs.salt.outputs.value }}
+      - run: cmake --build build --target ${{ matrix.target }} --config Release
+```
+
+Two details that quietly undo the whole thing:
+
+- **Mask the salt in every job that touches it.** `::add-mask::` is scoped to the
+  job that sets it, and a derived value is not a registered secret, so it is *not*
+  redacted downstream. `cmake -B build -DFW_RPC_IDENTIFIER_SALT=…` is echoed into
+  the log like any other `run:` line, and a salt printed in a public build log is
+  a salt an attacker never had to work for.
+- **If you generate a random salt instead, record it** with the release artifacts,
+  somewhere private. A random value you did not keep means that release can never
+  be rebuilt — no debug symbols matching the shipped binary, no reproducing a
+  wire-level bug report against it.
+
+The framework's own release workflow (`.github/workflows/pr_tag_commit.yml`)
+does not rotate: it bumps `VERSION` and tags, and ships no binaries. Framework
+releases therefore carry the default salt, and rotation is entirely the mod
+pipeline's job — the mod is what actually ships a client and a server that have
+to agree.
+
 ### Salt mismatch is caught at connect time
 
 Both peers must derive identical tokens, and a mismatch has no error path of its


### PR DESCRIPTION
## Summary

RPC identifiers were plaintext on two surfaces. RPC4 keys its slots by, and transmits, the identifier as a string — `Signal`/`Call` write it with `WriteCompressed(RakString)`, and the receiver reads it back as a `RakString` for a string-keyed lookup. So every RPC packet carried a readable name like `Framework::ChatMessage` on the wire, and the same literals sat in the compiled binary. With no transport encryption in the current build, that hands a passive sniffer — and anyone running `strings` on a mod — the entire RPC surface.

This PR replaces each readable identifier with a **keyed compile-time hash**, so the binary and the wire carry only an opaque, per-build token.

Full write-up for mod authors: [`docs/rpc_identifiers.md`](docs/rpc_identifiers.md).

## Approach

New header `networking/rpc/rpc_identifier.h`:

- `FW_RPC_IDENTIFIER("Framework::ChatMessage")` → SipHash-2-4 of the name under a key derived from `FW_RPC_IDENTIFIER_SALT`, rendered as a stable 16-character token.
- The token backs a plain `const char*`, so **RPC4's string-keyed API is untouched** — registration, dispatch, and the `Payload` concept are unchanged.
- The readable name is consumed only inside a template argument (mandatory constant evaluation), so it is never referenced at runtime and does not reach the binary.

Converted every framework RPC identifier: `ClientIdentity`, `ChatMessage`, `ServerResources`, `ResourceRefresh`, `ResourceStop`, `VoiceSettings`, `VoiceSpeakerRange`, `VoicePreference`, `EmitScriptEvent`, plus the replication `ForceState` / `SetOwner` RPCs. Source keeps the readable names for developers.

### Why a keyed hash and not a salted FNV-1a

A salted FNV-1a is cheaper but **invertible**: multiply by the modular inverse of the FNV prime and unwind the name backwards, and you recover the seed — hence the salt. Every framework identifier name is public in this repository, so a single captured token plus its known name would hand over the salt and with it the whole table, which would leave the per-build rotation below doing nothing. A keyed PRF has no such shortcut. `SipHash24` is pinned against its published reference vectors in the tests.

### Why that token alphabet

RPC4 writes the identifier with `WriteCompressed`, i.e. Huffman-coded against RakNet's fixed *English* `StringCompressor` table. Hex is expensive there — digits cost 10–16 bits, only `a`–`f` are cheap — so a hex token would land at ~151 bits, **above most of the names it replaces**. The alphabet is instead the sixteen cheapest characters in that table (`eaintoshlrudbcfg`), which caps the token at 96 bits:

| identifier | plaintext | hex | this PR |
|---|---|---|---|
| `Framework::SetOwner` | 110 b | ~151 b | ≤96 b |
| `Framework::ForceState` | 117 b | ~151 b | ≤96 b |
| `Framework::ChatMessage` | 125 b | ~151 b | ≤96 b |
| `Framework::ServerResources` | 143 b | ~151 b | ≤96 b |
| `Framework::VoiceSpeakerRange` | 158 b | ~151 b | ≤96 b |

Worst case (96 bits) is below the cheapest plaintext name (110), so the token is unconditionally smaller than what it replaced. A test enforces this through the real `BitStream::WriteCompressed` path so a future alphabet edit cannot regress it.

## Per-build rotation

The salt makes the mapping per-build: bump `FW_RPC_IDENTIFIER_SALT`, or configure with `-DFW_RPC_IDENTIFIER_SALT=<uint64>` in release CI, to re-derive every identifier. `code/framework/CMakeLists.txt` turns that cache variable into a `PUBLIC` compile definition — a bare cache variable never reaches the preprocessor, so CI setting it would otherwise have silently kept the default. It accepts the value with or without a `ULL`/`ull` suffix. The default keeps local dev builds deterministic and interoperable.

Client and server must share the salt, and a mismatch has no error path of its own: `Signal` to a slot the other side never registered is a no-op, so the peers would complete the handshake and then silently dispatch nothing. `NetworkPeer::BuildToken` therefore folds in `IdentifierSaltTag()`, so `TwoWayAuthentication` rejects the connection at the gate — the same way a game or framework version mismatch already is.

## Compatibility

- **Wire-format change → MAJOR bump.** Automatic: `.github/bump_version.sh` lists both `networking/rpc` and `networking/replication` under `major_paths`, and this PR touches both. Client and server must be built together with the same salt.
- No API change for game code: payload structs still declare `kIdentifier`, just via the macro. Projects that define their own RPCs keep working unchanged, and can opt in to the macro.

## Scope / non-goals

- **Not** obfuscation of the transport itself. The right fix for wire confidentiality of *payloads* is enabling transport encryption (`LIBCAT_SECURITY` is currently `0`), reported separately. Identifier hashing narrows the surface and adds per-build rotation; it is not a substitute for encryption, and does not make identifiers secret at runtime.
- Project identifiers (`M2O::*`, `HogwartsMP::*`, `KCDMP::*`, `VantaMP::*`) are **still plaintext** — a follow-up per project, now that the macro exists. Converting four downstream mods inside a framework PR is a larger blast radius than this change warrants.
- Also out of scope: `EmitScriptEvent`'s script-defined event *name* (application data) and entity type ids (an unsalted CRC32; a candidate for the same treatment). The `TwoWayAuthentication` build-challenge identifier is a separate auth-plugin mechanism, left untouched.

## Testing

`code/tests/modules/rpc_identifier_ut.h` — 11 cases, swept across every converted identifier rather than a sample:

- the SipHash-2-4 core against the published reference vectors (key `000102…0f`, inputs of length 0–15),
- token opacity, 16-character length, and alphabet membership; alphabet is 16 distinct characters,
- pairwise distinctness across all 11 identifiers, and the token being exactly the alphabet rendering of the hash,
- determinism (both peers must agree) and rotation under a salt change, with an avalanche floor on both salt and name,
- **regression guard**: runs the FNV-1a unwind against the current construction and requires it to fail, so a swap back to an invertible mixer cannot pass,
- **wire cost**: encodes token and readable name through `BitStream::WriteCompressed` and requires the token to be cheaper,
- `static_assert`s that the derivation resolves entirely at compile time.

Verified locally on Windows/MSVC (`builds\build.bat FrameworkTests 64`), building each of the three commits in turn so `git bisect` has no broken point:

- full suite **26 modules / 324 tests, 0 failed**,
- scanning the built `Framework.lib` and `FrameworkServer.lib`: **0 occurrences** of any readable RPC name, with the derived tokens present instead — the names really do not ship, even in a debug build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * RPC identifiers are now represented as opaque, per-build tokens instead of readable names.
  * Builds can use a configurable identifier salt, with mismatched salts detected during connection setup.
  * Existing RPC registration and messaging workflows remain unchanged.

* **Documentation**
  * Added guidance for configuring, adopting, debugging, and rotating RPC identifiers.

* **Tests**
  * Added coverage for token generation, formatting, determinism, collision resistance, and salt behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->