### PR TITLE
Tests: compare the missing-dependency error with STREQUALS

### DIFF
--- a/code/tests/modules/resource_manager_ut.h
+++ b/code/tests/modules/resource_manager_ut.h
@@ -540,7 +540,7 @@ MODULE(resource_manager, {
 
         auto result = manager.StartAll();
         EQUALS(static_cast<bool>(result), false);
-        EQUALS(result.GetError(), std::string("Resource 'req-user' depends on missing resource 'req-absent'"));
+        STREQUALS(result.GetError().c_str(), "Resource 'req-user' depends on missing resource 'req-absent'");
 
         engine.Shutdown();
         TestManagerHelper::Cleanup();


### PR DESCRIPTION
`Test Build` has failed on `macos-latest` for every PR since #246 merged:

```
code/tests/modules/resource_manager_ut.h:543:23: error: cannot pass object of
non-trivial type 'const std::string' through variadic function; call will abort
at runtime [-Wnon-pod-varargs]
```

`EQUALS(a, b)` expands to `FAIL(a, b)`, which passes both operands to
`unit__bprintf` under `%lld`. That is fine for the scalars every other call site
uses, but #246 added one comparing two `std::string`s. MSVC and GCC only warn;
Clang makes it an error, so the macOS leg never gets past `framework_ut.cpp`.

Switched that one line to the `STREQUALS(x.c_str(), "literal")` form the rest of
the suite already uses (`engine_ut.h`, `gui_resources_ut.h`). No production code
touched, and `unit.h` is vendored from zpl-c/tester so it is left alone.

This is not caused by #248 — the same two errors appear in #246's own run
([33796008033](https://github.com/MafiaHub/Framework/actions/runs/33796008033)),
which was merged red. `build-test.yml` only runs on PRs into `develop`, so it
went unnoticed on the branch itself.

Verified locally on Windows/MSVC: `FrameworkTests` builds, all 23 modules pass
(exit 0), including `StartAll fails on a missing required dependency`. The macOS
leg on this PR is the real check.
