### PR TITLE
Vendors: pin MafiaNet v0.16.0 for the tunnelled-client MTU fix

### DIFF
--- a/cmake/MafiaNetPin.cmake
+++ b/cmake/MafiaNetPin.cmake
@@ -24,4 +24,4 @@
 # tree, so bumping the pin here and rebuilding incrementally would silently keep
 # fetching the old revision. This file is the single source of truth, and there is
 # no reason to let -D override the wire format of the protocol.
-set(MAFIANET_PIN "2221f074cc32bf305c181d145fe4ba1550bab1b7") # v0.15.0 -- session handshake (RAKNET_PROTOCOL_VERSION 7)
+set(MAFIANET_PIN "667fa4e927b908a8c2ca67b4477e4beca4b1b259") # v0.16.0 -- MTU capped at 1400 (RAKNET_PROTOCOL_VERSION still 7, wire-compatible)


### PR DESCRIPTION
Pins MafiaNet to [v0.16.0](https://github.com/MafiaHub/MafiaNet/releases/tag/v0.16.0), which fixes players behind a VPN being unable to connect.

## Why

MafiaNet negotiated the path MTU **in one direction only** — the connecting peer padded `ID_OPEN_CONNECTION_REQUEST_1` down its ladder, the accepting peer echoed back whatever size arrived — then froze that value for the life of the connection and applied it to **both** directions, with no black-hole detection afterwards. A datagram too large for the return path was resent at the same size until the connection timed out.

Every handshake packet is small enough to survive that, so the failure landed on the first split payload instead: the peer connected and then hung or dropped. Which tunnelled players it hit depended entirely on their exit node's encapsulation overhead — WireGuard 1420, Tailscale and many providers 1280, IKEv2 ~1400 — against MafiaNet's old top rung of 1492. That is why it looked intermittent.

v0.16.0 caps the negotiated MTU at 1400, adds finer rungs (1280, 1024) so stepping down costs less payload capacity, and clamps an MTU reported by a remote peer — previously guarded only by a `RakAssert`, so a release build would adopt an MTU of 65535 from a single forged, unauthenticated datagram. It also fixes a dead `WSAEMSGSIZE` check, a stalled `sendto` abandoning a connection attempt outright, and a latent divide-by-zero in `Connect()`.

## Compatibility

**Wire-compatible. `RAKNET_PROTOCOL_VERSION` stays at 7 and no message ids move.**

Two peers converge on the smaller of their two caps, because the accepting side clamps to its own `MAXIMUM_MTU_SIZE` before replying and both sides clamp what they are told. **A server built on this pin caps every connection — including clients still built against 0.15.0 — with no client update required.**

## On the version bump

`bump_version.sh` classifies this as a **major** Framework bump because it touches `cmake/MafiaNetPin.cmake`. That rule is a deliberate proxy for "the wire format may have moved", and the pin file documents it as such. It has not moved here — the protocol version is unchanged and the MTU is negotiated per connection, never part of the packet format — so the major classification is the tooling being conservative by design rather than a real break. Flagging it rather than working around it.

## Verification

- `builds\build.bat M2OServer 64` builds clean against the new pin.
- The fetched tree under `_deps/mafianet-src` is at `667fa4e9` (`chore(release): v0.16.0`) with `MAXIMUM_MTU_SIZE 1400`, confirming the pin actually moved rather than reusing the cached 0.15.0 checkout.
- Upstream: 137/137 unit and 49/49 integration on Windows, plus MafiaNet CI green on Linux (Debug and Release), macOS and Windows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled MafiaNet networking dependency to version 0.16.0.
  * Network behavior remains wire-compatible, with improved MTU handling capped at 1400.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->