### PR TITLE
Utils: name the encoding at every wide/narrow conversion

### DIFF
--- a/code/framework/CMakeLists.txt
+++ b/code/framework/CMakeLists.txt
@@ -17,6 +17,7 @@ set(FRAMEWORK_SRC
     src/utils/hashing.cpp
     src/utils/path.cpp
     src/utils/safe_string.cpp
+    src/utils/string_utils.cpp
     src/utils/states/machine.cpp
 
     src/external/sentry/wrapper.cpp
@@ -168,6 +169,7 @@ if(WIN32)
     add_library(FrameworkLoader
         STATIC
         src/utils/hashing.cpp
+        src/utils/string_utils.cpp
         src/launcher/gpu_preference.cpp
         src/launcher/project.cpp
         src/launcher/rgl_bypass.cpp

--- a/code/framework/src/launcher/project.cpp
+++ b/code/framework/src/launcher/project.cpp
@@ -112,8 +112,10 @@ LPWSTR BuildGameCommandLineW() {
 
 LPSTR BuildGameCommandLineA() {
     static char buffer[32768] = {};
-    const auto commandLine    = Framework::Utils::StringUtils::WideToNormal(BuildGameCommandLineW());
-    strcpy_s(buffer, commandLine.c_str());
+    const auto commandLine    = Framework::Utils::StringUtils::WideToACP(BuildGameCommandLineW());
+    // A DBCS code page can spend two bytes on one wchar_t, so the ACP form can outgrow
+    // the wide one; truncate like the wide side rather than trip strcpy_s's handler.
+    strncpy_s(buffer, commandLine.c_str(), _TRUNCATE);
     return buffer;
 }
 
@@ -158,7 +160,7 @@ LPSTR WINAPI GetCommandLineA_Stub() {
 
 DWORD WINAPI GetModuleFileNameA_Hook(HMODULE hModule, LPSTR lpFilename, DWORD nSize) {
     if (!hModule || hModule == GetModuleHandle(nullptr)) {
-        const auto gamePath = Framework::Utils::StringUtils::WideToNormal(gImagePath);
+        const auto gamePath = Framework::Utils::StringUtils::WideToACP(gImagePath);
         strcpy_s(lpFilename, nSize, gamePath.c_str());
 
         return (DWORD)gamePath.size();
@@ -169,7 +171,7 @@ DWORD WINAPI GetModuleFileNameA_Hook(HMODULE hModule, LPSTR lpFilename, DWORD nS
 
 DWORD WINAPI GetModuleFileNameExA_Hook(HANDLE hProcess, HMODULE hModule, LPSTR lpFilename, DWORD nSize) {
     if (!hModule || hModule == GetModuleHandle(nullptr)) {
-        const auto gamePath = Framework::Utils::StringUtils::WideToNormal(gImagePath);
+        const auto gamePath = Framework::Utils::StringUtils::WideToACP(gImagePath);
         strcpy_s(lpFilename, nSize, gamePath.c_str());
 
         return (DWORD)gamePath.size();
@@ -240,7 +242,7 @@ namespace Framework::Launcher {
 
         Logging::GetInstance()->SetLogName(_config.name);
 
-        auto projectPath = Utils::StringUtils::WideToNormal(gProjectDllPath);
+        auto projectPath = Utils::StringUtils::WideToACP(gProjectDllPath);
         std::replace(projectPath.begin(), projectPath.end(), '/', '\\');
         Logging::GetInstance()->SetLogFolder(projectPath + "/logs");
 
@@ -248,7 +250,7 @@ namespace Framework::Launcher {
         _minidump     = std::make_unique<Utils::MiniDump>();
         _fileConfig   = std::make_unique<Utils::Config>();
 
-        _minidump->SetSymbolPath(Utils::StringUtils::WideToNormal(gProjectDllPath));
+        _minidump->SetSymbolPath(Utils::StringUtils::WideToACP(gProjectDllPath));
     }
 
     bool Project::Launch() {
@@ -364,7 +366,7 @@ namespace Framework::Launcher {
 
         std::error_code ec;
         if (!std::filesystem::is_regular_file(_gamePath, ec)) {
-            MessageBoxA(nullptr, ("The game executable could not be found:\n" + Utils::StringUtils::WideToNormal(_gamePath)).c_str(), _config.name.c_str(), MB_ICONERROR);
+            MessageBoxA(nullptr, ("The game executable could not be found:\n" + Utils::StringUtils::WideToACP(_gamePath)).c_str(), _config.name.c_str(), MB_ICONERROR);
             return false;
         }
 
@@ -379,7 +381,7 @@ namespace Framework::Launcher {
             }
         }
 
-        Logging::GetLogger(FRAMEWORK_INNER_LAUNCHER)->info("Loading game {}", Utils::StringUtils::WideToNormal(_gamePath));
+        Logging::GetLogger(FRAMEWORK_INNER_LAUNCHER)->info("Loading game {}", Utils::StringUtils::WideToUTF8(_gamePath));
 
         // Run with type depending
         if (_config.launchType == ProjectLaunchType::PE_LOADING) {
@@ -485,12 +487,12 @@ namespace Framework::Launcher {
             return unavailable("Steam returned an empty install directory for the destination game");
         }
 
-        auto installPath = Utils::StringUtils::NormalToWide(installDir);
+        auto installPath = Utils::StringUtils::UTF8ToWide(installDir);
         std::replace(installPath.begin(), installPath.end(), '\\', '/');
 
         if (!GameExecutableExistsIn(installPath)) {
             _steamWrapper->Shutdown();
-            return unavailable(fmt::format("Steam points at {}, but the game executable is not there", Utils::StringUtils::WideToNormal(installPath)));
+            return unavailable(fmt::format("Steam points at {}, but the game executable is not there", Utils::StringUtils::WideToACP(installPath)));
         }
 
         _gamePath = installPath;
@@ -517,19 +519,19 @@ namespace Framework::Launcher {
 
         // Locate the game via the Epic launcher's plaintext manifests - no SDK or running client
         // needed, just Epic having installed it once. Matched by AppName, else by exe file name.
-        const auto exeName = Utils::StringUtils::WideToNormal(_config.executableName);
-        const auto appName = Utils::StringUtils::WideToNormal(_config.epicAppName);
+        const auto exeName = Utils::StringUtils::WideToUTF8(_config.executableName);
+        const auto appName = Utils::StringUtils::WideToUTF8(_config.epicAppName);
 
         const auto app = External::Epic::FindInstalledApp(exeName, appName);
         if (!app.IsValid()) {
             return unavailable("The destination game is not installed through the Epic Games Launcher");
         }
 
-        auto installPath = Utils::StringUtils::NormalToWide(app.installLocation);
+        auto installPath = Utils::StringUtils::UTF8ToWide(app.installLocation);
         std::ranges::replace(installPath, L'\\', L'/');
 
         if (!GameExecutableExistsIn(installPath)) {
-            return unavailable(fmt::format("Epic points at {}, but the game executable is not there", Utils::StringUtils::WideToNormal(installPath)));
+            return unavailable(fmt::format("Epic points at {}, but the game executable is not there", Utils::StringUtils::WideToACP(installPath)));
         }
 
         _gamePath = installPath;
@@ -561,7 +563,7 @@ namespace Framework::Launcher {
     }
 
     bool Project::ResolveGamePathFromPrompt() {
-        const auto startPath = Utils::StringUtils::WideToNormal(gProjectDllPath);
+        const auto startPath = Utils::StringUtils::WideToACP(gProjectDllPath);
 
         sfd_Options sfd = {};
         sfd.path        = startPath.c_str();
@@ -579,7 +581,7 @@ namespace Framework::Launcher {
             return false;
         }
 
-        const std::filesystem::path exePath(Utils::StringUtils::NormalToWide(picked));
+        const std::filesystem::path exePath(Utils::StringUtils::ACPToWide(picked));
 
         std::error_code ec;
         if (!std::filesystem::is_regular_file(exePath, ec)) {
@@ -587,9 +589,9 @@ namespace Framework::Launcher {
             return false;
         }
 
-        const auto expectedName = Utils::StringUtils::WideToNormal(_config.executableName);
+        const auto expectedName = Utils::StringUtils::WideToACP(_config.executableName);
         if (_wcsicmp(exePath.filename().c_str(), _config.executableName.c_str()) != 0) {
-            MessageBoxA(nullptr, ("Please select " + expectedName + ", not " + Utils::StringUtils::WideToNormal(exePath.filename().wstring()) + ".").c_str(), _config.name.c_str(), MB_ICONERROR);
+            MessageBoxA(nullptr, ("Please select " + expectedName + ", not " + Utils::StringUtils::WideToACP(exePath.filename().wstring()) + ".").c_str(), _config.name.c_str(), MB_ICONERROR);
             return false;
         }
 
@@ -627,7 +629,7 @@ namespace Framework::Launcher {
         }
 
         if (!GameExecutableExistsIn(gamePath)) {
-            MessageBoxA(nullptr, ("Cannot find " + expectedName + " inside the selected game directory:\n" + Utils::StringUtils::WideToNormal(gamePath)).c_str(), _config.name.c_str(), MB_ICONERROR);
+            MessageBoxA(nullptr, ("Cannot find " + expectedName + " inside the selected game directory:\n" + Utils::StringUtils::WideToACP(gamePath)).c_str(), _config.name.c_str(), MB_ICONERROR);
             return false;
         }
 
@@ -1114,7 +1116,7 @@ namespace Framework::Launcher {
             return false;
         }
 
-        auto gameExeHandle = std::ifstream(Utils::StringUtils::WideToNormal(_gamePath), std::ios::binary | std::ios::ate);
+        auto gameExeHandle = std::ifstream(std::filesystem::path(_gamePath), std::ios::binary | std::ios::ate);
         if (!gameExeHandle.good()) {
             MessageBoxA(nullptr, "Failed to find the game executable", _config.name.c_str(), MB_ICONERROR);
             return false;

--- a/code/framework/src/utils/config.h
+++ b/code/framework/src/utils/config.h
@@ -63,7 +63,8 @@ namespace Framework::Utils {
             std::string key(field);
             Document &doc = *_document;
             if constexpr (std::is_same_v<T, std::wstring>) {
-                return Utils::StringUtils::NormalToWide(doc[key]);
+                const std::string narrow = doc[key];
+                return Utils::StringUtils::UTF8ToWide(narrow);
             }
             return doc[key];
         }
@@ -79,7 +80,8 @@ namespace Framework::Utils {
                 std::string key(field);
                 Document &doc = *_document;
                 if constexpr (std::is_same_v<T, std::wstring>) {
-                    return Utils::StringUtils::NormalToWide(doc[key]);
+                    const std::string narrow = doc[key];
+                    return Utils::StringUtils::UTF8ToWide(narrow);
                 }
                 return doc[key];
             }
@@ -94,7 +96,7 @@ namespace Framework::Utils {
                 return;
             Document &doc = *_document;
             if constexpr (std::is_same_v<T, std::wstring>) {
-                doc[field] = Utils::StringUtils::WideToNormal(value);
+                doc[field] = Utils::StringUtils::WideToUTF8(value);
                 return;
             }
             doc[field] = value;

--- a/code/framework/src/utils/game_module.cpp
+++ b/code/framework/src/utils/game_module.cpp
@@ -112,7 +112,7 @@ namespace Framework::Utils {
             UnregisterNotification();
 
             const auto logger     = Logging::GetLogger(FRAMEWORK_INNER_CLIENT);
-            const auto moduleName = StringUtils::WideToNormal(gWatch.moduleName);
+            const auto moduleName = StringUtils::WideToUTF8(gWatch.moduleName);
             const auto gameModule = signalled ? GetModuleHandleW(gWatch.moduleName.c_str()) : nullptr;
             if (!gameModule) {
                 logger->error("Game module {} did not load within {} ms, the game SDK will not be initialised", moduleName, GameModule::kWaitTimeoutMs);

--- a/code/framework/src/utils/string_utils.cpp
+++ b/code/framework/src/utils/string_utils.cpp
@@ -1,0 +1,63 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2023, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
+#include "string_utils.h"
+
+#ifdef _WIN32
+
+#include "safe_win32.h"
+
+namespace Framework::Utils::StringUtils {
+    namespace {
+        std::string Narrow(UINT codePage, std::wstring_view wide) {
+            if (wide.empty()) {
+                return {};
+            }
+            const int length = static_cast<int>(wide.size());
+            const int size   = WideCharToMultiByte(codePage, 0, wide.data(), length, nullptr, 0, nullptr, nullptr);
+            if (size <= 0) {
+                return {};
+            }
+            std::string out(static_cast<size_t>(size), '\0');
+            WideCharToMultiByte(codePage, 0, wide.data(), length, out.data(), size, nullptr, nullptr);
+            return out;
+        }
+
+        std::wstring Widen(UINT codePage, std::string_view narrow) {
+            if (narrow.empty()) {
+                return {};
+            }
+            const int length = static_cast<int>(narrow.size());
+            const int size   = MultiByteToWideChar(codePage, 0, narrow.data(), length, nullptr, 0);
+            if (size <= 0) {
+                return {};
+            }
+            std::wstring out(static_cast<size_t>(size), L'\0');
+            MultiByteToWideChar(codePage, 0, narrow.data(), length, out.data(), size);
+            return out;
+        }
+    } // namespace
+
+    std::string WideToUTF8(std::wstring_view wide) {
+        return Narrow(CP_UTF8, wide);
+    }
+
+    std::wstring UTF8ToWide(std::string_view utf8) {
+        return Widen(CP_UTF8, utf8);
+    }
+
+    std::string WideToACP(std::wstring_view wide) {
+        return Narrow(CP_ACP, wide);
+    }
+
+    std::wstring ACPToWide(std::string_view acp) {
+        return Widen(CP_ACP, acp);
+    }
+} // namespace Framework::Utils::StringUtils
+
+#endif

--- a/code/framework/src/utils/string_utils.h
+++ b/code/framework/src/utils/string_utils.h
@@ -16,21 +16,15 @@
 #include <string_view>
 
 namespace Framework::Utils::StringUtils {
-    inline std::wstring NormalToWide(const std::string &str) {
-        std::wstring wstr(str.length(), 0);
-        std::transform(str.begin(), str.end(), wstr.begin(), [](char c) {
-            return (wchar_t)c;
-        });
-        return wstr;
-    }
-
-    inline std::string WideToNormal(const std::wstring &wstr) {
-        std::string str(wstr.length(), 0);
-        std::transform(wstr.begin(), wstr.end(), str.begin(), [](wchar_t c) {
-            return (char)c;
-        });
-        return str;
-    }
+#ifdef _WIN32
+    // A narrow string on Windows carries one of two encodings. UTF-8 is what cppfs,
+    // std::filesystem, nlohmann and CEF read; the ACP is what the CRT's narrow file
+    // APIs and the ANSI Win32 calls read. Name the one you mean at every call site.
+    std::string WideToUTF8(std::wstring_view wide);
+    std::wstring UTF8ToWide(std::string_view utf8);
+    std::string WideToACP(std::wstring_view wide);
+    std::wstring ACPToWide(std::string_view acp);
+#endif
 
     inline std::string LeftTrim(std::string_view s) {
         return std::regex_replace(std::string(s), std::regex("^\\s+"), std::string(""));


### PR DESCRIPTION
## Problem

`StringUtils::WideToNormal` truncated each `wchar_t` to a `char`:

```cpp
std::transform(wstr.begin(), wstr.end(), str.begin(), [](wchar_t c) {
    return (char)c;
});
```

For `Á` (U+00C1) that yields the single byte `0xC1` — valid CP1252, invalid UTF-8.

That is not uniformly wrong, which is what makes it hard to spot: Windows narrow strings carry **two** encodings, and one lossy helper was serving both.

- The **ACP** is what the CRT's narrow file APIs and the ANSI Win32 calls read — spdlog's sink (`SPDLOG_WCHAR_FILENAMES` is `OFF`, so it is `fopen`), dbghelp's symbol path, `sfd`'s `GetOpenFileNameA`, `std::ifstream`, the `GetModuleFileNameA` hooks.
- **UTF-8** is what cppfs, `std::filesystem`, nlohmann and CEF read.

A downstream project hit this as a hard crash: a player whose install sat under `…\OneDrive\Área de Trabalho\…` got a deterministic `C0000005` during client init, while the launcher's own log wrote to that same path perfectly — because the log sink is ACP and the crash-reporter init is UTF-8. Moving the folder to an ASCII path fixed it.

There are two latent bugs of the same shape here: `Config::Set<std::wstring>` fed invalid UTF-8 straight into nlohmann, which throws `type_error.316` on serialize, and `Project::LoadLibrarySafe` read the game exe through `std::ifstream(WideToNormal(...))`, which breaks for a non-ASCII Steam library path.

## Change

Replace the lossy pair with four helpers that name their encoding:

```cpp
std::string  WideToUTF8(std::wstring_view);
std::wstring UTF8ToWide(std::string_view);
std::string  WideToACP(std::wstring_view);
std::wstring ACPToWide(std::string_view);
```

Declared in `string_utils.h`, defined in a new `string_utils.cpp` so `<Windows.h>` stays out of a widely-included header; added to both `FRAMEWORK_SRC` and `FrameworkLoader`, since the loader keeps its own source list.

`WideToNormal`/`NormalToWide` are **deleted** rather than kept as aliases, so the compiler forces a decision at every call site instead of leaving a helper that is right half the time.

All Framework call sites migrated per consumer — ACP for the game's narrow command line, both `GetModuleFileNameA` hooks, the log folder, the symbol path, the `sfd` dialog in *and* out, and the `MessageBoxA` text; UTF-8 for the Steam and Epic install dirs, the Epic manifest lookup keys, and log message text. The `std::ifstream` now just takes a `std::filesystem::path` and converts nothing.

## Testing

Build clean (Ninja Multi-Config, Debug) — `FrameworkTests`, `FrameworkClient`, `FrameworkServer` and the loader all compile and link with no new warnings. `FrameworkTests` passes 240/240 across 20 modules.

Not yet exercised on a non-ASCII install path in a real session — that is the one check this cannot self-verify, and it is what the original report came from.

## Note for downstreams

This is a source-breaking rename. Any project calling `WideToNormal`/`NormalToWide` must pick the encoding it means; MafiaMP has one such call site (`code/client/src/main.cpp`) that wants `WideToUTF8`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of non-ASCII characters in launcher paths, log messages, configuration values, and game metadata.
  * Added explicit support for UTF-8 and Windows ANSI encodings to reduce garbled text and conversion errors.
  * Improved reliability when reading and writing configuration data containing international characters.
  * Improved game executable path handling, including Steam, Epic, and manually selected paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->