### PR TITLE
Vendors: pin MafiaNet v0.17.0 for in-session MTU black-hole recovery

### DIFF
--- a/cmake/MafiaNetPin.cmake
+++ b/cmake/MafiaNetPin.cmake
@@ -24,4 +24,4 @@
 # tree, so bumping the pin here and rebuilding incrementally would silently keep
 # fetching the old revision. This file is the single source of truth, and there is
 # no reason to let -D override the wire format of the protocol.
-set(MAFIANET_PIN "667fa4e927b908a8c2ca67b4477e4beca4b1b259") # v0.16.0 -- MTU capped at 1400 (RAKNET_PROTOCOL_VERSION still 7, wire-compatible)
+set(MAFIANET_PIN "9b0e240cce9d5cca77f50637fc59a8071606e633") # v0.17.0 -- in-session MTU black-hole detection (RAKNET_PROTOCOL_VERSION still 7, wire-compatible)


### PR DESCRIPTION
Bumps the MafiaNet pin from v0.16.0 (`667fa4e9`) to v0.17.0 (`9b0e240c`).

v0.16.0's 1400-byte MTU cap fixed tunnelled players on paths the handshake can probe; v0.17.0 adds the deferred follow-up for the ones it can't: a tunnel that black-holes large datagrams on the **return** path only (OpenVPN's defaults do exactly this — no UDP fragmentation, direction-asymmetric drops, OpenVPN/openvpn#823), or a path that shrinks mid-session. The reliability layer now detects the black-hole signature, steps the connection's MTU down the handshake's own ladder, and re-splits every queued message that no longer fits — instead of resending the same too-large datagram until the connection times out. Ordinary packet loss can never trigger a step-down.

Wire-compatible: `RAKNET_PROTOCOL_VERSION` stays at 7, no message ids move, and the split/reassembly wire format is unchanged (the new bookkeeping is sender-side only), so mixed 0.15/0.16/0.17 peers interoperate and a server-side bump helps players who have not updated. Release notes: https://github.com/MafiaHub/MafiaNet/releases/tag/v0.17.0

Verified locally: a reconfigure fetches the pinned commit and `MafiaNetStatic`, `Framework`, and `FrameworkServer` all build clean against it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the bundled MafiaNet networking component to version 0.17.0.
  * Maintained compatibility with the existing network protocol.
  * Improved in-session detection of network MTU black-hole conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->