### PR TITLE
Vendors: consume precompiled MafiaNet release archives

### DIFF
--- a/cmake/MafiaNetPin.cmake
+++ b/cmake/MafiaNetPin.cmake
@@ -16,12 +16,22 @@
 # Note it must NOT live under vendors/: .gitignore carries `vendors/**/*.cmake`,
 # which would silently exclude it from the repository.
 
-# Pinned by commit, not by tag. A tag is a mutable ref -- repointing it would
-# change what every future build fetches while this file still reads the same --
-# whereas a commit is what it is. Keep the human-readable release beside it.
+# The pin names a MafiaNet release whose precompiled per-platform archives are
+# downloaded at configure time (see vendors/CMakeLists.txt). A tag is a mutable
+# ref, so the version alone would not pin anything; the SHA-256 of each archive
+# is what actually fixes the content -- file(DOWNLOAD EXPECTED_HASH) fails the
+# configure if an archive is ever repointed or tampered with. When bumping,
+# update the version and all five hashes together (they are printed by the
+# MafiaNet release pipeline, or: shasum -a 256 MafiaNet-<ver>-*).
 #
-# Plain set(), not a CACHE entry: a cached value survives in an existing build
-# tree, so bumping the pin here and rebuilding incrementally would silently keep
-# fetching the old revision. This file is the single source of truth, and there is
-# no reason to let -D override the wire format of the protocol.
-set(MAFIANET_PIN "46fd83581e24037b0535a545b6204248e4a90c28") # v0.18.0 -- RakVoice::SetOrderingChannels (RAKNET_PROTOCOL_VERSION still 7, wire-compatible)
+# Plain set(), not CACHE entries: a cached value survives in an existing build
+# tree, so bumping the pin here and reconfiguring incrementally would silently
+# keep the old release. This file is the single source of truth, and there is no
+# reason to let -D override the wire format of the protocol.
+set(MAFIANET_PIN_VERSION "0.18.0") # RakVoice::SetOrderingChannels (RAKNET_PROTOCOL_VERSION still 7, wire-compatible)
+
+set(MAFIANET_PIN_SHA256_linux-x86_64 "2b5aff6acb3cb8495cedafb94361c987836c61b40c748b860a4f07bf29dbd2c7")
+set(MAFIANET_PIN_SHA256_macos-arm64 "08628084f65f6d635c9e2ca69301fd3465e50818c930b12ed6c52f931c2e725d")
+set(MAFIANET_PIN_SHA256_macos-x86_64 "6489025e3045510d5c2ef37c494820570762582d0be24522740e4b745198ddbd")
+set(MAFIANET_PIN_SHA256_windows-x64 "abe7533eacf9ae5f929d39e003f0e1c3638cb851cae7d799b6058bc037a02368")
+set(MAFIANET_PIN_SHA256_windows-x86 "2766995cf725b2b682a9bf42c04e8d25ebcb273d653d690357210930d460b40a")

--- a/vendors/CMakeLists.txt
+++ b/vendors/CMakeLists.txt
@@ -51,79 +51,96 @@ set(HTTPLIB_REQUIRE_OPENSSL ON)
 set(HTTPLIB_COMPILE ON)
 add_subdirectory(httplib)
 
-# MafiaNet (networking) - fetched, not vendored.
+# MafiaNet (networking) - precompiled release archive, neither vendored nor
+# built from source.
 #
-# MafiaNet owns RakVoice, and therefore owns RakVoice's Opus and RNNoise
-# dependencies, which its own build fetches. Vendoring MafiaNet here would mean
-# hoisting those two a level up into this repository: ~85 MB of third-party
-# source, a collision with this repo's `vendors/**/*.cmake` ignore rule, and a
-# re-vendor split across three trees that have to stay in lockstep. Fetching the
-# release instead keeps the dependency boundary where it belongs.
+# MafiaNet's release pipeline publishes per-platform archives (linux-x86_64,
+# windows-x86/x64, macos-x86_64/arm64) containing the static library, the
+# bundled Opus/RNNoise static libs RakVoice needs, all public headers, and the
+# MafiaNet CMake package. Downloading one archive replaces compiling ~85 MB of
+# third-party source (plus MafiaNet's own Opus/RNNoise fetches) on every cold
+# configure, and keeps the dependency boundary where it belongs.
 #
-# This is the only FetchContent in the Framework build; everything else under
-# vendors/ is genuinely vendored in-tree. Building therefore needs network access
-# on a cold configure (the fetch is cached in the build tree afterwards).
-include(FetchContent)
-
-# Framework links the static library only; samples and MafiaNet's own test suite
-# are not our concern.
-set(MAFIANET_BUILD_SHARED OFF CACHE BOOL "" FORCE)
-set(MAFIANET_BUILD_STATIC ON CACHE BOOL "" FORCE)
-set(MAFIANET_BUILD_SAMPLES OFF CACHE BOOL "" FORCE)
-set(MAFIANET_BUILD_TESTS OFF CACHE BOOL "" FORCE)
-
-# Pinned to a release tag, never a branch: the message-id enum is positional, so
-# an unpinned bump would silently change the wire format. The pin lives in
-# cmake/MafiaNetPin.cmake so the release tooling can watch that one path.
+# This is the only download in the Framework build; everything else under
+# vendors/ is genuinely vendored in-tree. A cold configure therefore needs
+# network access (the archive is cached in the build tree afterwards).
+#
+# The pin (version + per-archive SHA-256) lives in cmake/MafiaNetPin.cmake so
+# the release tooling can watch that one path: the message-id enum is
+# positional, so a bump can move the wire format.
 include(MafiaNetPin)
 
-# No GIT_SHALLOW: it makes CMake clone the default branch at depth 1 and then check the
-# pin out of it, which only resolves while the pinned commit is still that branch's tip.
-# Any later MafiaNet commit leaves the pin unreachable and a cold configure dies with
-# "unable to read tree". A full clone is the cost of pinning by commit at all.
-FetchContent_Declare(
-    MafiaNet
-    GIT_REPOSITORY https://github.com/MafiaHub/MafiaNet.git
-    GIT_TAG        ${MAFIANET_PIN}
-)
-FetchContent_MakeAvailable(MafiaNet)
-
-# Reconcile the fetched dependencies with this build's CRT convention.
-#
-# Framework uses the RELEASE CRT even in Debug builds: FrameworkSetup forces
-# CMAKE_MSVC_RUNTIME_LIBRARY to MultiThreadedDLL and replaces
-# CMAKE_CXX_FLAGS_DEBUG outright, so no /MDd and no _DEBUG reach its objects.
-#
-# MafiaNet follows the ordinary convention instead -- Source/CMakeLists.txt does
-# target_compile_definitions(... $<$<CONFIG:Debug>:_DEBUG>). Defining _DEBUG makes
-# MSVC select the debug CRT semantics in the object itself: _ITERATOR_DEBUG_LEVEL
-# becomes 2 and the object records MDd_DynamicDebug. Linking that against
-# Framework's MD_DynamicRelease objects fails with LNK2038, and no flag or
-# MSVC_RUNTIME_LIBRARY property can override it, because the definition is what
-# drives it. CI confirmed exactly that: the property was applied correctly and the
-# objects still came out MDd.
-#
-# So drop the definition on the fetched targets rather than fighting the symptom.
-# This is Framework adapting to its own unusual choice, not a defect upstream --
-# MafiaNet is right to define _DEBUG when it is built normally.
-#
-# Nothing analogous was needed while MafiaNet was vendored: that copy was a bare
-# add_library() with no target_compile_definitions of its own.
-if(MSVC)
-    foreach(_mafianet_target MafiaNetStatic MafiaNet opus rnnoise)
-        if(TARGET ${_mafianet_target})
-            set_property(TARGET ${_mafianet_target} PROPERTY
-                MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
-
-            get_target_property(_fw_defs ${_mafianet_target} COMPILE_DEFINITIONS)
-            if(_fw_defs)
-                list(REMOVE_ITEM _fw_defs "$<$<CONFIG:Debug>:_DEBUG>" "_DEBUG")
-                set_property(TARGET ${_mafianet_target} PROPERTY
-                    COMPILE_DEFINITIONS ${_fw_defs})
-            endif()
-        endif()
-    endforeach()
+if(WIN32)
+    if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+        set(_mafianet_platform "windows-x86")
+    else()
+        set(_mafianet_platform "windows-x64")
+    endif()
+    set(_mafianet_ext "zip")
+elseif(APPLE)
+    if(CMAKE_OSX_ARCHITECTURES STREQUAL "x86_64"
+       OR (NOT CMAKE_OSX_ARCHITECTURES AND CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64"))
+        set(_mafianet_platform "macos-x86_64")
+    elseif(CMAKE_OSX_ARCHITECTURES STREQUAL "arm64"
+       OR (NOT CMAKE_OSX_ARCHITECTURES AND CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64"))
+        set(_mafianet_platform "macos-arm64")
+    else()
+        message(FATAL_ERROR "No precompiled MafiaNet archive for macOS architectures '${CMAKE_OSX_ARCHITECTURES}' (universal builds are not supported)")
+    endif()
+    set(_mafianet_ext "tar.gz")
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|amd64)$")
+    set(_mafianet_platform "linux-x86_64")
+    set(_mafianet_ext "tar.gz")
+else()
+    message(FATAL_ERROR "No precompiled MafiaNet archive for ${CMAKE_SYSTEM_NAME}/${CMAKE_SYSTEM_PROCESSOR}")
 endif()
+
+set(_mafianet_name "MafiaNet-${MAFIANET_PIN_VERSION}-${_mafianet_platform}")
+set(_mafianet_root "${CMAKE_BINARY_DIR}/mafianet/${_mafianet_name}")
+
+if(NOT EXISTS "${_mafianet_root}/lib/cmake/MafiaNet/MafiaNetConfig.cmake")
+    set(_mafianet_archive "${CMAKE_BINARY_DIR}/mafianet/${_mafianet_name}.${_mafianet_ext}")
+    message(STATUS "Downloading precompiled MafiaNet ${MAFIANET_PIN_VERSION} (${_mafianet_platform})")
+    # EXPECTED_HASH makes any failure fatal: a failed download, a repointed tag,
+    # or a tampered archive all stop the configure here.
+    file(DOWNLOAD
+        "https://github.com/MafiaHub/MafiaNet/releases/download/v${MAFIANET_PIN_VERSION}/${_mafianet_name}.${_mafianet_ext}"
+        "${_mafianet_archive}"
+        EXPECTED_HASH SHA256=${MAFIANET_PIN_SHA256_${_mafianet_platform}}
+        SHOW_PROGRESS
+    )
+    file(ARCHIVE_EXTRACT INPUT "${_mafianet_archive}" DESTINATION "${CMAKE_BINARY_DIR}/mafianet")
+    file(REMOVE "${_mafianet_archive}")
+endif()
+
+# The archives carry a single Release configuration, compiled with the /MD
+# runtime on Windows -- exactly the CRT FrameworkSetup forces even in Debug
+# builds -- so the old _DEBUG/CRT reconciliation the source build needed is gone
+# with it. Map every consumer configuration onto that Release config; the
+# variables seed MAP_IMPORTED_CONFIG_* on the imported targets find_package
+# creates, and are cleared right after so no other target is affected.
+set(CMAKE_MAP_IMPORTED_CONFIG_DEBUG Release)
+set(CMAKE_MAP_IMPORTED_CONFIG_RELWITHDEBINFO Release)
+set(CMAKE_MAP_IMPORTED_CONFIG_MINSIZEREL Release)
+# Resolves OpenSSL through find_dependency: on Windows that is the vendored
+# OpenSSL forced above, elsewhere the system one -- either way OpenSSL 3, which
+# is what the archives were compiled against.
+find_package(MafiaNet ${MAFIANET_PIN_VERSION} CONFIG REQUIRED
+    PATHS "${_mafianet_root}"
+    NO_DEFAULT_PATH
+)
+unset(CMAKE_MAP_IMPORTED_CONFIG_DEBUG)
+unset(CMAKE_MAP_IMPORTED_CONFIG_RELWITHDEBINFO)
+unset(CMAKE_MAP_IMPORTED_CONFIG_MINSIZEREL)
+
+# find_package imports are scoped to this directory; the consumers live under
+# code/ (a sibling), which could see the old add_subdirectory alias targets but
+# not these. Promote everything the package exports.
+foreach(_mafianet_target MafiaNet::MafiaNetStatic MafiaNet::MafiaNet MafiaNet::opus MafiaNet::rnnoise)
+    if(TARGET ${_mafianet_target})
+        set_target_properties(${_mafianet_target} PROPERTIES IMPORTED_GLOBAL TRUE)
+    endif()
+endforeach()
 
 # Build sentry
 set(CURL_STATICLIB ON)

--- a/vendors/CMakeLists.txt
+++ b/vendors/CMakeLists.txt
@@ -113,15 +113,6 @@ if(NOT EXISTS "${_mafianet_root}/lib/cmake/MafiaNet/MafiaNetConfig.cmake")
     file(REMOVE "${_mafianet_archive}")
 endif()
 
-# The archives carry a single Release configuration, compiled with the /MD
-# runtime on Windows -- exactly the CRT FrameworkSetup forces even in Debug
-# builds -- so the old _DEBUG/CRT reconciliation the source build needed is gone
-# with it. Map every consumer configuration onto that Release config; the
-# variables seed MAP_IMPORTED_CONFIG_* on the imported targets find_package
-# creates, and are cleared right after so no other target is affected.
-set(CMAKE_MAP_IMPORTED_CONFIG_DEBUG Release)
-set(CMAKE_MAP_IMPORTED_CONFIG_RELWITHDEBINFO Release)
-set(CMAKE_MAP_IMPORTED_CONFIG_MINSIZEREL Release)
 # Resolves OpenSSL through find_dependency: on Windows that is the vendored
 # OpenSSL forced above, elsewhere the system one -- either way OpenSSL 3, which
 # is what the archives were compiled against.
@@ -129,16 +120,29 @@ find_package(MafiaNet ${MAFIANET_PIN_VERSION} CONFIG REQUIRED
     PATHS "${_mafianet_root}"
     NO_DEFAULT_PATH
 )
-unset(CMAKE_MAP_IMPORTED_CONFIG_DEBUG)
-unset(CMAKE_MAP_IMPORTED_CONFIG_RELWITHDEBINFO)
-unset(CMAKE_MAP_IMPORTED_CONFIG_MINSIZEREL)
 
-# find_package imports are scoped to this directory; the consumers live under
-# code/ (a sibling), which could see the old add_subdirectory alias targets but
-# not these. Promote everything the package exports.
+# Two per-target fixups, on the MafiaNet targets ONLY -- deliberately not via
+# the CMAKE_MAP_IMPORTED_CONFIG_* variables, which would also seed the
+# OpenSSL::SSL/Crypto targets that find_dependency creates inside the same
+# find_package call; those carry a single config-less IMPORTED_LOCATION, and a
+# mapping they cannot satisfy fails the configure ("IMPORTED_LOCATION not set
+# for ... configuration Debug").
+#
+#  - MAP_IMPORTED_CONFIG_*: the archives carry a single Release configuration,
+#    compiled with the /MD runtime on Windows -- exactly the CRT FrameworkSetup
+#    forces even in Debug builds -- so every consumer configuration maps onto
+#    it (and the old _DEBUG/CRT reconciliation the source build needed is gone).
+#  - IMPORTED_GLOBAL: find_package imports are scoped to this directory; the
+#    consumers live under code/ (a sibling), which could see the old
+#    add_subdirectory alias targets but not these.
 foreach(_mafianet_target MafiaNet::MafiaNetStatic MafiaNet::MafiaNet MafiaNet::opus MafiaNet::rnnoise)
     if(TARGET ${_mafianet_target})
-        set_target_properties(${_mafianet_target} PROPERTIES IMPORTED_GLOBAL TRUE)
+        set_target_properties(${_mafianet_target} PROPERTIES
+            IMPORTED_GLOBAL TRUE
+            MAP_IMPORTED_CONFIG_DEBUG Release
+            MAP_IMPORTED_CONFIG_RELWITHDEBINFO Release
+            MAP_IMPORTED_CONFIG_MINSIZEREL Release
+        )
     endif()
 endforeach()
 


### PR DESCRIPTION
## What

Replaces the `FetchContent` source build of MafiaNet with a configure-time download of the per-platform precompiled archive published by [MafiaNet's release pipeline](https://github.com/MafiaHub/MafiaNet/releases/tag/v0.18.0) (linux-x86_64, windows-x86/x64, macos-x86_64/arm64 — static + shared libs, bundled opus/rnnoise, all headers, and the `MafiaNetConfig.cmake` package). The archive is extracted into the build tree and consumed via `find_package(MafiaNet CONFIG REQUIRED)`; consumers keep linking `MafiaNet::MafiaNetStatic` unchanged.

## Why

Building MafiaNet from source dragged ~85 MB of third-party source (plus its own Opus/RNNoise fetches) through every cold configure. Downloading one ~12 MB archive is faster and keeps the dependency boundary where it belongs.

## Details

- **Pin**: `cmake/MafiaNetPin.cmake` keeps its path (so `bump_version.sh` keeps its wire-format signal) but now names the release version plus the SHA-256 of each archive. It tracks the same release `develop` is on, v0.18.0. Tags are mutable refs, so the hashes are what actually pin content — `file(DOWNLOAD EXPECTED_HASH)` fails the configure on any mismatch. Bumping MafiaNet = update the version and five hashes, nothing else.
- **Configs**: the archives carry a single Release configuration compiled with `/MD` on Windows — exactly the CRT FrameworkSetup forces even in Debug — so Debug/RelWithDebInfo/MinSizeRel are mapped onto it via `MAP_IMPORTED_CONFIG_*`, and the old `_DEBUG`/CRT reconciliation block for the source build is deleted.
- **Scope**: `find_package` imports are directory-scoped, unlike the old alias targets, so they are promoted `IMPORTED_GLOBAL` for the consumers under `code/` (the `GLOBAL` keyword needs CMake 3.24; minimum here is 3.20).
- OpenSSL still resolves through `find_dependency(OpenSSL)`: the vendored 3.3.1 on Windows, the system one elsewhere — matching the OpenSSL 3 the archives were compiled against.

## Verification

On Windows x64 (rebased on `develop`, MafiaNet 0.18.0): clean reconfigure downloads and hash-verifies `MafiaNet-0.18.0-windows-x64.zip`, then `FrameworkTests` (313/313 across 25 modules), `FrameworkClient` and `MafiaMPServer` all build and link against the prebuilt static libs.

Earlier on macOS arm64 (0.15.0 archives): same flow, `FrameworkServer` built and `FrameworkTests` passed. Linux/macOS 0.18.0 archives are covered by this PR's CI run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build Improvements**
  * MafiaNet is now retrieved as a pinned, platform-specific release archive instead of being built from source.
  * Downloads are verified with SHA-256 checksums for improved integrity.
  * Added support for Linux, Windows, and Intel- and Apple Silicon-based macOS builds.
  * Unsupported platform and architecture combinations now fail during configuration.
  * Build configurations consistently use the packaged Release binaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->