### PR TITLE
Launcher: honour the buffer size in the module-filename hooks

### DIFF
--- a/code/framework/src/launcher/project.cpp
+++ b/code/framework/src/launcher/project.cpp
@@ -156,43 +156,65 @@ LPSTR WINAPI GetCommandLineA_Stub() {
     return BuildGameCommandLineA();
 }
 
-DWORD WINAPI GetModuleFileNameA_Hook(HMODULE hModule, LPSTR lpFilename, DWORD nSize) {
-    if (!hModule || hModule == GetModuleHandle(nullptr)) {
-        const auto gamePath = Framework::Utils::StringUtils::WideToNormal(gImagePath);
-        strcpy_s(lpFilename, nSize, gamePath.c_str());
+namespace {
+    // The real API truncates into the caller's buffer and says so in its return value;
+    // the CRT's _s copies abort the process instead, which is not a contract the game
+    // can be handed. Mirror Win32: fill what fits, terminate, report the truncation.
+    template <typename CharT>
+    DWORD CopyMappedImagePath(CharT *destination, DWORD size, const CharT *path, size_t length) {
+        if (!destination || size == 0) {
+            SetLastError(ERROR_INSUFFICIENT_BUFFER);
+            return 0;
+        }
 
-        return (DWORD)gamePath.size();
+        if (length >= size) {
+            std::copy_n(path, size - 1, destination);
+            destination[size - 1] = CharT {};
+            SetLastError(ERROR_INSUFFICIENT_BUFFER);
+            return size;
+        }
+
+        std::copy_n(path, length, destination);
+        destination[length] = CharT {};
+        return static_cast<DWORD>(length);
+    }
+
+    // Set only once Launch() has resolved the game, but these hooks are reachable before
+    // that; without the guard the conversions below read through a null pointer.
+    bool ShouldReportMappedImage(HMODULE module) {
+        return gImagePath && (!module || module == GetModuleHandle(nullptr));
+    }
+} // namespace
+
+DWORD WINAPI GetModuleFileNameA_Hook(HMODULE hModule, LPSTR lpFilename, DWORD nSize) {
+    if (ShouldReportMappedImage(hModule)) {
+        const auto gamePath = Framework::Utils::StringUtils::WideToNormal(gImagePath);
+        return CopyMappedImagePath(lpFilename, nSize, gamePath.c_str(), gamePath.size());
     }
 
     return GetModuleFileNameA(hModule, lpFilename, nSize);
 }
 
 DWORD WINAPI GetModuleFileNameExA_Hook(HANDLE hProcess, HMODULE hModule, LPSTR lpFilename, DWORD nSize) {
-    if (!hModule || hModule == GetModuleHandle(nullptr)) {
+    if (ShouldReportMappedImage(hModule)) {
         const auto gamePath = Framework::Utils::StringUtils::WideToNormal(gImagePath);
-        strcpy_s(lpFilename, nSize, gamePath.c_str());
-
-        return (DWORD)gamePath.size();
+        return CopyMappedImagePath(lpFilename, nSize, gamePath.c_str(), gamePath.size());
     }
 
     return GetModuleFileNameExA(hProcess, hModule, lpFilename, nSize);
 }
 
 DWORD WINAPI GetModuleFileNameW_Hook(HMODULE hModule, LPWSTR lpFilename, DWORD nSize) {
-    if (!hModule || hModule == GetModuleHandle(nullptr)) {
-        wcscpy_s(lpFilename, nSize, gImagePath);
-
-        return (DWORD)wcslen(gImagePath);
+    if (ShouldReportMappedImage(hModule)) {
+        return CopyMappedImagePath(lpFilename, nSize, gImagePath, wcslen(gImagePath));
     }
-    const auto len = GetModuleFileNameW(hModule, lpFilename, nSize);
-    return len;
+
+    return GetModuleFileNameW(hModule, lpFilename, nSize);
 }
 
 DWORD WINAPI GetModuleFileNameExW_Hook(HANDLE hProcess, HMODULE hModule, LPWSTR lpFilename, DWORD nSize) {
-    if (!hModule || hModule == GetModuleHandle(nullptr)) {
-        wcscpy_s(lpFilename, nSize, gImagePath);
-
-        return (DWORD)wcslen(gImagePath);
+    if (ShouldReportMappedImage(hModule)) {
+        return CopyMappedImagePath(lpFilename, nSize, gImagePath, wcslen(gImagePath));
     }
 
     return GetModuleFileNameExW(hProcess, hModule, lpFilename, nSize);


### PR DESCRIPTION
Spun out of a review comment on #270, which flagged the two `A` hooks. The same bug is in the `W` pair, so all four are fixed here.

## Problem

```cpp
DWORD WINAPI GetModuleFileNameA_Hook(HMODULE hModule, LPSTR lpFilename, DWORD nSize) {
    if (!hModule || hModule == GetModuleHandle(nullptr)) {
        const auto gamePath = Framework::Utils::StringUtils::WideToNormal(gImagePath);
        strcpy_s(lpFilename, nSize, gamePath.c_str());
        return (DWORD)gamePath.size();
    }
```

Three problems, all four hooks:

1. **`strcpy_s`/`wcscpy_s` do not truncate.** When the source does not fit, they invoke the invalid-parameter handler, which by default terminates the process. The real `GetModuleFileName` truncates and carries on, so a caller doing the perfectly ordinary thing — passing a small buffer and growing it on `ERROR_INSUFFICIENT_BUFFER` — kills the game instead of retrying.
2. **The return value ignores the buffer.** They return the full path length even when less was written, so a caller reading that many bytes runs past what was copied.
3. **`gImagePath` is read unguarded.** It is only set once `Launch()` has resolved the game, and these hooks are reachable before that. `WideToNormal(nullptr)` is UB and `wcslen(nullptr)` faults; `BuildGameCommandLineW` already guards the same global, so the hooks should too.

## Change

One helper both character types share, mirroring the documented Win32 contract — fill what fits, null-terminate, return `nSize` and set `ERROR_INSUFFICIENT_BUFFER` on truncation, otherwise return the length excluding the null — plus a `gImagePath` null check that falls through to the real API.

## Testing

`FrameworkLoader`, `Framework` and `FrameworkTests` build clean; `FrameworkTests` passes 240/240.

The suite does not reach these hooks, and the helper is file-local, so I exercised the boundary separately — that off-by-one is the whole point of the change and worth more than an inspection:

```
nSize=0   ret=0   str=""      insufficient=1     cannot write at all
nSize=1   ret=1   str=""      insufficient=1     room for the null only
nSize=4   ret=4   str="ABC"   insufficient=1     truncated: returns nSize
nSize=5   ret=4   str="ABCD"  insufficient=0     exact fit
nSize=10  ret=4   str="ABCD"  insufficient=0     room to spare
```

Each case also asserts nothing is written past `nSize`.

## Note

Independent of #270, but both edit these lines, so whichever merges second needs a trivial rebase — the conflict is only `WideToNormal` vs `WideToACP` on the two `A` hooks. Happy to take that either way round.
