### PR TITLE
Voice: add a single-client test bench

### DIFF
--- a/code/framework/CMakeLists.txt
+++ b/code/framework/CMakeLists.txt
@@ -105,6 +105,7 @@ set(FRAMEWORK_CLIENT_SRC
 
     src/voice/client/mixer.cpp
     src/voice/client/audio_device.cpp
+    src/voice/client/voice_bench.cpp
     src/voice/client/voice_client.cpp
 )
 

--- a/code/framework/src/voice/client/voice_bench.cpp
+++ b/code/framework/src/voice/client/voice_bench.cpp
@@ -1,0 +1,128 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2026, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
+#include "voice_bench.h"
+
+#include <algorithm>
+#include <cmath>
+#include <utility>
+
+namespace Framework::Voice {
+    namespace {
+        constexpr int64_t kFrameDurationMs = kFrameSamples * 1000 / kSampleRate;
+        constexpr float kTwoPi             = 6.28318530718f;
+    } // namespace
+
+    void VoiceBench::Start(const BenchConfig &config) {
+        _config        = config;
+        _active        = true;
+        _lastTickMs    = 0; // first Advance only seeds the clock
+        _accumMs       = 0;
+        _pendingFrames = 0;
+    }
+
+    void VoiceBench::Stop() {
+        _active        = false;
+        _sweepActive   = false;
+        _pendingFrames = 0;
+    }
+
+    void VoiceBench::SetPosition(const glm::vec3 &position) {
+        _sweepActive = false;
+        _position    = position;
+    }
+
+    void VoiceBench::Sweep(const glm::vec3 &from, const glm::vec3 &to, float seconds, bool pingPong) {
+        if (seconds <= 0.0f) {
+            SetPosition(to);
+            return;
+        }
+
+        _sweepFrom       = from;
+        _sweepTo         = to;
+        _sweepDurationMs = seconds * 1000.0f;
+        _sweepElapsedMs  = 0.0f;
+        _sweepPingPong   = pingPong;
+        _sweepActive     = true;
+        _position        = from;
+    }
+
+    void VoiceBench::Advance(int64_t nowMs) {
+        if (!_active) {
+            return;
+        }
+
+        if (_lastTickMs == 0) {
+            _lastTickMs = nowMs;
+            return;
+        }
+
+        int64_t delta = std::clamp<int64_t>(nowMs - _lastTickMs, 0, kMaxCatchUpMs);
+        _lastTickMs   = nowMs;
+
+        AdvanceSweep(delta);
+
+        _accumMs += delta;
+        _pendingFrames += static_cast<int>(_accumMs / kFrameDurationMs);
+        _accumMs %= kFrameDurationMs;
+    }
+
+    bool VoiceBench::NextFrame(int16_t *out) {
+        if (!_active || _pendingFrames <= 0 || out == nullptr) {
+            return false;
+        }
+
+        _pendingFrames--;
+        GenerateFrame(out);
+        return true;
+    }
+
+    void VoiceBench::AdvanceSweep(int64_t deltaMs) {
+        if (!_sweepActive) {
+            return;
+        }
+
+        _sweepElapsedMs += static_cast<float>(deltaMs);
+        if (_sweepElapsedMs >= _sweepDurationMs) {
+            if (_sweepPingPong) {
+                _sweepElapsedMs -= _sweepDurationMs;
+                std::swap(_sweepFrom, _sweepTo);
+            }
+            else {
+                _sweepActive = false;
+                _position    = _sweepTo;
+                return;
+            }
+        }
+
+        const float t = std::clamp(_sweepElapsedMs / _sweepDurationMs, 0.0f, 1.0f);
+        _position     = _sweepFrom + (_sweepTo - _sweepFrom) * t;
+    }
+
+    void VoiceBench::GenerateFrame(int16_t *out) {
+        const float amplitude = std::clamp(_config.amplitude, 0.0f, 1.0f);
+
+        if (_config.signal == BenchConfig::Signal::Noise) {
+            for (uint32_t i = 0; i < kFrameSamples; i++) {
+                _noiseState = _noiseState * 1664525u + 1013904223u;
+                out[i]      = static_cast<int16_t>(static_cast<float>(static_cast<int16_t>(_noiseState >> 16)) * amplitude);
+            }
+            return;
+        }
+
+        // Phase carries across frames, otherwise every 20ms boundary clicks.
+        const float step = kTwoPi * _config.frequency / static_cast<float>(kSampleRate);
+        for (uint32_t i = 0; i < kFrameSamples; i++) {
+            out[i] = static_cast<int16_t>(std::sin(_phase) * amplitude * 32767.0f);
+            _phase += step;
+            if (_phase >= kTwoPi) {
+                _phase -= kTwoPi;
+            }
+        }
+    }
+} // namespace Framework::Voice

--- a/code/framework/src/voice/client/voice_bench.cpp
+++ b/code/framework/src/voice/client/voice_bench.cpp
@@ -89,14 +89,18 @@ namespace Framework::Voice {
 
         _sweepElapsedMs += static_cast<float>(deltaMs);
         if (_sweepElapsedMs >= _sweepDurationMs) {
-            if (_sweepPingPong) {
-                _sweepElapsedMs -= _sweepDurationMs;
-                std::swap(_sweepFrom, _sweepTo);
-            }
-            else {
+            if (!_sweepPingPong) {
                 _sweepActive = false;
                 _position    = _sweepTo;
                 return;
+            }
+
+            // One tick can cross several durations when the sweep is shorter than the frame time.
+            // Each crossing is one reversal, and leaving the excess would burn a lap per tick.
+            const float laps = std::floor(_sweepElapsedMs / _sweepDurationMs);
+            _sweepElapsedMs -= laps * _sweepDurationMs;
+            if (static_cast<long long>(laps) % 2 != 0) {
+                std::swap(_sweepFrom, _sweepTo);
             }
         }
 

--- a/code/framework/src/voice/client/voice_bench.h
+++ b/code/framework/src/voice/client/voice_bench.h
@@ -1,0 +1,96 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2026, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
+#pragma once
+
+#include "mixer.h"
+#include "voice/voice_config.h"
+
+#include <array>
+#include <cstdint>
+
+namespace Framework::Voice {
+    // Identity of the synthetic speaker. One below UNASSIGNED_RAKNET_GUID, so it cannot collide
+    // with a real peer.
+    constexpr uint64_t kBenchSpeakerId = 0xFFFFFFFFFFFFFFFEULL;
+
+    struct BenchConfig {
+        enum class Signal { Tone, Noise };
+
+        Signal signal   = Signal::Tone;
+        float frequency = 440.0f; // Hz, Tone only
+        float amplitude = 0.25f;  // 0..1 peak
+    };
+
+    // Diagnostic snapshot. Assembled by VoiceClient, which owns the listener and the ranges.
+    struct BenchState {
+        bool active   = false;
+        bool sweeping = false;
+        glm::vec3 position {0.0f};
+        glm::vec3 listener {0.0f};
+        float distance = 0.0f;
+        float range    = 0.0f;
+        SpeakerGain gain {};
+    };
+
+    // Signal source for single-client voice testing: a steady tone or noise at a movable world
+    // position, so attenuation and panning can be exercised with no second player, microphone or
+    // network. Pure harness -- it neither mixes nor sends; the caller pumps it and submits.
+    class VoiceBench final {
+      public:
+        void Start(const BenchConfig &config);
+        void Stop();
+
+        // Cancels any sweep in progress.
+        void SetPosition(const glm::vec3 &position);
+        void Sweep(const glm::vec3 &from, const glm::vec3 &to, float seconds, bool pingPong);
+
+        // Advances the sweep and queues whole frames against the wall clock. Emitting per tick
+        // instead would starve or overrun the consumer at any frame rate but exactly 50fps.
+        void Advance(int64_t nowMs);
+
+        // Pulls one queued 20ms frame into `out` (kFrameSamples mono int16); false when none.
+        bool NextFrame(int16_t *out);
+
+        bool IsActive() const {
+            return _active;
+        }
+        bool IsSweeping() const {
+            return _sweepActive;
+        }
+        const glm::vec3 &GetPosition() const {
+            return _position;
+        }
+        float GetSweepProgress() const {
+            return _sweepDurationMs > 0.0f ? _sweepElapsedMs / _sweepDurationMs : 0.0f;
+        }
+
+      private:
+        // A frame-rate hitch must not dump a burst that overruns the consumer's ring.
+        static constexpr int64_t kMaxCatchUpMs = 200;
+
+        void AdvanceSweep(int64_t deltaMs);
+        void GenerateFrame(int16_t *out);
+
+        BenchConfig _config {};
+        bool _active         = false;
+        glm::vec3 _position {0.0f};
+        float _phase         = 0.0f;
+        uint32_t _noiseState = 0x13579BDFu;
+        int64_t _lastTickMs  = 0;
+        int64_t _accumMs     = 0;
+        int _pendingFrames   = 0;
+
+        bool _sweepActive      = false;
+        bool _sweepPingPong    = false;
+        glm::vec3 _sweepFrom {0.0f};
+        glm::vec3 _sweepTo {0.0f};
+        float _sweepDurationMs = 0.0f;
+        float _sweepElapsedMs  = 0.0f;
+    };
+} // namespace Framework::Voice

--- a/code/framework/src/voice/client/voice_client.cpp
+++ b/code/framework/src/voice/client/voice_client.cpp
@@ -257,6 +257,8 @@ namespace Framework::Voice {
     }
 
     void VoiceClient::Shutdown() {
+        // Before the sink pointer goes: a custom sink would otherwise keep the bench's slot.
+        BenchStop();
         CloseSession();
 
         _capture.Stop();
@@ -704,10 +706,15 @@ namespace Framework::Voice {
         const float range = ResolveRange(kBenchSpeakerId);
         // Walk out from the distance origin, so a plotted point at x really is x away.
         const glm::vec3 origin = glm::dot(_listener.attenuationPosition, _listener.attenuationPosition) > 0.0f ? _listener.attenuationPosition : _listener.position;
+        // The curve's x axis is a distance, so the step must be unit length; ListenerTransform
+        // promises no such thing, and a degenerate forward would sample the origin every time.
+        const float forwardLen = glm::length(_listener.forward);
+        const glm::vec3 step   = forwardLen > 0.0001f ? _listener.forward / forwardLen : glm::vec3(0.0f, 0.0f, -1.0f);
+
         curve.reserve(samples);
         for (size_t i = 0; i < samples; i++) {
             const float distance   = maxDistance * (static_cast<float>(i) / static_cast<float>(samples - 1));
-            const SpeakerGain gain = ComputeGain(_listener, origin + _listener.forward * distance, range);
+            const SpeakerGain gain = ComputeGain(_listener, origin + step * distance, range);
             // Constant-power pan makes left^2 + right^2 the attenuation, independent of bearing.
             curve.push_back(std::sqrt(gain.left * gain.left + gain.right * gain.right));
         }
@@ -736,6 +743,12 @@ namespace Framework::Voice {
         // left holding voices it will not be told to release.
         for (size_t i = 0; i < _admitted.size(); i++) {
             ReleaseAdmitted(static_cast<int>(i));
+        }
+
+        // The bench never enters _admitted, so the loop above does not cover it. UpdateBench
+        // re-submits on the next tick, which acquires a slot on the replacement.
+        if (_bench.IsActive() && _sink != nullptr) {
+            _sink->ReleaseSpeaker(kBenchSpeakerId);
         }
 
         _sink = next;

--- a/code/framework/src/voice/client/voice_client.cpp
+++ b/code/framework/src/voice/client/voice_client.cpp
@@ -438,6 +438,9 @@ namespace Framework::Voice {
         UpdateSession();
         PumpCapture();
         PumpSpeakers();
+        // Before PublishWorld: the sink allocates the bench's slot on its first Submit, and
+        // PublishWorld places speakers by the slot they already hold.
+        UpdateBench();
         PublishWorld();
     }
 
@@ -520,6 +523,15 @@ namespace Framework::Voice {
 
             _published.push_back(it->second.placement);
             _published.back().range = ResolveRange(admitted.id);
+        }
+
+        // Placed outside _placements so a game's per-tick speaker pass cannot retire it.
+        if (_bench.IsActive()) {
+            SpeakerPlacement bench;
+            bench.speaker  = kBenchSpeakerId;
+            bench.position = _bench.GetPosition();
+            bench.range    = ResolveRange(kBenchSpeakerId);
+            _published.push_back(bench);
         }
 
         // Without a listener every gain is computed against the origin, so a mod that forgot
@@ -656,6 +668,61 @@ namespace Framework::Voice {
         const int slot = FindAdmitted(speaker);
         if (slot >= 0) {
             ReleaseAdmitted(slot);
+        }
+    }
+
+    void VoiceClient::BenchStop() {
+        if (!_bench.IsActive()) {
+            return;
+        }
+
+        _bench.Stop();
+        if (_sink != nullptr) {
+            _sink->ReleaseSpeaker(kBenchSpeakerId);
+        }
+    }
+
+    BenchState VoiceClient::GetBenchState() const {
+        BenchState state;
+        state.active   = _bench.IsActive();
+        state.sweeping = _bench.IsSweeping();
+        state.position = _bench.GetPosition();
+        // Report against the distance origin, so the readout cannot disagree with what is heard.
+        state.listener = glm::dot(_listener.attenuationPosition, _listener.attenuationPosition) > 0.0f ? _listener.attenuationPosition : _listener.position;
+        state.distance = glm::length(state.position - state.listener);
+        state.range    = ResolveRange(kBenchSpeakerId);
+        state.gain     = ComputeGain(_listener, state.position, state.range);
+        return state;
+    }
+
+    std::vector<float> VoiceClient::BenchSampleCurve(float maxDistance, size_t samples) const {
+        std::vector<float> curve;
+        if (samples < 2 || maxDistance <= 0.0f) {
+            return curve;
+        }
+
+        const float range = ResolveRange(kBenchSpeakerId);
+        // Walk out from the distance origin, so a plotted point at x really is x away.
+        const glm::vec3 origin = glm::dot(_listener.attenuationPosition, _listener.attenuationPosition) > 0.0f ? _listener.attenuationPosition : _listener.position;
+        curve.reserve(samples);
+        for (size_t i = 0; i < samples; i++) {
+            const float distance   = maxDistance * (static_cast<float>(i) / static_cast<float>(samples - 1));
+            const SpeakerGain gain = ComputeGain(_listener, origin + _listener.forward * distance, range);
+            // Constant-power pan makes left^2 + right^2 the attenuation, independent of bearing.
+            curve.push_back(std::sqrt(gain.left * gain.left + gain.right * gain.right));
+        }
+
+        return curve;
+    }
+
+    void VoiceClient::UpdateBench() {
+        if (!_bench.IsActive() || _sink == nullptr) {
+            return;
+        }
+
+        _bench.Advance(Utils::Time::GetTime());
+        while (_bench.NextFrame(_benchFrame.data())) {
+            _sink->Submit(kBenchSpeakerId, _benchFrame.data(), kFrameSamples);
         }
     }
 

--- a/code/framework/src/voice/client/voice_client.h
+++ b/code/framework/src/voice/client/voice_client.h
@@ -11,6 +11,7 @@
 #include "audio_device.h"
 #include "i_voice_sink.h"
 #include "mixer.h"
+#include "voice_bench.h"
 #include "voice/voice_config.h"
 
 #include <mafianet/RakVoice.h>
@@ -234,6 +235,30 @@ namespace Framework::Voice {
             return _localSink.GetMasterVolume();
         }
 
+        // --- diagnostics ---
+
+        // Single-client test bench: a synthetic speaker mixed as if it had been relayed. Needs an
+        // open session, since the playback device opens with one.
+        void BenchStart(const BenchConfig &config) {
+            _bench.Start(config);
+        }
+        void BenchStop();
+        void BenchSetPosition(const glm::vec3 &position) {
+            _bench.SetPosition(position);
+        }
+        void BenchSweep(const glm::vec3 &from, const glm::vec3 &to, float seconds, bool pingPong) {
+            _bench.Sweep(from, to, seconds, pingPong);
+        }
+        BenchState GetBenchState() const;
+
+        // Attenuation at `samples` evenly spaced distances over [0, maxDistance], sampled from
+        // ComputeGain itself so a diagnostic plot cannot drift from what the mixer applies.
+        std::vector<float> BenchSampleCurve(float maxDistance, size_t samples) const;
+
+        bool IsInputSuppressed() const {
+            return _inputSuppressed;
+        }
+
       private:
         struct AdmittedSpeaker {
             uint64_t id       = 0;
@@ -267,6 +292,7 @@ namespace Framework::Voice {
         void PumpCapture();
         void PumpSpeakers();
         void PublishWorld();
+        void UpdateBench();
 
         int FindAdmitted(uint64_t speaker) const;
         bool IsSelf(uint64_t speaker) const;
@@ -304,6 +330,9 @@ namespace Framework::Voice {
         float _hearingRange           = 0.0f;
         float _defaultSpeakerRange    = kDefaultProximityRange;
         std::array<AdmittedSpeaker, kMaxAudibleTalkers> _admitted {};
+
+        VoiceBench _bench;
+        std::array<int16_t, kFrameSamples> _benchFrame {};
 
         // Reused every tick so the per-frame path never allocates.
         std::array<int16_t, kFrameSamples> _frame {};


### PR DESCRIPTION
Proximity voice could only be exercised with two players and two microphones, which made the one layer most likely to be misconfigured -- distance attenuation and panning -- the hardest to check. VoiceBench generates a steady tone or noise at a movable world position and VoiceClient submits it as a synthetic speaker, so the mixer can be driven and measured by one client with no microphone and no network.

The harness owns only signal generation, the sweep and the wall-clock pacing; VoiceClient contributes the parts that need its private state -- submitting into the sink and appending a placement that its host's per-tick speaker pass cannot retire. Frames are emitted against the wall clock rather than per tick, or the ring starves or overruns at any frame rate but exactly 50fps, and both sound like a spatialisation fault.

BenchSampleCurve samples ComputeGain itself rather than reproducing its curve, so a diagnostic plot cannot drift from what is actually mixed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added voice benchmarking with generated sine-wave or noise audio.
  * Supports fixed positioning, ping-pong movement sweeps, and real-time progress tracking.
  * Added diagnostic state and attenuation-curve sampling for evaluating voice behavior.
  * Bench audio can be started, stopped, positioned, and submitted through the voice system.
  * Added input-suppression status reporting during benchmark playback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->