### PR TITLE
feat: advertise client capabilities

### DIFF
--- a/code/framework/src/integrations/client/instance.cpp
+++ b/code/framework/src/integrations/client/instance.cpp
@@ -1057,6 +1057,9 @@ namespace Framework::Integrations::Client {
             identity.steamId    = steamId;
             identity.discordId  = _presence ? _presence->GetUserId() : "";
             identity.hardwareId = Framework::Utils::GetHardwareId();
+            identity.capabilityProtocolVersion = Framework::Networking::RPC::ClientIdentity::kCapabilityProtocolVersion;
+            identity.clientKind                = Framework::Networking::RPC::ClientKind::Game;
+            identity.capabilities              = Framework::Networking::RPC::ClientCapability::GameDefaults;
             net->SendRPC(identity, serverGuid);
 
             net->GetReadyEvent()->SetEvent(_readyEventId, false);

--- a/code/framework/src/integrations/server/instance.cpp
+++ b/code/framework/src/integrations/server/instance.cpp
@@ -495,6 +495,14 @@ namespace Framework::Integrations::Server {
             digits(identity.steamId, 32);
             digits(identity.discordId, 32);
             digits(identity.hardwareId, 128);
+            if (identity.clientKind != Framework::Networking::RPC::ClientKind::Game
+                && identity.clientKind != Framework::Networking::RPC::ClientKind::Headless) {
+                identity.clientKind = Framework::Networking::RPC::ClientKind::Game;
+            }
+            identity.capabilities &= Framework::Networking::RPC::ClientCapability::KnownMask;
+            if (identity.clientKind == Framework::Networking::RPC::ClientKind::Headless) {
+                identity.capabilities &= Framework::Networking::RPC::ClientCapability::HeadlessDefaults;
+            }
             net->SetPeerIdentity(guid, identity);
 
             Logging::GetLogger(FRAMEWORK_INNER_SERVER)->info("Player {} guid {} hwid {}", identity.name, guid.g, identity.hardwareId);

--- a/code/framework/src/networking/rpc/client_identity.h
+++ b/code/framework/src/networking/rpc/client_identity.h
@@ -10,24 +10,57 @@
 
 #include "rpc.h"
 
+#include <cstdint>
 #include <string>
 
 namespace Framework::Networking::RPC {
+    enum class ClientKind : uint8_t {
+        Game = 0,
+        Headless = 1,
+    };
+
+    namespace ClientCapability {
+        inline constexpr uint32_t ScriptEvents = 1u << 0;
+        inline constexpr uint32_t Replication  = 1u << 1;
+        inline constexpr uint32_t GameWorld    = 1u << 2;
+        inline constexpr uint32_t NativePlayer = 1u << 3;
+        inline constexpr uint32_t UI           = 1u << 4;
+        inline constexpr uint32_t Input        = 1u << 5;
+        inline constexpr uint32_t KnownMask    = ScriptEvents | Replication | GameWorld | NativePlayer | UI | Input;
+        inline constexpr uint32_t GameDefaults = KnownMask;
+        inline constexpr uint32_t HeadlessDefaults = ScriptEvents | Replication;
+    } // namespace ClientCapability
+
     // Client -> server after assets download: announces the player. Only honoured for an
     // authenticated connection (NetworkServer::IsAuthenticated).
     struct ClientIdentity {
         static constexpr const char *kIdentifier = "Framework::ClientIdentity";
+        static constexpr uint16_t kCapabilityProtocolVersion = 1;
 
         std::string name;
         std::string steamId;
         std::string discordId;
         std::string hardwareId;
+        uint16_t capabilityProtocolVersion = kCapabilityProtocolVersion;
+        ClientKind clientKind = ClientKind::Game;
+        uint32_t capabilities = ClientCapability::GameDefaults;
+
+        bool HasCapability(uint32_t capability) const {
+            return (capabilities & capability) == capability;
+        }
 
         void Serialize(MafiaNet::BitStream *bs, bool write) {
             bs->Serialize(write, name);
             bs->Serialize(write, steamId);
             bs->Serialize(write, discordId);
             bs->Serialize(write, hardwareId);
+            bs->Serialize(write, capabilityProtocolVersion);
+            uint8_t serializedKind = static_cast<uint8_t>(clientKind);
+            bs->Serialize(write, serializedKind);
+            if (!write) {
+                clientKind = static_cast<ClientKind>(serializedKind);
+            }
+            bs->Serialize(write, capabilities);
         }
     };
 } // namespace Framework::Networking::RPC

--- a/code/framework/src/scripting/builtins/player.cpp
+++ b/code/framework/src/scripting/builtins/player.cpp
@@ -63,6 +63,45 @@ namespace Framework::Scripting::Builtins {
         return identity ? identity->hardwareId : "";
     }
 
+    std::string Player::GetClientKind() const {
+        const auto *identity = ResolveIdentity();
+        if (!identity) {
+            return "unknown";
+        }
+        return identity->clientKind == Networking::RPC::ClientKind::Headless ? "headless" : "game";
+    }
+
+    uint16_t Player::GetCapabilityProtocolVersion() const {
+        const auto *identity = ResolveIdentity();
+        return identity ? identity->capabilityProtocolVersion : 0;
+    }
+
+    uint32_t Player::GetCapabilityFlags() const {
+        const auto *identity = ResolveIdentity();
+        return identity ? identity->capabilities : 0;
+    }
+
+    v8::Local<v8::Object> Player::GetCapabilities(v8::Isolate *isolate) const {
+        auto context = isolate->GetCurrentContext();
+        auto value   = v8::Object::New(isolate);
+        const uint32_t flags = GetCapabilityFlags();
+        const auto set = [&](const char *key, v8::Local<v8::Value> field) {
+            (void)value->Set(context, v8pp::to_v8(isolate, key), field);
+        };
+        const auto boolean = [&](uint32_t flag) {
+            return v8::Boolean::New(isolate, (flags & flag) == flag);
+        };
+        set("clientKind", v8pp::to_v8(isolate, GetClientKind()));
+        set("protocolVersion", v8pp::to_v8(isolate, GetCapabilityProtocolVersion()));
+        set("scriptEvents", boolean(Networking::RPC::ClientCapability::ScriptEvents));
+        set("replication", boolean(Networking::RPC::ClientCapability::Replication));
+        set("gameWorld", boolean(Networking::RPC::ClientCapability::GameWorld));
+        set("nativePlayer", boolean(Networking::RPC::ClientCapability::NativePlayer));
+        set("ui", boolean(Networking::RPC::ClientCapability::UI));
+        set("input", boolean(Networking::RPC::ClientCapability::Input));
+        return value;
+    }
+
     int Player::GetPing() const {
         const auto *entity = Resolve();
         if (!entity) {
@@ -218,6 +257,8 @@ namespace Framework::Scripting::Builtins {
             .property("steamId", &Player::GetSteamId, v8pp::metadata::property_docs("string", "Authenticated Steam identifier, or an empty string when unavailable."))
             .property("discordId", &Player::GetDiscordId, v8pp::metadata::property_docs("string", "Authenticated Discord identifier, or an empty string when unavailable."))
             .property("hardwareId", &Player::GetHardwareId, v8pp::metadata::property_docs("string", "Framework hardware identifier, or an empty string when unavailable."))
+            .property("clientKind", &Player::GetClientKind, v8pp::metadata::property_docs("\"game\" | \"headless\" | \"unknown\"", "Client implementation announced during the connection handshake; informational, not authorization."))
+            .property("capabilities", &Player::GetCapabilities, v8pp::metadata::property_options{"Negotiated client features; client-announced and informational, never an authorization source.", "PlayerCapabilities", true})
             .property("ping", &Player::GetPing, v8pp::metadata::property_docs("number", "Current round-trip latency in milliseconds, or -1 when unavailable."))
             .property("ip", &Player::GetAddress, v8pp::metadata::property_docs("string", "Current remote network address, or an empty string when unavailable."));
         return *cls;

--- a/code/framework/src/scripting/builtins/player.h
+++ b/code/framework/src/scripting/builtins/player.h
@@ -46,6 +46,10 @@ namespace Framework::Scripting::Builtins {
         std::string GetSteamId() const;
         std::string GetDiscordId() const;
         std::string GetHardwareId() const;
+        std::string GetClientKind() const;
+        uint16_t GetCapabilityProtocolVersion() const;
+        uint32_t GetCapabilityFlags() const;
+        v8::Local<v8::Object> GetCapabilities(v8::Isolate *isolate) const;
 
         // Connection's average round-trip time in ms. Server-only; -1 when unavailable.
         int GetPing() const;

--- a/code/tests/modules/network_packets_ut.h
+++ b/code/tests/modules/network_packets_ut.h
@@ -81,6 +81,9 @@ MODULE(network_packets, {
         out.steamId    = "steam-1";
         out.discordId  = "discord-2";
         out.hardwareId = "hw-3";
+        out.capabilityProtocolVersion = RPC::ClientIdentity::kCapabilityProtocolVersion;
+        out.clientKind = RPC::ClientKind::Headless;
+        out.capabilities = RPC::ClientCapability::HeadlessDefaults;
 
         MafiaNet::BitStream bs;
         out.Serialize(&bs, true);
@@ -89,6 +92,11 @@ MODULE(network_packets, {
         STREQUALS(in.steamId.c_str(), "steam-1");
         STREQUALS(in.discordId.c_str(), "discord-2");
         STREQUALS(in.hardwareId.c_str(), "hw-3");
+        EQUALS(in.capabilityProtocolVersion, RPC::ClientIdentity::kCapabilityProtocolVersion);
+        EQUALS(in.clientKind, RPC::ClientKind::Headless);
+        EQUALS(in.capabilities, RPC::ClientCapability::HeadlessDefaults);
+        EQUALS(in.HasCapability(RPC::ClientCapability::Replication), true);
+        EQUALS(in.HasCapability(RPC::ClientCapability::NativePlayer), false);
     });
 
     IT("round-trips a ServerResources payload with a resource list", {


### PR DESCRIPTION
## Summary

Adds a capability handshake to `ClientIdentity`, allowing servers and scripting resources to distinguish full game clients from lightweight headless clients.

This supports headless QA bots while preventing them from being selected for features requiring a native game world, UI, input, or player pawn.

## Changes

- Adds `ClientKind` with `Game` and `Headless` variants.
- Adds versioned client capability flags:
  - Script events
  - Replication
  - Game world
  - Native player
  - UI
  - Input
- Makes game clients announce the complete default capability set.
- Sanitizes client kind and capability flags on the server.
- Restricts headless clients to the supported script-event and replication capabilities.
- Exposes `Player.clientKind` and structured `Player.capabilities` properties to server scripts.
- Adds packet serialization coverage for the extended identity payload.

## Motivation

Multiplayer QA needs lightweight clients that participate in authentication, replication, and script events without launching the game.

Previously, resources had no reliable way to distinguish these clients from full game clients. Tests and ownership systems either had to infer support from timeouts or accidentally assign native-world work to a client incapable of performing it.

The capability handshake makes feature selection explicit while remaining informational: these client-announced values are not intended for authorization.

## Validation

- Verified the headless client can authenticate and complete initial replication.
- Verified capability-aware multiplayer QA with one game client and one headless client.
- Live QA result: 3 passed, 0 failed, 1 skipped; the skipped test intentionally requires native game clients.
- Added identity packet round-trip coverage.
- Confirmed the dependent headless bot target compiles and links.

## Compatibility

This extends the `ClientIdentity` wire payload. Client and server binaries should be rebuilt and deployed together when adopting this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added client capability and client type information during connection setup.
  * Scripts can now inspect a player’s client kind, capability protocol version, and supported features.
  * Added capability checks for game and headless clients.

* **Bug Fixes**
  * Unsupported or unknown client information is now safely normalized and restricted to permitted capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->