### PR TITLE
Scripting: Await asynchronous resource lifecycle handlers

### DIFF
--- a/code/framework/src/scripting/builtins/events.cpp
+++ b/code/framework/src/scripting/builtins/events.cpp
@@ -519,6 +519,28 @@ namespace Framework::Scripting::Builtins {
         }
     }
 
+    void Events::CancelPendingEmission(v8::Isolate *isolate, v8::Local<v8::Promise> promise) {
+        if (!isolate || promise.IsEmpty()) {
+            return;
+        }
+
+        std::scoped_lock lock(_pendingCallbacksMutex);
+        for (auto it = _pendingCallbacks.begin(); it != _pendingCallbacks.end(); ++it) {
+            const auto &data = *it;
+            if (data->resolver.IsEmpty()) {
+                continue;
+            }
+
+            auto resolver = data->resolver.Get(isolate);
+            if (!resolver.IsEmpty() && resolver->GetPromise()->StrictEquals(promise)) {
+                data->cancelled.store(true, std::memory_order_release);
+                data->resolver.Reset();
+                _pendingCallbacks.erase(it);
+                return;
+            }
+        }
+    }
+
     void Events::AggregateWithAllSettled(v8::Isolate *isolate, v8::Local<v8::Context> context, v8::Local<v8::Array> promises, v8::Local<v8::Promise::Resolver> resolver, const std::string &aggregateErrorMessage) {
         // Get Promise.allSettled
         v8::MaybeLocal<v8::Value> maybePromiseCtor = context->Global()->Get(context, v8pp::to_v8(isolate, "Promise"));

--- a/code/framework/src/scripting/builtins/events.h
+++ b/code/framework/src/scripting/builtins/events.h
@@ -118,6 +118,12 @@ namespace Framework::Scripting::Builtins {
                                           const std::vector<v8::Local<v8::Value>> &args);
 
         /**
+         * Release the native resolver retained for one emitted Promise. Used by bounded native
+         * callers when they stop waiting; unrelated event emissions remain intact.
+         */
+        void CancelPendingEmission(v8::Isolate *isolate, v8::Local<v8::Promise> promise);
+
+        /**
          * Clean up all handlers for a resource (called on resource stop).
          */
         void CleanupResource(std::string_view resourceName);

--- a/code/framework/src/scripting/engine.h
+++ b/code/framework/src/scripting/engine.h
@@ -64,6 +64,10 @@ namespace Framework::Scripting {
          */
         virtual bool ExecuteFile(std::string_view filepath) = 0;
 
+        // Advance microtasks, timers, and host I/O without blocking. Resource lifecycle barriers use
+        // this while awaiting async resourceStart/resourceStop handlers.
+        virtual void Tick() = 0;
+
         // Evict cached modules under a resource dir so hot-reload re-reads
         // edited files. No-op without a module cache; call only after stop.
         virtual void EvictModulesUnderPath(const std::string &rootPath) {}

--- a/code/framework/src/scripting/node_engine.h
+++ b/code/framework/src/scripting/node_engine.h
@@ -100,7 +100,7 @@ namespace Framework::Scripting {
          * Process pending Node.js events (non-blocking).
          * Call this from game loop to process async operations.
          */
-        void Tick();
+        void Tick() override;
 
         /**
          * Pending uncaught error from process.on('uncaughtException') or

--- a/code/framework/src/scripting/resource/resource_manager.cpp
+++ b/code/framework/src/scripting/resource/resource_manager.cpp
@@ -33,9 +33,7 @@ namespace Framework::Scripting {
             std::string error;
         };
 
-        std::string StringifyPromiseRejection(v8::Isolate *isolate,
-                                              v8::Local<v8::Context> context,
-                                              v8::Local<v8::Value> reason) {
+        std::string StringifyPromiseRejection(v8::Isolate *isolate, v8::Local<v8::Context> context, v8::Local<v8::Value> reason) {
             v8::TryCatch tryCatch(isolate);
             const auto stringify = [&](v8::Local<v8::Value> value) {
                 v8::Local<v8::String> text;
@@ -50,9 +48,7 @@ namespace Framework::Scripting {
             std::string result = stringify(reason);
             if (!reason.IsEmpty() && reason->IsObject()) {
                 v8::Local<v8::Value> errorsValue;
-                if (reason.As<v8::Object>()->Get(context,
-                        v8::String::NewFromUtf8Literal(isolate, "errors")).ToLocal(&errorsValue)
-                    && errorsValue->IsArray()) {
+                if (reason.As<v8::Object>()->Get(context, v8::String::NewFromUtf8Literal(isolate, "errors")).ToLocal(&errorsValue) && errorsValue->IsArray()) {
                     auto errors = errorsValue.As<v8::Array>();
                     for (uint32_t i = 0; i < errors->Length(); ++i) {
                         v8::Local<v8::Value> item;
@@ -72,16 +68,12 @@ namespace Framework::Scripting {
         // Lifecycle entry points remain synchronous to their C++ callers, but the JS work they gate
         // is asynchronous. Pump the shared scripting engine so microtasks, timers, and Node/libuv I/O
         // can make progress; a plain blocking wait here would deadlock every meaningful async handler.
-        LifecyclePromiseResult AwaitLifecyclePromise(Engine *engine,
-                                                      Builtins::Events &events,
-                                                      v8::Global<v8::Promise> &promise,
-                                                      int timeoutMs) {
+        LifecyclePromiseResult AwaitLifecyclePromise(Engine *engine, Builtins::Events &events, v8::Global<v8::Promise> &promise, int timeoutMs) {
             if (!engine || !engine->IsInitialized() || promise.IsEmpty()) {
                 return {};
             }
 
-            const auto deadline = std::chrono::steady_clock::now()
-                + std::chrono::milliseconds(std::max(timeoutMs, 1));
+            const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(std::max(timeoutMs, 1));
             for (;;) {
                 {
                     v8::Isolate *isolate = engine->GetIsolate();
@@ -489,17 +481,13 @@ namespace Framework::Scripting {
             SetCurrentResourceContext("");
         }
 
-        const auto startLifecycle = AwaitLifecyclePromise(
-            _jsEngine, _events, startPromise, _config.resourceStartTimeoutMs);
+        const auto startLifecycle = AwaitLifecyclePromise(_jsEngine, _events, startPromise, _config.resourceStartTimeoutMs);
         if (startLifecycle.status != LifecyclePromiseStatus::Fulfilled) {
-            error = startLifecycle.status == LifecyclePromiseStatus::TimedOut
-                ? "resourceStart timed out after " + std::to_string(std::max(_config.resourceStartTimeoutMs, 1)) + "ms"
-                : "resourceStart rejected: " + startLifecycle.error;
+            error = startLifecycle.status == LifecyclePromiseStatus::TimedOut ? "resourceStart timed out after " + std::to_string(std::max(_config.resourceStartTimeoutMs, 1)) + "ms" : "resourceStart rejected: " + startLifecycle.error;
             CleanupResourceRuntime(*resource, name);
             resource->SetError(error);
             FireOnResourceError(std::string(name), error);
-            Logging::GetLogger(FRAMEWORK_INNER_SCRIPTING)->error(
-                "Failed to start JS resource '{}': {}", name, error);
+            Logging::GetLogger(FRAMEWORK_INNER_SCRIPTING)->error("Failed to start JS resource '{}': {}", name, error);
             return ResourceOperationResult(error);
         }
 
@@ -567,16 +555,12 @@ namespace Framework::Scripting {
             SetCurrentResourceContext("");
         }
 
-        const auto stopLifecycle = AwaitLifecyclePromise(
-            _jsEngine, _events, stopPromise, _config.resourceStopTimeoutMs);
+        const auto stopLifecycle = AwaitLifecyclePromise(_jsEngine, _events, stopPromise, _config.resourceStopTimeoutMs);
         if (stopLifecycle.status == LifecyclePromiseStatus::Rejected) {
-            Logging::GetLogger(FRAMEWORK_INNER_SCRIPTING)->error(
-                "resourceStop for '{}' rejected; forcing cleanup: {}", name, stopLifecycle.error);
+            Logging::GetLogger(FRAMEWORK_INNER_SCRIPTING)->error("resourceStop for '{}' rejected; forcing cleanup: {}", name, stopLifecycle.error);
         }
         else if (stopLifecycle.status == LifecyclePromiseStatus::TimedOut) {
-            Logging::GetLogger(FRAMEWORK_INNER_SCRIPTING)->error(
-                "resourceStop for '{}' timed out after {}ms; forcing cleanup",
-                name, std::max(_config.resourceStopTimeoutMs, 1));
+            Logging::GetLogger(FRAMEWORK_INNER_SCRIPTING)->error("resourceStop for '{}' timed out after {}ms; forcing cleanup", name, std::max(_config.resourceStopTimeoutMs, 1));
         }
 
         CleanupResourceRuntime(*resource, name);
@@ -902,8 +886,7 @@ namespace Framework::Scripting {
         return true;
     }
 
-    void ResourceManager::CleanupResourceRuntime(Resource &resource,
-                                                 std::string_view resourceName) {
+    void ResourceManager::CleanupResourceRuntime(Resource &resource, std::string_view resourceName) {
         CallResourceStop(resourceName);
         if (_jsEngine) {
             _jsEngine->ClearResourceTimers(std::string(resourceName));

--- a/code/framework/src/scripting/resource/resource_manager.cpp
+++ b/code/framework/src/scripting/resource/resource_manager.cpp
@@ -18,9 +18,112 @@
 #include <filesystem>
 #include <queue>
 #include <stack>
+#include <thread>
 
 namespace Framework::Scripting {
     namespace {
+        enum class LifecyclePromiseStatus {
+            Fulfilled,
+            Rejected,
+            TimedOut,
+        };
+
+        struct LifecyclePromiseResult {
+            LifecyclePromiseStatus status = LifecyclePromiseStatus::Fulfilled;
+            std::string error;
+        };
+
+        std::string StringifyPromiseRejection(v8::Isolate *isolate,
+                                              v8::Local<v8::Context> context,
+                                              v8::Local<v8::Value> reason) {
+            v8::TryCatch tryCatch(isolate);
+            const auto stringify = [&](v8::Local<v8::Value> value) {
+                v8::Local<v8::String> text;
+                if (value.IsEmpty() || !value->ToString(context).ToLocal(&text)) {
+                    tryCatch.Reset();
+                    return std::string("Promise rejected");
+                }
+                v8::String::Utf8Value utf8(isolate, text);
+                return *utf8 ? std::string(*utf8, utf8.length()) : std::string("Promise rejected");
+            };
+
+            std::string result = stringify(reason);
+            if (!reason.IsEmpty() && reason->IsObject()) {
+                v8::Local<v8::Value> errorsValue;
+                if (reason.As<v8::Object>()->Get(context,
+                        v8::String::NewFromUtf8Literal(isolate, "errors")).ToLocal(&errorsValue)
+                    && errorsValue->IsArray()) {
+                    auto errors = errorsValue.As<v8::Array>();
+                    for (uint32_t i = 0; i < errors->Length(); ++i) {
+                        v8::Local<v8::Value> item;
+                        if (errors->Get(context, i).ToLocal(&item)) {
+                            result += i == 0 ? ": " : "; ";
+                            result += stringify(item);
+                        }
+                    }
+                }
+            }
+            if (tryCatch.HasCaught()) {
+                tryCatch.Reset();
+            }
+            return result;
+        }
+
+        // Lifecycle entry points remain synchronous to their C++ callers, but the JS work they gate
+        // is asynchronous. Pump the shared scripting engine so microtasks, timers, and Node/libuv I/O
+        // can make progress; a plain blocking wait here would deadlock every meaningful async handler.
+        LifecyclePromiseResult AwaitLifecyclePromise(Engine *engine,
+                                                      Builtins::Events &events,
+                                                      v8::Global<v8::Promise> &promise,
+                                                      int timeoutMs) {
+            if (!engine || !engine->IsInitialized() || promise.IsEmpty()) {
+                return {};
+            }
+
+            const auto deadline = std::chrono::steady_clock::now()
+                + std::chrono::milliseconds(std::max(timeoutMs, 1));
+            for (;;) {
+                {
+                    v8::Isolate *isolate = engine->GetIsolate();
+                    v8::Locker locker(isolate);
+                    v8::Isolate::Scope isolateScope(isolate);
+                    v8::HandleScope handleScope(isolate);
+                    v8::Local<v8::Context> context = engine->GetContext();
+                    v8::Context::Scope contextScope(context);
+                    auto local = promise.Get(isolate);
+                    if (local.IsEmpty()) {
+                        promise.Reset();
+                        return {};
+                    }
+                    if (local->State() == v8::Promise::PromiseState::kFulfilled) {
+                        promise.Reset();
+                        return {};
+                    }
+                    if (local->State() == v8::Promise::PromiseState::kRejected) {
+                        auto error = StringifyPromiseRejection(isolate, context, local->Result());
+                        promise.Reset();
+                        return {LifecyclePromiseStatus::Rejected, std::move(error)};
+                    }
+                }
+
+                if (std::chrono::steady_clock::now() >= deadline) {
+                    v8::Isolate *isolate = engine->GetIsolate();
+                    v8::Locker locker(isolate);
+                    v8::Isolate::Scope isolateScope(isolate);
+                    v8::HandleScope handleScope(isolate);
+                    auto local = promise.Get(isolate);
+                    if (!local.IsEmpty()) {
+                        events.CancelPendingEmission(isolate, local);
+                    }
+                    promise.Reset();
+                    return {LifecyclePromiseStatus::TimedOut, {}};
+                }
+
+                engine->Tick();
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            }
+        }
+
         bool IsPathInsideRoot(const std::filesystem::path &path, const std::filesystem::path &root) {
             auto canonicalRoot = std::filesystem::weakly_canonical(root);
             auto canonicalPath = std::filesystem::weakly_canonical(path);
@@ -359,12 +462,14 @@ namespace Framework::Scripting {
         // Execute the entry point script
         std::string error;
         if (!ExecuteResourceScript(*resource, error)) {
+            CleanupResourceRuntime(*resource, name);
             resource->SetError(error);
             FireOnResourceError(std::string(name), error);
             return ResourceOperationResult(error);
         }
 
         // Emit resourceStart event (bypass running check since resource is still Loading)
+        v8::Global<v8::Promise> startPromise;
         if (_jsEngine && _jsEngine->IsInitialized()) {
             v8::Isolate *isolate = _jsEngine->GetIsolate();
             v8::Locker locker(isolate);
@@ -378,8 +483,24 @@ namespace Framework::Scripting {
             args.push_back(v8pp::to_v8(isolate, nameStr));
 
             SetCurrentResourceContext(nameStr);
-            _events.EmitReserved(isolate, context, "resourceStart", args);
+            auto emitted = _events.EmitReserved(isolate, context, "resourceStart", args);
+            emitted->MarkAsHandled(); // C++ observes State()/Result(); avoid an unhandled-rejection echo
+            startPromise.Reset(isolate, emitted);
             SetCurrentResourceContext("");
+        }
+
+        const auto startLifecycle = AwaitLifecyclePromise(
+            _jsEngine, _events, startPromise, _config.resourceStartTimeoutMs);
+        if (startLifecycle.status != LifecyclePromiseStatus::Fulfilled) {
+            error = startLifecycle.status == LifecyclePromiseStatus::TimedOut
+                ? "resourceStart timed out after " + std::to_string(std::max(_config.resourceStartTimeoutMs, 1)) + "ms"
+                : "resourceStart rejected: " + startLifecycle.error;
+            CleanupResourceRuntime(*resource, name);
+            resource->SetError(error);
+            FireOnResourceError(std::string(name), error);
+            Logging::GetLogger(FRAMEWORK_INNER_SCRIPTING)->error(
+                "Failed to start JS resource '{}': {}", name, error);
+            return ResourceOperationResult(error);
         }
 
         // Transition to Running
@@ -426,6 +547,7 @@ namespace Framework::Scripting {
         resource->TransitionTo(ResourceState::Stopping);
 
         // Emit resourceStop event before cleanup
+        v8::Global<v8::Promise> stopPromise;
         if (_jsEngine && _jsEngine->IsInitialized()) {
             v8::Isolate *isolate = _jsEngine->GetIsolate();
             v8::Locker locker(isolate);
@@ -439,20 +561,25 @@ namespace Framework::Scripting {
             args.push_back(v8pp::to_v8(isolate, nameStr));
 
             SetCurrentResourceContext(nameStr);
-            _events.EmitReserved(isolate, context, "resourceStop", args);
+            auto emitted = _events.EmitReserved(isolate, context, "resourceStop", args);
+            emitted->MarkAsHandled();
+            stopPromise.Reset(isolate, emitted);
             SetCurrentResourceContext("");
         }
 
-        // Call cleanup (removes handlers)
-        CallResourceStop(name);
-
-        // Cancel timers the resource left running.
-        if (_jsEngine) {
-            _jsEngine->ClearResourceTimers(std::string(name));
+        const auto stopLifecycle = AwaitLifecyclePromise(
+            _jsEngine, _events, stopPromise, _config.resourceStopTimeoutMs);
+        if (stopLifecycle.status == LifecyclePromiseStatus::Rejected) {
+            Logging::GetLogger(FRAMEWORK_INNER_SCRIPTING)->error(
+                "resourceStop for '{}' rejected; forcing cleanup: {}", name, stopLifecycle.error);
+        }
+        else if (stopLifecycle.status == LifecyclePromiseStatus::TimedOut) {
+            Logging::GetLogger(FRAMEWORK_INNER_SCRIPTING)->error(
+                "resourceStop for '{}' timed out after {}ms; forcing cleanup",
+                name, std::max(_config.resourceStopTimeoutMs, 1));
         }
 
-        // Clear exports
-        resource->ClearExports();
+        CleanupResourceRuntime(*resource, name);
 
         // Transition to Stopped
         resource->TransitionTo(ResourceState::Stopped);
@@ -773,6 +900,15 @@ namespace Framework::Scripting {
             Builtins::Messages::CleanupResource(isolate, context, std::string(resourceName));
         }
         return true;
+    }
+
+    void ResourceManager::CleanupResourceRuntime(Resource &resource,
+                                                 std::string_view resourceName) {
+        CallResourceStop(resourceName);
+        if (_jsEngine) {
+            _jsEngine->ClearResourceTimers(std::string(resourceName));
+        }
+        resource.ClearExports();
     }
 
     std::vector<std::string> ResourceManager::GetAllResourceNames() const {

--- a/code/framework/src/scripting/resource/resource_manager.h
+++ b/code/framework/src/scripting/resource/resource_manager.h
@@ -53,6 +53,11 @@ namespace Framework::Scripting {
 
         // Minimum interval between file-change polls, in milliseconds.
         int fileWatchIntervalMs = 1000;
+
+        // Maximum time lifecycle handlers may delay the corresponding transition. Start rejection
+        // or timeout fails startup; stop rejection or timeout logs and then forces cleanup.
+        int resourceStartTimeoutMs = 30'000;
+        int resourceStopTimeoutMs  = 10'000;
     };
 
     /**
@@ -362,6 +367,10 @@ namespace Framework::Scripting {
 
         // Call resource onResourceStop lifecycle function
         bool CallResourceStop(std::string_view resourceName);
+
+        // Removes runtime-owned handlers, requests, timers, and exports. Lifecycle handlers must
+        // settle (or time out) before this is called.
+        void CleanupResourceRuntime(Resource &resource, std::string_view resourceName);
 
         // Build dependency graph from discovered resources
         void BuildDependencyGraph();

--- a/code/framework/src/scripting/v8_engine.h
+++ b/code/framework/src/scripting/v8_engine.h
@@ -67,7 +67,7 @@ namespace Framework::Scripting {
          * Process pending timers and microtasks.
          * Call this from game loop to process async operations.
          */
-        void Tick();
+        void Tick() override;
 
         v8::Isolate *GetIsolate() const override;
         v8::Local<v8::Context> GetContext() const override;

--- a/code/tests/framework_ut.cpp
+++ b/code/tests/framework_ut.cpp
@@ -51,6 +51,8 @@ int main() {
     UNIT_MODULE(engine);
     UNIT_MODULE(resource);
     UNIT_MODULE(resource_manager);
+    UNIT_MODULE(resource_lifecycle);
+    UNIT_MODULE(resource_manager_callbacks);
     UNIT_MODULE(js_features);
     UNIT_MODULE(timer_context);
 

--- a/code/tests/modules/resource_manager_ut.h
+++ b/code/tests/modules/resource_manager_ut.h
@@ -68,6 +68,45 @@ class TestManagerHelper {
         scriptFile.close();
     }
 
+    static void RegisterEvents(Framework::Scripting::NodeEngine &engine,
+                               Framework::Scripting::ResourceManager &manager) {
+        v8::Isolate *isolate = engine.GetIsolate();
+        v8::Locker locker(isolate);
+        v8::Isolate::Scope isolateScope(isolate);
+        v8::HandleScope handleScope(isolate);
+        v8::Local<v8::Context> context = engine.GetContext();
+        v8::Context::Scope contextScope(context);
+        v8::Local<v8::Value> coreValue;
+        if (!context->Global()->Get(context,
+                v8::String::NewFromUtf8Literal(isolate, "Core")).ToLocal(&coreValue)
+            || !coreValue->IsObject()) {
+            coreValue = v8::Object::New(isolate);
+            context->Global()->Set(context,
+                v8::String::NewFromUtf8Literal(isolate, "Core"), coreValue).Check();
+        }
+        manager.GetEvents().Register(isolate, context, coreValue.As<v8::Object>(), &manager);
+    }
+
+    static int32_t EvalInt(Framework::Scripting::NodeEngine &engine, const char *source) {
+        v8::Isolate *isolate = engine.GetIsolate();
+        v8::Locker locker(isolate);
+        v8::Isolate::Scope isolateScope(isolate);
+        v8::HandleScope handleScope(isolate);
+        v8::Local<v8::Context> context = engine.GetContext();
+        v8::Context::Scope contextScope(context);
+        v8::TryCatch tryCatch(isolate);
+        v8::Local<v8::Script> script;
+        if (!v8::Script::Compile(context,
+                v8::String::NewFromUtf8(isolate, source).ToLocalChecked()).ToLocal(&script)) {
+            return -1;
+        }
+        v8::Local<v8::Value> result;
+        if (!script->Run(context).ToLocal(&result) || !result->IsNumber()) {
+            return -1;
+        }
+        return result->Int32Value(context).FromMaybe(-1);
+    }
+
     static void Cleanup() {
         cppfs::FileHandle testDir = cppfs::fs::open(GetTestResourcePath());
         if (testDir.exists()) {
@@ -105,6 +144,8 @@ MODULE(resource_manager, {
         config.resourcesPath = TestManagerHelper::GetTestResourcePath();
         config.isClient = true;
         config.cascadeStopDependents = false;
+        config.resourceStartTimeoutMs = 1234;
+        config.resourceStopTimeoutMs  = 5678;
 
         ResourceManager manager(&engine, config);
 
@@ -112,6 +153,8 @@ MODULE(resource_manager, {
         STREQUALS(retrievedConfig.resourcesPath.c_str(), config.resourcesPath.c_str());
         EQUALS(retrievedConfig.isClient, true);
         EQUALS(retrievedConfig.cascadeStopDependents, false);
+        EQUALS(retrievedConfig.resourceStartTimeoutMs, 1234);
+        EQUALS(retrievedConfig.resourceStopTimeoutMs, 5678);
 
         engine.Shutdown();
     });
@@ -508,6 +551,200 @@ MODULE(resource_manager, {
     });
 
     // ==================== Callbacks ====================
+
+});
+
+MODULE(resource_lifecycle, {
+    using namespace Framework::Scripting;
+
+    IT("awaits async resourceStart before starting dependents", {
+        TestManagerHelper::Cleanup();
+        TestManagerHelper::CreateTestResource("async-dependency", R"({
+            "name": "async-dependency",
+            "version": "1.0.0",
+            "mafiahub": { "server": "main.js" }
+        })");
+        TestManagerHelper::CreateTestScript("async-dependency", "main.js", R"(
+            globalThis.__dependencyReady = 0;
+            Core.Events.on("resourceStart", async (name) => {
+                if (name !== "async-dependency") return;
+                await new Promise((resolve) => setTimeout(resolve, 15));
+                globalThis.__dependencyReady = 1;
+            });
+        )");
+        TestManagerHelper::CreateTestResource("async-dependent", R"({
+            "name": "async-dependent",
+            "version": "1.0.0",
+            "mafiahub": {
+                "server": "main.js",
+                "resourceDependencies": [{"name": "async-dependency"}]
+            }
+        })");
+        TestManagerHelper::CreateTestScript("async-dependent", "main.js", R"(
+            globalThis.__dependentSawReady = globalThis.__dependencyReady === 1 ? 1 : 0;
+        )");
+
+        NodeEngine engine;
+        EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
+        ResourceManagerConfig config;
+        config.resourcesPath          = TestManagerHelper::GetTestResourcePath();
+        config.resourceStartTimeoutMs = 250;
+        ResourceManager manager(&engine, config);
+        TestManagerHelper::RegisterEvents(engine, manager);
+        EQUALS(manager.DiscoverResources(), 2u);
+
+        const auto result = manager.StartResource("async-dependent");
+        EQUALS((bool)result, true);
+        EQUALS(manager.IsResourceRunning("async-dependency"), true);
+        EQUALS(manager.IsResourceRunning("async-dependent"), true);
+        EQUALS(TestManagerHelper::EvalInt(engine, "globalThis.__dependencyReady"), 1);
+        EQUALS(TestManagerHelper::EvalInt(engine, "globalThis.__dependentSawReady"), 1);
+
+        manager.StopAll();
+        engine.Shutdown();
+        TestManagerHelper::Cleanup();
+    });
+
+    IT("awaits async resourceStop before removing handlers and timers", {
+        TestManagerHelper::Cleanup();
+        TestManagerHelper::CreateTestResource("async-stop", R"({
+            "name": "async-stop",
+            "version": "1.0.0",
+            "mafiahub": { "server": "main.js" }
+        })");
+        TestManagerHelper::CreateTestScript("async-stop", "main.js", R"(
+            globalThis.__stopFinished = 0;
+            globalThis.__stopSawOwnedListener = 0;
+            Core.Events.on("owned-listener", () => {});
+            Core.Events.on("resourceStop", async (name) => {
+                if (name !== "async-stop") return;
+                await new Promise((resolve) => setTimeout(resolve, 15));
+                globalThis.__stopSawOwnedListener = Core.Events.listenerCount("owned-listener");
+                globalThis.__stopFinished = 1;
+            });
+        )");
+
+        NodeEngine engine;
+        EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
+        ResourceManagerConfig config;
+        config.resourcesPath         = TestManagerHelper::GetTestResourcePath();
+        config.resourceStopTimeoutMs = 250;
+        ResourceManager manager(&engine, config);
+        TestManagerHelper::RegisterEvents(engine, manager);
+        EQUALS(manager.DiscoverResources(), 1u);
+        EQUALS((bool)manager.StartResource("async-stop"), true);
+
+        const auto result = manager.StopResource("async-stop");
+        EQUALS((bool)result, true);
+        EQUALS(manager.GetResourceState("async-stop"), ResourceState::Stopped);
+        EQUALS(TestManagerHelper::EvalInt(engine, "globalThis.__stopFinished"), 1);
+        EQUALS(TestManagerHelper::EvalInt(engine, "globalThis.__stopSawOwnedListener"), 1);
+        EQUALS(manager.GetEvents().GetListenerCount("owned-listener"), static_cast<size_t>(0));
+
+        engine.Shutdown();
+        TestManagerHelper::Cleanup();
+    });
+
+    IT("fails and cleans a resource whose async start rejects", {
+        TestManagerHelper::Cleanup();
+        TestManagerHelper::CreateTestResource("reject-start", R"({
+            "name": "reject-start",
+            "version": "1.0.0",
+            "mafiahub": { "server": "main.js" }
+        })");
+        TestManagerHelper::CreateTestScript("reject-start", "main.js", R"(
+            Core.Events.on("leaked-start-listener", () => {});
+            Core.Events.on("resourceStart", async (name) => {
+                if (name !== "reject-start") return;
+                await Promise.resolve();
+                throw new Error("migration failed");
+            });
+        )");
+
+        NodeEngine engine;
+        EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
+        ResourceManagerConfig config;
+        config.resourcesPath          = TestManagerHelper::GetTestResourcePath();
+        config.resourceStartTimeoutMs = 250;
+        ResourceManager manager(&engine, config);
+        TestManagerHelper::RegisterEvents(engine, manager);
+        EQUALS(manager.DiscoverResources(), 1u);
+
+        const auto result = manager.StartResource("reject-start");
+        EQUALS((bool)result, false);
+        EQUALS(result.GetError().find("migration failed") != std::string::npos, true);
+        EQUALS(manager.GetResourceState("reject-start"), ResourceState::Error);
+        EQUALS(manager.GetEvents().GetListenerCount("leaked-start-listener"), static_cast<size_t>(0));
+
+        engine.Shutdown();
+        TestManagerHelper::Cleanup();
+    });
+
+    IT("bounds async start and cleans a timed-out partial resource", {
+        TestManagerHelper::Cleanup();
+        TestManagerHelper::CreateTestResource("timeout-start", R"({
+            "name": "timeout-start",
+            "version": "1.0.0",
+            "mafiahub": { "server": "main.js" }
+        })");
+        TestManagerHelper::CreateTestScript("timeout-start", "main.js", R"(
+            Core.Events.on("leaked-timeout-listener", () => {});
+            Core.Events.on("resourceStart", (name) =>
+                name === "timeout-start" ? new Promise(() => {}) : undefined);
+        )");
+
+        NodeEngine engine;
+        EQUALS(engine.Init(), ScriptingError::SCRIPTING_NONE);
+        ResourceManagerConfig config;
+        config.resourcesPath          = TestManagerHelper::GetTestResourcePath();
+        config.resourceStartTimeoutMs = 10;
+        ResourceManager manager(&engine, config);
+        TestManagerHelper::RegisterEvents(engine, manager);
+        EQUALS(manager.DiscoverResources(), 1u);
+
+        const auto result = manager.StartResource("timeout-start");
+        EQUALS((bool)result, false);
+        EQUALS(result.GetError().find("timed out") != std::string::npos, true);
+        EQUALS(manager.GetResourceState("timeout-start"), ResourceState::Error);
+        EQUALS(manager.GetEvents().GetListenerCount("leaked-timeout-listener"), static_cast<size_t>(0));
+
+        engine.Shutdown();
+        TestManagerHelper::Cleanup();
+    });
+
+    IT("forces stop cleanup after async rejection or timeout", {
+        const auto runCase = [](const std::string &name, const std::string &stopBody) {
+            TestManagerHelper::Cleanup();
+            TestManagerHelper::CreateTestResource(name, "{\"name\":\"" + name
+                + "\",\"version\":\"1.0.0\",\"mafiahub\":{\"server\":\"main.js\"}}");
+            TestManagerHelper::CreateTestScript(name, "main.js",
+                "Core.Events.on('force-cleanup-listener', () => {});"
+                "Core.Events.on('resourceStop', (name) => name === '" + name + "' ? (" + stopBody + ") : undefined);");
+
+            NodeEngine engine;
+            bool ok = engine.Init() == ScriptingError::SCRIPTING_NONE;
+            ResourceManagerConfig config;
+            config.resourcesPath         = TestManagerHelper::GetTestResourcePath();
+            config.resourceStopTimeoutMs = 10;
+            ResourceManager manager(&engine, config);
+            TestManagerHelper::RegisterEvents(engine, manager);
+            ok = ok && manager.DiscoverResources() == 1u;
+            ok = ok && static_cast<bool>(manager.StartResource(name));
+            ok = ok && static_cast<bool>(manager.StopResource(name));
+            ok = ok && manager.GetResourceState(name) == ResourceState::Stopped;
+            ok = ok && manager.GetEvents().GetListenerCount("force-cleanup-listener") == 0u;
+            engine.Shutdown();
+            TestManagerHelper::Cleanup();
+            return ok;
+        };
+
+        EQUALS(runCase("reject-stop", "Promise.reject(new Error('final save failed'))"), true);
+        EQUALS(runCase("timeout-stop", "new Promise(() => {})"), true);
+    });
+});
+
+MODULE(resource_manager_callbacks, {
+    using namespace Framework::Scripting;
 
     IT("fires OnResourceStarted callback", {
         TestManagerHelper::CreateTestResource("callback-start", R"({

--- a/code/tests/modules/resource_manager_ut.h
+++ b/code/tests/modules/resource_manager_ut.h
@@ -68,8 +68,7 @@ class TestManagerHelper {
         scriptFile.close();
     }
 
-    static void RegisterEvents(Framework::Scripting::NodeEngine &engine,
-                               Framework::Scripting::ResourceManager &manager) {
+    static void RegisterEvents(Framework::Scripting::NodeEngine &engine, Framework::Scripting::ResourceManager &manager) {
         v8::Isolate *isolate = engine.GetIsolate();
         v8::Locker locker(isolate);
         v8::Isolate::Scope isolateScope(isolate);
@@ -77,12 +76,9 @@ class TestManagerHelper {
         v8::Local<v8::Context> context = engine.GetContext();
         v8::Context::Scope contextScope(context);
         v8::Local<v8::Value> coreValue;
-        if (!context->Global()->Get(context,
-                v8::String::NewFromUtf8Literal(isolate, "Core")).ToLocal(&coreValue)
-            || !coreValue->IsObject()) {
+        if (!context->Global()->Get(context, v8::String::NewFromUtf8Literal(isolate, "Core")).ToLocal(&coreValue) || !coreValue->IsObject()) {
             coreValue = v8::Object::New(isolate);
-            context->Global()->Set(context,
-                v8::String::NewFromUtf8Literal(isolate, "Core"), coreValue).Check();
+            context->Global()->Set(context, v8::String::NewFromUtf8Literal(isolate, "Core"), coreValue).Check();
         }
         manager.GetEvents().Register(isolate, context, coreValue.As<v8::Object>(), &manager);
     }
@@ -96,8 +92,7 @@ class TestManagerHelper {
         v8::Context::Scope contextScope(context);
         v8::TryCatch tryCatch(isolate);
         v8::Local<v8::Script> script;
-        if (!v8::Script::Compile(context,
-                v8::String::NewFromUtf8(isolate, source).ToLocalChecked()).ToLocal(&script)) {
+        if (!v8::Script::Compile(context, v8::String::NewFromUtf8(isolate, source).ToLocalChecked()).ToLocal(&script)) {
             return -1;
         }
         v8::Local<v8::Value> result;
@@ -551,7 +546,6 @@ MODULE(resource_manager, {
     });
 
     // ==================== Callbacks ====================
-
 });
 
 MODULE(resource_lifecycle, {
@@ -715,11 +709,11 @@ MODULE(resource_lifecycle, {
     IT("forces stop cleanup after async rejection or timeout", {
         const auto runCase = [](const std::string &name, const std::string &stopBody) {
             TestManagerHelper::Cleanup();
-            TestManagerHelper::CreateTestResource(name, "{\"name\":\"" + name
-                + "\",\"version\":\"1.0.0\",\"mafiahub\":{\"server\":\"main.js\"}}");
+            TestManagerHelper::CreateTestResource(name, "{\"name\":\"" + name + "\",\"version\":\"1.0.0\",\"mafiahub\":{\"server\":\"main.js\"}}");
             TestManagerHelper::CreateTestScript(name, "main.js",
                 "Core.Events.on('force-cleanup-listener', () => {});"
-                "Core.Events.on('resourceStop', (name) => name === '" + name + "' ? (" + stopBody + ") : undefined);");
+                "Core.Events.on('resourceStop', (name) => name === '"
+                    + name + "' ? (" + stopBody + ") : undefined);");
 
             NodeEngine engine;
             bool ok = engine.Init() == ScriptingError::SCRIPTING_NONE;

--- a/docs/resource_hot_reload.md
+++ b/docs/resource_hot_reload.md
@@ -31,6 +31,42 @@ opts.developmentMode = true; // enable the file watcher
 The watcher interval defaults to 1s (`ResourceManagerConfig::fileWatchIntervalMs`)
 and skips `node_modules`/`.git`.
 
+## Asynchronous lifecycle handlers
+
+The existing `resourceStart` and `resourceStop` events are Promise-aware. The
+resource manager pumps the scripting runtime while it waits, so handlers may do
+real asynchronous work such as database migrations, final saves, or connection
+shutdown:
+
+```js
+Events.on("resourceStart", async (resourceName) => {
+    if (resourceName !== "my-resource") return;
+    await database.migrate();
+});
+
+Events.on("resourceStop", async (resourceName) => {
+    if (resourceName !== "my-resource") return;
+    await saveInventory();
+    await database.close();
+});
+```
+
+Startup does not transition the resource to `Running`, invoke its started
+callback, or start a dependent resource until every matching handler settles.
+If a start handler rejects or exceeds the timeout, startup fails and the
+partially loaded resource's handlers, messages, timers, and exports are cleaned
+up.
+
+Shutdown waits before removing those runtime-owned objects, allowing the stop
+handler to use them during finalization. A rejected or timed-out stop is logged
+loudly, then cleanup is forced so one resource cannot indefinitely block a
+reload or server shutdown.
+
+The defaults are 30 seconds for start and 10 seconds for stop. Native hosts can
+override them with `ResourceManagerConfig::resourceStartTimeoutMs` and
+`ResourceManagerConfig::resourceStopTimeoutMs`; non-positive values are treated
+as a 1ms bounded timeout.
+
 ## What a reload does
 
 `ResourceManager::RefreshResource(name)` (and `RefreshAll`):
@@ -83,6 +119,11 @@ Clients that haven't finished connecting ignore `ResourceRefresh`/`ResourceStop`
 
 ## Limitations
 
+- **Timeouts cannot cancel arbitrary JavaScript work.** The manager releases its
+  native wait state and cleans up the resource after a lifecycle timeout, but a
+  third-party Promise has no general cancellation mechanism. Code after a late
+  external I/O completion may still resume and must tolerate the resource
+  already being stopped.
 - **CommonJS only.** Module-cache eviction covers the framework's CJS load path.
   Resources loaded via dynamic ESM `import()` are not in `require.cache` and
   won't be re-read on reload.


### PR DESCRIPTION
## Summary

Makes the existing `resourceStart` and `resourceStop` lifecycle events Promise-aware, with bounded timeouts.

Resources can now safely perform asynchronous initialization and shutdown work:

```js
Events.on("resourceStart", async (resourceName) => {
    if (resourceName !== "my-resource") return;
    await database.migrate();
});

Events.on("resourceStop", async (resourceName) => {
    if (resourceName !== "my-resource") return;
    await saveInventory();
    await database.close();
});
```

## Motivation

Previously, the resource manager emitted these events but ignored the returned Promise. It immediately continued the lifecycle:

- A resource could become `Running` before initialization or migrations completed.
- Dependent resources could start against partially initialized dependencies.
- Stop handlers could lose their event handlers, timers, exports, or messaging state while a final save was still running.
- Node could shut down before databases and other asynchronous resources closed cleanly.

This forced resources to implement their own `start()`/`ready()` guards and made reliable final persistence difficult.

Awaiting the existing events gives lifecycle handlers a deterministic window in which their resource is still intact, without adding another lifecycle API.

## Behavior

### `resourceStart`

- Waits for all matching synchronous and asynchronous handlers.
- Does not mark the resource as running or start dependents until handlers settle.
- A rejection fails startup and reports the underlying error.
- A timeout fails startup.
- Failed or timed-out startup cleans partially registered handlers, messages, timers, and exports.

The default start timeout is 30 seconds.

### `resourceStop`

- Waits before removing resource-owned handlers, messages, timers, and exports.
- A rejection is logged, but does not prevent shutdown.
- A timeout is logged, after which cleanup is forced.
- One broken resource therefore cannot indefinitely block a reload or server shutdown.

The default stop timeout is 10 seconds.

Both timeouts are configurable through:

```cpp
ResourceManagerConfig::resourceStartTimeoutMs
ResourceManagerConfig::resourceStopTimeoutMs
```

## Implementation notes

The lifecycle entry points remain synchronous to their native callers, while the resource manager pumps the active Node/V8 runtime so Promise microtasks, timers, and host I/O can progress.

Timed-out event emissions release their retained native Promise resolver without disturbing unrelated emissions.

JavaScript Promises do not support general forced cancellation. If third-party I/O completes after a timeout, its continuation may still resume and must tolerate the resource already being stopped.

## Testing

Added coverage for:

- Awaiting asynchronous startup before starting dependents
- Awaiting asynchronous shutdown before resource cleanup
- Startup rejection and partial-state cleanup
- Bounded startup timeouts
- Forced shutdown cleanup after rejection or timeout
- Lifecycle timeout configuration

Both `FrameworkClient` and `FrameworkServer` libraries compile successfully. All five new lifecycle tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Resource startup and shutdown now support asynchronous lifecycle handlers.
  - Startup waits for handlers to settle before activating dependent resources.
  - Configurable timeouts are available for startup and shutdown operations.
  - Failed or timed-out handlers trigger runtime cleanup.

- **Bug Fixes**
  - Pending event callbacks are safely cancelled when no longer needed.

- **Documentation**
  - Added guidance on asynchronous lifecycle handling, timeouts, cleanup, and late-running code limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->