### PR TITLE
Server: Report the mod's own version on the info endpoint

### DIFF
--- a/code/framework/src/integrations/server/instance.cpp
+++ b/code/framework/src/integrations/server/instance.cpp
@@ -288,7 +288,8 @@ namespace Framework::Integrations::Server {
             nlohmann::json root;
             root["mod_name"]          = _opts.modName;
             root["mod_slug"]          = _opts.modSlug;
-            root["mod_version"]       = Utils::Version::rel;
+            root["mod_version"]       = _opts.modVersion;
+            root["framework_version"] = Utils::Version::rel;
             root["host"]              = _opts.bindHost;
             root["port"]              = _opts.bindPort;
             root["password_required"] = !_opts.bindPassword.empty();

--- a/code/framework/src/integrations/server/instance.cpp
+++ b/code/framework/src/integrations/server/instance.cpp
@@ -1072,7 +1072,7 @@ namespace Framework::Integrations::Server {
                 Services::ServerInfo info {};
                 info.port           = _opts.bindPort;
                 info.gameMode       = _opts.modName;
-                info.version        = Utils::Version::rel;
+                info.version        = _opts.modVersion;
                 info.maxPlayers     = _opts.maxPlayers;
                 info.currentPlayers = _networkingEngine->GetNetworkServer()->GetPeer()->NumberOfConnections();
                 _masterlist->Ping(info);


### PR DESCRIPTION
Commit 1:
mod_version carried Framework::Utils::Version::rel, so the endpoint advertised the framework's version under the mod's name. Use _opts.modVersion and expose the framework build as framework_version.

Commit 2:
The heartbeat carried the framework's version, so server browsers listed a framework build number where players expect the mod release they downloaded. The build token still pairs both versions separately. I'm not sure of the side-effects on what this change will do for services though.

Current issue:
<img width="1081" height="261" alt="image" src="https://github.com/user-attachments/assets/be854a0c-8803-457f-9af1-e303a8e38b4d" />

Masterlist perhaps should reflect the mod server version (1.0.0) rather than framework (11.0.0 here) since that's the public-facing server version that they're downloading.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected version information displayed by the HTTP root endpoint.
  * Mod and framework versions are now reported separately for greater accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->