### PR TITLE
Voice: make the rolloff's full-volume radius runtime-settable

### DIFF
--- a/code/framework/src/voice/client/mixer.cpp
+++ b/code/framework/src/voice/client/mixer.cpp
@@ -99,9 +99,12 @@ namespace Framework::Voice {
     }
 
     void LimitStereoBuffer(float *stereoOut, uint32_t samples, float volume) {
+        // SoftLimit's ceiling does not hold for NaN: its comparisons are false, so a NaN volume
+        // writes NaN samples out to the device instead of being bent towards the ceiling.
+        const float scale   = std::isfinite(volume) ? volume : 1.0f;
         const size_t values = static_cast<size_t>(samples) * 2;
         for (size_t i = 0; i < values; i++) {
-            stereoOut[i] = SoftLimit(stereoOut[i] * volume);
+            stereoOut[i] = SoftLimit(stereoOut[i] * scale);
         }
     }
 } // namespace Framework::Voice

--- a/code/framework/src/voice/client/mixer.cpp
+++ b/code/framework/src/voice/client/mixer.cpp
@@ -15,13 +15,6 @@ namespace Framework::Voice {
     namespace {
         constexpr float kInt16Scale = 1.0f / 32768.0f;
 
-        // Within this fraction of `range` a speaker is at full volume; beyond it attenuation
-        // starts, and the floor keeps a speaker crossing the listener's own position from blowing
-        // up the division. A fraction rather than an absolute distance so the curve is scale
-        // invariant: a centimetre-scale game passes a proportionally larger range and gets the
-        // same rolloff in physical terms. 1/25 leaves the default range's radius at 1.0.
-        constexpr float kFullVolumeFraction = 1.0f / 25.0f;
-
         // How far the pan is allowed to swing. A full hard pan sounds wrong on headphones
         // for a speaker only slightly off-axis, so the effect is deliberately partial.
         constexpr float kMaxPan = 0.6f;
@@ -45,7 +38,7 @@ namespace Framework::Voice {
         }
     } // namespace
 
-    SpeakerGain ComputeGain(const ListenerTransform &listener, const glm::vec3 &speakerPos, float range) {
+    SpeakerGain ComputeGain(const ListenerTransform &listener, const glm::vec3 &speakerPos, float range, float fullVolumeFraction) {
         SpeakerGain gain;
 
         const glm::vec3 attenuationFrom = glm::dot(listener.attenuationPosition, listener.attenuationPosition) > 0.0f ? listener.attenuationPosition : listener.position;
@@ -57,7 +50,7 @@ namespace Framework::Voice {
 
         // Inverse-distance rolloff, normalised so it reaches zero exactly at `range` rather
         // than trailing off asymptotically and leaving a faint always-audible tail.
-        const float fullVolume  = range * kFullVolumeFraction;
+        const float fullVolume  = range * std::clamp(fullVolumeFraction, 0.0001f, 1.0f);
         const float clamped     = std::max(distance, fullVolume);
         const float rolloff     = fullVolume / clamped;
         const float edgeFade    = 1.0f - (distance / range);

--- a/code/framework/src/voice/client/mixer.cpp
+++ b/code/framework/src/voice/client/mixer.cpp
@@ -50,7 +50,11 @@ namespace Framework::Voice {
 
         // Inverse-distance rolloff, normalised so it reaches zero exactly at `range` rather
         // than trailing off asymptotically and leaving a faint always-audible tail.
-        const float fullVolume  = range * std::clamp(fullVolumeFraction, 0.0001f, 1.0f);
+        // std::clamp returns NaN unchanged — every comparison against it is false — and a NaN
+        // reaches both gains, where the caller's `> 0.0f` audibility check reads as inaudible and
+        // consumes the speaker's audio without mixing it.
+        const float fraction    = std::isfinite(fullVolumeFraction) ? std::clamp(fullVolumeFraction, 0.0001f, 1.0f) : kDefaultFullVolumeFraction;
+        const float fullVolume  = range * fraction;
         const float clamped     = std::max(distance, fullVolume);
         const float rolloff     = fullVolume / clamped;
         const float edgeFade    = 1.0f - (distance / range);

--- a/code/framework/src/voice/client/mixer.h
+++ b/code/framework/src/voice/client/mixer.h
@@ -34,9 +34,14 @@ namespace Framework::Voice {
         float right = 0.0f;
     };
 
+    // Fraction of `range` within which a speaker is at full volume. A fraction rather than an
+    // absolute distance so the curve is scale invariant: a centimetre-scale game passes a
+    // proportionally larger range and gets the same rolloff in physical terms.
+    constexpr float kDefaultFullVolumeFraction = 1.0f / 25.0f;
+
     // Distance attenuation and constant-power stereo pan for one speaker relative to the
     // listener. Returns silence beyond `range`. Pure: no state, safe on the audio thread.
-    SpeakerGain ComputeGain(const ListenerTransform &listener, const glm::vec3 &speakerPos, float range);
+    SpeakerGain ComputeGain(const ListenerTransform &listener, const glm::vec3 &speakerPos, float range, float fullVolumeFraction = kDefaultFullVolumeFraction);
 
     // Accumulates `samples` mono int16 samples into an interleaved stereo float buffer,
     // applying `gain`. Adds rather than assigns so several speakers can be layered.

--- a/code/framework/src/voice/client/voice_client.cpp
+++ b/code/framework/src/voice/client/voice_client.cpp
@@ -132,6 +132,12 @@ namespace Framework::Voice {
     }
 
     void LocalVoiceSink::SetMasterVolume(float volume) {
+        // Same NaN hole as the fraction below, and the same answer: keep the last good volume
+        // rather than store a value that silences the mix.
+        if (!std::isfinite(volume)) {
+            return;
+        }
+
         _masterVolume.store(std::clamp(volume, 0.0f, 4.0f), std::memory_order_relaxed);
     }
 

--- a/code/framework/src/voice/client/voice_client.cpp
+++ b/code/framework/src/voice/client/voice_client.cpp
@@ -14,6 +14,7 @@
 #include <utils/time.h>
 
 #include <algorithm>
+#include <cmath>
 #include <limits>
 
 namespace Framework::Voice {
@@ -135,6 +136,12 @@ namespace Framework::Voice {
     }
 
     void LocalVoiceSink::SetFullVolumeFraction(float fraction) {
+        // Dropped rather than clamped: std::clamp passes NaN through, and the last good value is a
+        // better answer for a settings UI that reads it back than a curve that silences everyone.
+        if (!std::isfinite(fraction)) {
+            return;
+        }
+
         _fullVolumeFraction.store(std::clamp(fraction, 0.0001f, 1.0f), std::memory_order_relaxed);
     }
 

--- a/code/framework/src/voice/client/voice_client.cpp
+++ b/code/framework/src/voice/client/voice_client.cpp
@@ -134,12 +134,19 @@ namespace Framework::Voice {
         _masterVolume.store(std::clamp(volume, 0.0f, 4.0f), std::memory_order_relaxed);
     }
 
+    void LocalVoiceSink::SetFullVolumeFraction(float fraction) {
+        _fullVolumeFraction.store(std::clamp(fraction, 0.0001f, 1.0f), std::memory_order_relaxed);
+    }
+
     void LocalVoiceSink::Render(float *stereoOut, uint32_t frameCount, void *user) {
         static_cast<LocalVoiceSink *>(user)->RenderInto(stereoOut, frameCount);
     }
 
     void LocalVoiceSink::RenderInto(float *stereoOut, uint32_t frameCount) {
         const World &world = _world[_publishedSlot.load(std::memory_order_acquire)];
+
+        // Read once per callback so every speaker in this buffer is mixed against the same curve.
+        const float fullVolumeFraction = _fullVolumeFraction.load(std::memory_order_relaxed);
 
         int16_t scratch[kRenderChunkSamples];
         bool mixedAnything = false;
@@ -191,7 +198,7 @@ namespace Framework::Voice {
 
             SpeakerGain gain;
             if (positioned) {
-                gain = ComputeGain(world.listener, world.position[i], world.range[i]);
+                gain = ComputeGain(world.listener, world.position[i], world.range[i], fullVolumeFraction);
             }
 
             const bool audible = gain.left > 0.0f || gain.right > 0.0f;

--- a/code/framework/src/voice/client/voice_client.h
+++ b/code/framework/src/voice/client/voice_client.h
@@ -73,6 +73,14 @@ namespace Framework::Voice {
             return _masterVolume.load(std::memory_order_relaxed);
         }
 
+        // Full-volume radius as a fraction of range. Atomic: the audio thread reads it per frame
+        // while the game sets it from a settings UI. Clamped to (0, 1].
+        void SetFullVolumeFraction(float fraction);
+
+        float GetFullVolumeFraction() const {
+            return _fullVolumeFraction.load(std::memory_order_relaxed);
+        }
+
       private:
         struct Slot {
             // 0 = free. Published last on acquire, cleared first on release.
@@ -107,6 +115,7 @@ namespace Framework::Voice {
         uint32_t _previousSlot = 0;
 
         std::atomic<float> _masterVolume {1.0f};
+        std::atomic<float> _fullVolumeFraction {kDefaultFullVolumeFraction};
     };
 
     // Client half of voice: the RakVoice relay session, push-to-talk, and speaker admission.
@@ -232,6 +241,17 @@ namespace Framework::Voice {
 
         float GetMasterVolume() const {
             return _localSink.GetMasterVolume();
+        }
+
+        // Rolloff shape: the fraction of range within which a speaker is at full volume. Raising
+        // it flattens the near field without moving the cutoff, which is the knob a player who
+        // says "I can't hear anyone standing next to me" actually needs.
+        void SetFullVolumeFraction(float fraction) {
+            _localSink.SetFullVolumeFraction(fraction);
+        }
+
+        float GetFullVolumeFraction() const {
+            return _localSink.GetFullVolumeFraction();
         }
 
       private:

--- a/code/tests/modules/voice_mixer_ut.h
+++ b/code/tests/modules/voice_mixer_ut.h
@@ -11,6 +11,7 @@
 #include "voice/client/mixer.h"
 
 #include <cmath>
+#include <limits>
 
 namespace {
     // glm's basis: -Z forward, +Y up, so +X is the right ear.
@@ -45,6 +46,16 @@ MODULE(voice_mixer, {
         const auto gain = ComputeGain(OriginListener(), glm::vec3(0.0f, 0.0f, 0.0f), 25.0f);
         EQUALS(NearlyEqual(gain.left, 0.707f), true);
         EQUALS(NearlyEqual(gain.right, 0.707f), true);
+    });
+
+    IT("falls back to the default rolloff on a non-finite full-volume fraction", {
+        // A NaN would survive the clamp and reach both gains, where the mixer's `> 0.0f` audibility
+        // check reads as inaudible: the speaker's audio is consumed and never mixed.
+        const auto expected = ComputeGain(OriginListener(), glm::vec3(0.0f, 0.0f, 5.0f), 25.0f);
+        const auto gain     = ComputeGain(OriginListener(), glm::vec3(0.0f, 0.0f, 5.0f), 25.0f, std::numeric_limits<float>::quiet_NaN());
+        EQUALS(NearlyEqual(gain.left, expected.left), true);
+        EQUALS(NearlyEqual(gain.right, expected.right), true);
+        EQUALS(gain.left > 0.0f, true);
     });
 
     IT("silences a speaker beyond the range", {

--- a/code/tests/modules/voice_mixer_ut.h
+++ b/code/tests/modules/voice_mixer_ut.h
@@ -162,6 +162,18 @@ MODULE(voice_mixer, {
         EQUALS(out[0] > 0.75f, true);
     });
 
+    IT("treats a non-finite master volume as unity rather than writing NaN to the device", {
+        // The soft limiter cannot bend NaN towards the ceiling -- every comparison inside it is
+        // false -- so an unguarded NaN volume reaches the audio device unclamped.
+        float out[2] = {0.5f, -0.5f};
+
+        LimitStereoBuffer(out, 1, std::numeric_limits<float>::quiet_NaN());
+
+        EQUALS(std::isfinite(out[0]), true);
+        EQUALS(std::isfinite(out[1]), true);
+        EQUALS(NearlyEqual(out[0], 0.5f), true);
+    });
+
     IT("never exceeds the ceiling for any input, including the absurd", {
         float out[8] = {0.9f, 1.0f, 2.0f, 25.0f, 1000.0f, -1000.0f, -7.5f, -1.2f};
 


### PR DESCRIPTION
The fraction of range inside which a speaker is at full volume was a compile-time constant, so tuning the curve meant a rebuild and shipping one shape to every player. It is the knob that matters when voice is audible only at arm's length: master volume raises the near field equally and so cannot fix a curve that is too steep.

ComputeGain takes it as a parameter, defaulting to the current 1/25 so behaviour is unchanged. LocalVoiceSink holds it in an atomic read once per render callback, alongside the master volume it already keeps that way, and VoiceClient forwards it for a settings UI to drive.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added controls to configure how voice volume decreases with distance.
  * Exposed getters and setters for the full-volume distance fraction.
  * Settings apply consistently across speakers and are constrained to valid values.

* **Improvements**
  * Distance-based voice attenuation now scales consistently across different speaker ranges.
  * Existing behavior remains unchanged by default.

* **Bug Fixes**
  * Improved handling of invalid volume settings to prevent distorted audio output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->