### PR TITLE
Networking: Isolate the pose stream and repair it on lossy links

### DIFF
--- a/cmake/MafiaNetPin.cmake
+++ b/cmake/MafiaNetPin.cmake
@@ -24,4 +24,4 @@
 # tree, so bumping the pin here and rebuilding incrementally would silently keep
 # fetching the old revision. This file is the single source of truth, and there is
 # no reason to let -D override the wire format of the protocol.
-set(MAFIANET_PIN "bc633a3a7fcc83d2b043b5360025b2b7dadef366") # MafiaHub/MafiaNet#57 -- RakVoice::SetOrderingChannels (RAKNET_PROTOCOL_VERSION still 7, wire-compatible)
+set(MAFIANET_PIN "b1af9501432a539969b5024bda88149e72a6ca30") # MafiaHub/MafiaNet#57 -- RakVoice::SetOrderingChannels (RAKNET_PROTOCOL_VERSION still 7, wire-compatible)

--- a/cmake/MafiaNetPin.cmake
+++ b/cmake/MafiaNetPin.cmake
@@ -24,4 +24,4 @@
 # tree, so bumping the pin here and rebuilding incrementally would silently keep
 # fetching the old revision. This file is the single source of truth, and there is
 # no reason to let -D override the wire format of the protocol.
-set(MAFIANET_PIN "9b0e240cce9d5cca77f50637fc59a8071606e633") # v0.17.0 -- in-session MTU black-hole detection (RAKNET_PROTOCOL_VERSION still 7, wire-compatible)
+set(MAFIANET_PIN "bc633a3a7fcc83d2b043b5360025b2b7dadef366") # MafiaHub/MafiaNet#57 -- RakVoice::SetOrderingChannels (RAKNET_PROTOCOL_VERSION still 7, wire-compatible)

--- a/cmake/MafiaNetPin.cmake
+++ b/cmake/MafiaNetPin.cmake
@@ -24,4 +24,4 @@
 # tree, so bumping the pin here and rebuilding incrementally would silently keep
 # fetching the old revision. This file is the single source of truth, and there is
 # no reason to let -D override the wire format of the protocol.
-set(MAFIANET_PIN "b1af9501432a539969b5024bda88149e72a6ca30") # MafiaHub/MafiaNet#57 -- RakVoice::SetOrderingChannels (RAKNET_PROTOCOL_VERSION still 7, wire-compatible)
+set(MAFIANET_PIN "46fd83581e24037b0535a545b6204248e4a90c28") # v0.18.0 -- RakVoice::SetOrderingChannels (RAKNET_PROTOCOL_VERSION still 7, wire-compatible)

--- a/code/framework/src/integrations/client/instance.cpp
+++ b/code/framework/src/integrations/client/instance.cpp
@@ -23,6 +23,7 @@
 #include "scripting/resource/resource_manager.h"
 #include "scripting/builtins/events.h"
 
+#include "networking/channels.h"
 #include "networking/state.h"
 #include "networking/replication/replication_manager.h"
 #include "networking/replication/nametag_state.h"
@@ -52,10 +53,6 @@
 
 namespace Framework::Integrations::Client {
     namespace {
-        // Ordering channel for the asset-download file transfer. Wire-affecting: the server must
-        // use the same channel for these transfers to stay ordered relative to each other.
-        constexpr char kAssetDownloadOrderingChannel = 2;
-
         // Handler for server-emitted scripting events; reaches the scripting engine through the
         // CoreModules singleton.
         void OnEmitScriptEvent(const Shared::RPC::EmitScriptEvent &rpc, MafiaNet::Packet *packet) {
@@ -974,7 +971,7 @@ namespace Framework::Integrations::Client {
         }
 
         _downloadStatus.downloading = true;
-        _downloadStatus.setID = streamer->DownloadFromSubdirectory(nullptr, nullptr, true, net->GetPeer()->GetSystemAddressFromIndex(0), &_assetDownloadProgress, MafiaNet::Priority::High, kAssetDownloadOrderingChannel, nullptr);
+        _downloadStatus.setID = streamer->DownloadFromSubdirectory(nullptr, nullptr, true, net->GetPeer()->GetSystemAddressFromIndex(0), &_assetDownloadProgress, MafiaNet::Priority::High, Framework::Networking::ToOrderingChannel(Framework::Networking::Channel::Assets), nullptr);
     }
 
     void Instance::SyncResourceUpdatesFromServer() {

--- a/code/framework/src/integrations/server/instance.cpp
+++ b/code/framework/src/integrations/server/instance.cpp
@@ -62,6 +62,21 @@ namespace Framework::Integrations::Server {
     namespace {
         constexpr double kTickHitchWarnMs         = 100.0;
         constexpr double kTickHitchWarnIntervalMs = 1000.0;
+
+        // The default 15.6 ms Windows sleep quantum would hold the tick to ~32 Hz. Restored on every
+        // exit from Run(), unwinding included.
+        struct TimerResolutionScope {
+#ifdef _WIN32
+            TimerResolutionScope() {
+                timeBeginPeriod(1);
+            }
+            ~TimerResolutionScope() {
+                timeEndPeriod(1);
+            }
+#endif
+            TimerResolutionScope(const TimerResolutionScope &)            = delete;
+            TimerResolutionScope &operator=(const TimerResolutionScope &) = delete;
+        };
     } // namespace
 
     Instance::Instance(): _shuttingDown(false) {
@@ -1213,7 +1228,9 @@ namespace Framework::Integrations::Server {
                 });
             }
 
-            DispatchVoiceTalkingChanges();
+            phase("voiceEvents", [&] {
+                DispatchVoiceTalkingChanges();
+            });
 
             if (_scriptingModule) {
                 FW_PROFILE_SCOPE_N("Server::Scripting");
@@ -1269,17 +1286,11 @@ namespace Framework::Integrations::Server {
         }
     }
     void Instance::Run() {
-#ifdef _WIN32
-        // The default 15.6 ms sleep quantum would hold the tick to ~32 Hz.
-        timeBeginPeriod(1);
-#endif
+        const TimerResolutionScope timerResolution;
         while (_initialized) {
             Update();
             std::this_thread::yield();
         }
-#ifdef _WIN32
-        timeEndPeriod(1);
-#endif
     }
 
     void Instance::OnSignal(const sig_signal_t signal) {

--- a/code/framework/src/integrations/server/instance.cpp
+++ b/code/framework/src/integrations/server/instance.cpp
@@ -73,6 +73,9 @@ namespace Framework::Integrations::Server {
             ~TimerResolutionScope() {
                 timeEndPeriod(1);
             }
+#else
+            TimerResolutionScope()  = default;
+            ~TimerResolutionScope() = default;
 #endif
             TimerResolutionScope(const TimerResolutionScope &)            = delete;
             TimerResolutionScope &operator=(const TimerResolutionScope &) = delete;

--- a/code/framework/src/integrations/server/instance.cpp
+++ b/code/framework/src/integrations/server/instance.cpp
@@ -1190,25 +1190,9 @@ namespace Framework::Integrations::Server {
         if (_nextTick <= start) {
             FW_PROFILE_SCOPE_N("Server::Tick");
 
-            // A stalled tick freezes replication for every client; anything past kTickHitchWarnMs is
-            // logged with the phase that took it.
-            const char *slowestPhase = "";
-            double slowestPhaseMs    = 0.0;
-            const auto phase         = [&](const char *name, auto &&body) {
-                const auto phaseStart = std::chrono::high_resolution_clock::now();
-                body();
-                const double ms = std::chrono::duration<double, std::milli>(std::chrono::high_resolution_clock::now() - phaseStart).count();
-                if (ms > slowestPhaseMs) {
-                    slowestPhaseMs = ms;
-                    slowestPhase   = name;
-                }
-            };
-
             if (_networkingEngine) {
                 FW_PROFILE_SCOPE_N("Server::Networking");
-                phase("networking", [&] {
-                    _networkingEngine->Update();
-                });
+                _networkingEngine->Update();
             }
 
             // Refresh the voice router's world view from the replicated entities. Every entity
@@ -1217,53 +1201,41 @@ namespace Framework::Integrations::Server {
             // ForEach<NetworkEntity> would cost for no added selectivity.
             if (auto *replication = _networkingEngine ? _networkingEngine->GetNetworkServer()->GetReplicationManager() : nullptr) {
                 FW_PROFILE_SCOPE_N("Server::VoicePositions");
-                phase("voice", [&] {
-                    auto &router = _voiceServer.GetRouter();
-                    replication->ForEachEntity([&router](Framework::Networking::Replication::NetworkEntity *entity) {
-                        if (entity->ownerGUID != MafiaNet::UNASSIGNED_PEER_GUID) {
-                            router.SetPlayerPosition(static_cast<uint64_t>(entity->ownerGUID), entity->position);
-                        }
-                    });
-                    _voiceServer.Update();
+                auto &router = _voiceServer.GetRouter();
+                replication->ForEachEntity([&router](Framework::Networking::Replication::NetworkEntity *entity) {
+                    if (entity->ownerGUID != MafiaNet::UNASSIGNED_PEER_GUID) {
+                        router.SetPlayerPosition(static_cast<uint64_t>(entity->ownerGUID), entity->position);
+                    }
                 });
+                _voiceServer.Update();
             }
 
-            phase("voiceEvents", [&] {
-                DispatchVoiceTalkingChanges();
-            });
+            DispatchVoiceTalkingChanges();
 
             if (_scriptingModule) {
                 FW_PROFILE_SCOPE_N("Server::Scripting");
-                phase("scripting", [&] {
-                    _scriptingModule->Update();
-                });
+                _scriptingModule->Update();
             }
 
             if (_commandListener) {
                 FW_PROFILE_SCOPE_N("Server::Commands");
-                phase("commands", [&] {
-                    _commandListener->Update();
-                });
+                _commandListener->Update();
             }
 
             if (_masterlist->IsInitialized()) {
                 FW_PROFILE_SCOPE_N("Server::MasterlistPing");
-                phase("masterlist", [&] {
-                    Services::ServerInfo info {};
-                    info.port           = _opts.bindPort;
-                    info.gameMode       = _opts.modName;
-                    info.version        = _opts.modVersion;
-                    info.maxPlayers     = _opts.maxPlayers;
-                    info.currentPlayers = _networkingEngine->GetNetworkServer()->GetPeer()->NumberOfConnections();
-                    _masterlist->Ping(info);
-                });
+                Services::ServerInfo info {};
+                info.port           = _opts.bindPort;
+                info.gameMode       = _opts.modName;
+                info.version        = _opts.modVersion;
+                info.maxPlayers     = _opts.maxPlayers;
+                info.currentPlayers = _networkingEngine->GetNetworkServer()->GetPeer()->NumberOfConnections();
+                _masterlist->Ping(info);
             }
 
             {
                 FW_PROFILE_SCOPE_N("Server::PostUpdate");
-                phase("postUpdate", [&] {
-                    PostUpdate();
-                });
+                PostUpdate();
             }
 
             FW_PROFILE_FRAME();
@@ -1273,7 +1245,7 @@ namespace Framework::Integrations::Server {
             if (tickMs >= kTickHitchWarnMs) {
                 ++_suppressedHitches;
                 if (std::chrono::duration<double, std::milli>(end - _lastHitchWarnAt).count() >= kTickHitchWarnIntervalMs) {
-                    Logging::GetLogger(FRAMEWORK_INNER_SERVER)->warn("Server tick took {:.0f} ms against a {:.0f} ms budget; slowest phase {} at {:.0f} ms ({} slow tick(s) since the last warning)", tickMs, Utils::Time::SecondsToMs(_opts.worldConfig.tickInterval), slowestPhase, slowestPhaseMs, _suppressedHitches);
+                    Logging::GetLogger(FRAMEWORK_INNER_SERVER)->warn("Server tick took {:.0f} ms against a {:.0f} ms budget ({} slow tick(s) since the last warning)", tickMs, Utils::Time::SecondsToMs(_opts.worldConfig.tickInterval), _suppressedHitches);
                     _lastHitchWarnAt   = end;
                     _suppressedHitches = 0;
                 }

--- a/code/framework/src/integrations/server/instance.cpp
+++ b/code/framework/src/integrations/server/instance.cpp
@@ -54,7 +54,15 @@
 #include <cppfs/fs.h>
 #include <csignal>
 
+#ifdef _WIN32
+#include <timeapi.h>
+#endif
+
 namespace Framework::Integrations::Server {
+    namespace {
+        constexpr double kTickHitchWarnMs         = 100.0;
+        constexpr double kTickHitchWarnIntervalMs = 1000.0;
+    } // namespace
 
     Instance::Instance(): _shuttingDown(false) {
         _networkingEngine = std::make_unique<Networking::Engine>();
@@ -1167,9 +1175,25 @@ namespace Framework::Integrations::Server {
         if (_nextTick <= start) {
             FW_PROFILE_SCOPE_N("Server::Tick");
 
+            // A stalled tick freezes replication for every client; anything past kTickHitchWarnMs is
+            // logged with the phase that took it.
+            const char *slowestPhase = "";
+            double slowestPhaseMs    = 0.0;
+            const auto phase         = [&](const char *name, auto &&body) {
+                const auto phaseStart = std::chrono::high_resolution_clock::now();
+                body();
+                const double ms = std::chrono::duration<double, std::milli>(std::chrono::high_resolution_clock::now() - phaseStart).count();
+                if (ms > slowestPhaseMs) {
+                    slowestPhaseMs = ms;
+                    slowestPhase   = name;
+                }
+            };
+
             if (_networkingEngine) {
                 FW_PROFILE_SCOPE_N("Server::Networking");
-                _networkingEngine->Update();
+                phase("networking", [&] {
+                    _networkingEngine->Update();
+                });
             }
 
             // Refresh the voice router's world view from the replicated entities. Every entity
@@ -1178,56 +1202,84 @@ namespace Framework::Integrations::Server {
             // ForEach<NetworkEntity> would cost for no added selectivity.
             if (auto *replication = _networkingEngine ? _networkingEngine->GetNetworkServer()->GetReplicationManager() : nullptr) {
                 FW_PROFILE_SCOPE_N("Server::VoicePositions");
-                auto &router = _voiceServer.GetRouter();
-                replication->ForEachEntity([&router](Framework::Networking::Replication::NetworkEntity *entity) {
-                    if (entity->ownerGUID != MafiaNet::UNASSIGNED_PEER_GUID) {
-                        router.SetPlayerPosition(static_cast<uint64_t>(entity->ownerGUID), entity->position);
-                    }
+                phase("voice", [&] {
+                    auto &router = _voiceServer.GetRouter();
+                    replication->ForEachEntity([&router](Framework::Networking::Replication::NetworkEntity *entity) {
+                        if (entity->ownerGUID != MafiaNet::UNASSIGNED_PEER_GUID) {
+                            router.SetPlayerPosition(static_cast<uint64_t>(entity->ownerGUID), entity->position);
+                        }
+                    });
+                    _voiceServer.Update();
                 });
-                _voiceServer.Update();
             }
 
             DispatchVoiceTalkingChanges();
 
             if (_scriptingModule) {
                 FW_PROFILE_SCOPE_N("Server::Scripting");
-                _scriptingModule->Update();
+                phase("scripting", [&] {
+                    _scriptingModule->Update();
+                });
             }
 
             if (_commandListener) {
                 FW_PROFILE_SCOPE_N("Server::Commands");
-                _commandListener->Update();
+                phase("commands", [&] {
+                    _commandListener->Update();
+                });
             }
 
             if (_masterlist->IsInitialized()) {
                 FW_PROFILE_SCOPE_N("Server::MasterlistPing");
-                Services::ServerInfo info {};
-                info.port           = _opts.bindPort;
-                info.gameMode       = _opts.modName;
-                info.version        = _opts.modVersion;
-                info.maxPlayers     = _opts.maxPlayers;
-                info.currentPlayers = _networkingEngine->GetNetworkServer()->GetPeer()->NumberOfConnections();
-                _masterlist->Ping(info);
+                phase("masterlist", [&] {
+                    Services::ServerInfo info {};
+                    info.port           = _opts.bindPort;
+                    info.gameMode       = _opts.modName;
+                    info.version        = _opts.modVersion;
+                    info.maxPlayers     = _opts.maxPlayers;
+                    info.currentPlayers = _networkingEngine->GetNetworkServer()->GetPeer()->NumberOfConnections();
+                    _masterlist->Ping(info);
+                });
             }
 
             {
                 FW_PROFILE_SCOPE_N("Server::PostUpdate");
-                PostUpdate();
+                phase("postUpdate", [&] {
+                    PostUpdate();
+                });
             }
 
             FW_PROFILE_FRAME();
 
-            _nextTick = std::chrono::high_resolution_clock::now() + std::chrono::milliseconds(static_cast<int64_t>(Utils::Time::SecondsToMs(_opts.worldConfig.tickInterval)));
+            const auto end      = std::chrono::high_resolution_clock::now();
+            const double tickMs = std::chrono::duration<double, std::milli>(end - start).count();
+            if (tickMs >= kTickHitchWarnMs) {
+                ++_suppressedHitches;
+                if (std::chrono::duration<double, std::milli>(end - _lastHitchWarnAt).count() >= kTickHitchWarnIntervalMs) {
+                    Logging::GetLogger(FRAMEWORK_INNER_SERVER)->warn("Server tick took {:.0f} ms against a {:.0f} ms budget; slowest phase {} at {:.0f} ms ({} slow tick(s) since the last warning)", tickMs, Utils::Time::SecondsToMs(_opts.worldConfig.tickInterval), slowestPhase, slowestPhaseMs, _suppressedHitches);
+                    _lastHitchWarnAt   = end;
+                    _suppressedHitches = 0;
+                }
+            }
+
+            _nextTick = end + std::chrono::milliseconds(static_cast<int64_t>(Utils::Time::SecondsToMs(_opts.worldConfig.tickInterval)));
         }
         else {
             std::this_thread::sleep_for(std::chrono::milliseconds(1));
         }
     }
     void Instance::Run() {
+#ifdef _WIN32
+        // The default 15.6 ms sleep quantum would hold the tick to ~32 Hz.
+        timeBeginPeriod(1);
+#endif
         while (_initialized) {
             Update();
             std::this_thread::yield();
         }
+#ifdef _WIN32
+        timeEndPeriod(1);
+#endif
     }
 
     void Instance::OnSignal(const sig_signal_t signal) {

--- a/code/framework/src/integrations/server/instance.h
+++ b/code/framework/src/integrations/server/instance.h
@@ -147,6 +147,8 @@ namespace Framework::Integrations::Server {
         // Set after the initial StartAll; gates runtime broadcasts to clients.
         bool _resourcesBooted = false;
         std::chrono::time_point<std::chrono::high_resolution_clock> _nextTick;
+        std::chrono::time_point<std::chrono::high_resolution_clock> _lastHitchWarnAt {};
+        uint32_t _suppressedHitches = 0;
 
         InstanceOptions _opts;
 

--- a/code/framework/src/networking/channels.h
+++ b/code/framework/src/networking/channels.h
@@ -1,0 +1,34 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2026, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
+#pragma once
+
+namespace Framework::Networking {
+    // RakNet ordering channels by traffic class. A lost ReliableOrdered message holds back every
+    // later sequenced message on the same channel until it is retransmitted, so the pose stream gets a
+    // channel of its own. RPCs name entities, so they share the construction channel to stay ordered
+    // after it.
+    enum class Channel : char {
+        Transform    = 0,
+        State        = 1,
+        Assets       = 2,
+        Events       = 3,
+        Construction = 3,
+        VoiceFrames  = 4,
+        VoiceControl = 5,
+    };
+
+    constexpr char ToOrderingChannel(Channel channel) {
+        return static_cast<char>(channel);
+    }
+
+    static_assert(ToOrderingChannel(Channel::Transform) != ToOrderingChannel(Channel::Events));
+    static_assert(ToOrderingChannel(Channel::Construction) == ToOrderingChannel(Channel::Events));
+    static_assert(ToOrderingChannel(Channel::Transform) != ToOrderingChannel(Channel::VoiceFrames));
+    static_assert(ToOrderingChannel(Channel::Transform) != ToOrderingChannel(Channel::Assets));
+} // namespace Framework::Networking

--- a/code/framework/src/networking/network_peer.h
+++ b/code/framework/src/networking/network_peer.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "channels.h"
 #include "connection.h"
 #include "rpc/rpc.h"
 
@@ -122,7 +123,7 @@ namespace Framework::Networking {
         void BroadcastRPC(T &payload, MafiaNet::Priority priority = MafiaNet::Priority::High, MafiaNet::Reliability reliability = MafiaNet::Reliability::ReliableOrdered, MafiaNet::RakNetGUID except = MafiaNet::UNASSIGNED_RAKNET_GUID) {
             MafiaNet::BitStream bs;
             payload.Serialize(&bs, true);
-            _rpc.Signal(T::kIdentifier, &bs, priority, reliability, 0, except, true, false);
+            _rpc.Signal(T::kIdentifier, &bs, priority, reliability, ToOrderingChannel(Channel::Events), except, true, false);
         }
 
         // Send an RPC payload to a single system.
@@ -130,7 +131,7 @@ namespace Framework::Networking {
         void SendRPC(T &payload, MafiaNet::RakNetGUID guid, MafiaNet::Priority priority = MafiaNet::Priority::High, MafiaNet::Reliability reliability = MafiaNet::Reliability::ReliableOrdered) {
             MafiaNet::BitStream bs;
             payload.Serialize(&bs, true);
-            _rpc.Signal(T::kIdentifier, &bs, priority, reliability, 0, guid, false, false);
+            _rpc.Signal(T::kIdentifier, &bs, priority, reliability, ToOrderingChannel(Channel::Events), guid, false, false);
         }
 
         // Raw variant of RegisterRPC for handlers that decode the bitstream themselves (e.g. a
@@ -146,7 +147,7 @@ namespace Framework::Networking {
 
         // Send a pre-encoded bitstream under a raw identifier (pairs with RegisterRawRPC).
         void SendRawRPC(const char *identifier, MafiaNet::BitStream &bs, MafiaNet::RakNetGUID guid, MafiaNet::Priority priority = MafiaNet::Priority::High, MafiaNet::Reliability reliability = MafiaNet::Reliability::ReliableOrdered) {
-            _rpc.Signal(identifier, &bs, priority, reliability, 0, guid, false, false);
+            _rpc.Signal(identifier, &bs, priority, reliability, ToOrderingChannel(Channel::Events), guid, false, false);
         }
 
         void Update() override;

--- a/code/framework/src/networking/network_server.cpp
+++ b/code/framework/src/networking/network_server.cpp
@@ -8,6 +8,7 @@
 
 #include "network_server.h"
 
+#include "channels.h"
 #include "replication/replication_manager.h"
 
 #include <mafianet/BitStream.h>
@@ -48,6 +49,7 @@ namespace Framework::Networking {
 
         _assetStreamer.SetFileListTransferPlugin(&_fileListTransfer);
         _assetStreamer.SetDownloadRequestIncrementalReadInterface(&_assetReader, kAssetChunkSize);
+        _assetStreamer.SetUploadSendParameters(MafiaNet::Priority::High, ToOrderingChannel(Channel::Assets));
         _peer->AttachPlugin(&_fileListTransfer);
         _peer->AttachPlugin(&_assetStreamer);
         RegisterBuildToken();
@@ -167,7 +169,7 @@ namespace Framework::Networking {
     void NetworkServer::SignalExcept(const char *identifier, MafiaNet::BitStream &bs, MafiaNet::RakNetGUID excludeGUID, MafiaNet::Priority priority, MafiaNet::Reliability reliability) {
         // When broadcasting, the system identifier is the peer to exclude, so a single Signal reaches
         // everyone but the sender.
-        _rpc.Signal(identifier, &bs, priority, reliability, 0, excludeGUID, true, false);
+        _rpc.Signal(identifier, &bs, priority, reliability, ToOrderingChannel(Channel::Events), excludeGUID, true, false);
     }
 
     void NetworkServer::PushReplicationConnection(MafiaNet::RakNetGUID guid) {

--- a/code/framework/src/networking/replication/network_entity.cpp
+++ b/code/framework/src/networking/replication/network_entity.cpp
@@ -8,19 +8,30 @@
 
 #include "network_entity.h"
 
+#include "../channels.h"
 #include "replication_manager.h"
 
 #include <mafianet/GetTime.h>
 #include <utils/time.h>
 
+#include <cstring>
+
 namespace Framework::Networking::Replication {
     namespace {
-        // Serialize channel split: the pose rides an unreliable-sequenced channel (a dropped frame is
-        // covered by the next one / receiver-side interpolation), game state rides a reliable-ordered
-        // channel (on-change deltas must never be lost). Both are flushed as independent RakNet
-        // messages because their PacketReliability differs (see Connection_RM3::SendSerialize).
+        // Serialize channel split: the pose rides an unreliable channel (a dropped frame is covered by
+        // the next one / receiver-side interpolation), game state rides a reliable-ordered channel
+        // (on-change deltas must never be lost). Both are flushed as independent RakNet messages
+        // because their PacketReliability differs (see Connection_RM3::SendSerialize).
         constexpr int kTransformChannel = 0;
         constexpr int kStateChannel     = 1;
+
+        bool SameBytes(const MafiaNet::BitStream *last, const MafiaNet::BitStream &current) {
+            if (!last || last->GetNumberOfBitsUsed() != current.GetNumberOfBitsUsed()) {
+                return false;
+            }
+            const MafiaNet::BitSize_t bytes = current.GetNumberOfBytesUsed();
+            return bytes == 0 || std::memcmp(last->GetData(), current.GetData(), bytes) == 0;
+        }
     } // namespace
 
     ReplicationManager *NetworkEntity::Manager() {
@@ -44,8 +55,9 @@ namespace Framework::Networking::Replication {
     void NetworkEntity::AdoptIncomingOwner(MafiaNet::PeerGuid incomingOwner) {
         // The server keeps its own authoritative owner assignment and must not let an owning client
         // dictate it back; clients adopt whatever the server sends.
-        if (!IsServerPeer()) {
+        if (!IsServerPeer() && ownerGUID != incomingOwner) {
             ownerGUID = incomingOwner;
+            _lastTransformTime = 0;
         }
     }
 
@@ -167,13 +179,34 @@ namespace Framework::Networking::Replication {
         // variable is omitted when unchanged, which would let a pre-override packet pass the staleness
         // check by absence), and the two channels are independent messages, so each carries its own.
 
-        // Channel 0 — transform: raw pose, unreliable-sequenced. Written every tick; ReplicaManager3
-        // memcmp-dedupes it against the last broadcast, so a motionless entity stops sending.
+        // Channel 0 — transform: raw pose, ordered per entity by the receiver's timestamp gate. Written
+        // every tick; ReplicaManager3 memcmp-dedupes it against the last broadcast.
         serializeParameters->outputBitstream[kTransformChannel].Write(stateEpoch);
         FieldSerializer transform(&serializeParameters->outputBitstream[kTransformChannel], true);
         SerializeTransform(transform);
-        serializeParameters->pro[kTransformChannel].reliability     = MafiaNet::Reliability::UnreliableSequenced;
-        serializeParameters->pro[kTransformChannel].orderingChannel = kTransformChannel;
+        serializeParameters->pro[kTransformChannel].reliability     = MafiaNet::Reliability::Unreliable;
+        serializeParameters->pro[kTransformChannel].orderingChannel = ToOrderingChannel(Channel::Transform);
+
+        // Idle refresh (see kTransformRefreshMs). An unchanged state channel is empty, so a forced send
+        // carries only the pose.
+        const MafiaNet::Time now                = serializeParameters->curTime;
+        const MafiaNet::BitStream *lastTransform = serializeParameters->lastSentBitstream[kTransformChannel];
+        bool refreshTransform                   = false;
+        if (!SameBytes(lastTransform, serializeParameters->outputBitstream[kTransformChannel])) {
+            if (lastTransform && lastTransform->GetNumberOfBitsUsed() > 0) {
+                _transformMoved      = true;
+                _lastTransformChange = now;
+            }
+            _lastTransformSend = now;
+        }
+        else if (_transformMoved && now >= _lastTransformSend) {
+            const bool inBurst          = now >= _lastTransformChange && now - _lastTransformChange < kTransformRefreshBurstMs;
+            const MafiaNet::Time period = inBurst ? kTransformRefreshMs : kTransformHeartbeatMs;
+            if (now - _lastTransformSend >= period) {
+                _lastTransformSend = now;
+                refreshTransform   = true;
+            }
+        }
 
         // Channel 1 — state: owner + game fields, VDS delta, reliable-ordered. whenLastSerialized == 0
         // means first send to a fresh system: write every variable in full; else only changed ones.
@@ -185,13 +218,13 @@ namespace Framework::Networking::Replication {
         SerializeFields(fields);
         _vds.EndSerialize(&ctx);
         serializeParameters->pro[kStateChannel].reliability    = MafiaNet::Reliability::ReliableOrdered;
-        serializeParameters->pro[kStateChannel].orderingChannel = kStateChannel;
+        serializeParameters->pro[kStateChannel].orderingChannel = ToOrderingChannel(Channel::State);
 
         // Both channels carry recipient-identical bytes, so broadcast-identically: ReplicaManager3
         // serializes once per tick, reuses the bytes for every connection, and suppresses each channel
         // whose bytes are unchanged. Per-connection filtering (owner exclusion) still happens upstream
         // in QuerySerializationWithinWorld.
-        return MafiaNet::RM3SR_BROADCAST_IDENTICALLY;
+        return refreshTransform ? MafiaNet::RM3SR_BROADCAST_IDENTICALLY_FORCE_SERIALIZATION : MafiaNet::RM3SR_BROADCAST_IDENTICALLY;
     }
 
     void NetworkEntity::Deserialize(MafiaNet::DeserializeParameters *deserializeParameters) {
@@ -203,15 +236,20 @@ namespace Framework::Networking::Replication {
 
         bool transformUpdated = false;
 
-        // Channel 0 — transform. The epoch fences a forced-state override against an owner's in-flight
-        // pose (which would otherwise revert it); the server drops a stale-epoch pose, clients adopt.
-        if (deserializeParameters->bitstreamWrittenTo[kTransformChannel]) {
+        // Channel 0 — transform. A pose older than the newest applied one is dropped. The epoch fences
+        // a forced-state override against an owner's in-flight pose (which would otherwise revert it);
+        // the server drops a stale-epoch pose, clients adopt.
+        const MafiaNet::Time sentAt = deserializeParameters->timeStamp;
+        if (deserializeParameters->bitstreamWrittenTo[kTransformChannel] && (sentAt == 0 || _lastTransformTime == 0 || sentAt >= _lastTransformTime)) {
             uint8_t incomingEpoch = stateEpoch;
             deserializeParameters->serializationBitstream[kTransformChannel].Read(incomingEpoch);
             if (ApplyIncomingEpoch(incomingEpoch)) {
                 FieldSerializer transform(&deserializeParameters->serializationBitstream[kTransformChannel], false);
                 SerializeTransform(transform);
                 transformUpdated = true;
+                if (sentAt != 0) {
+                    _lastTransformTime = sentAt;
+                }
             }
         }
 
@@ -230,7 +268,7 @@ namespace Framework::Networking::Replication {
         }
 
         // Already shifted to our local clock by RakPeer; do not subtract GetClockDifferential.
-        if (deserializeParameters->timeStamp != 0) {
+        if (deserializeParameters->timeStamp > lastUpdateTime) {
             lastUpdateTime = deserializeParameters->timeStamp;
         }
 

--- a/code/framework/src/networking/replication/network_entity.cpp
+++ b/code/framework/src/networking/replication/network_entity.cpp
@@ -217,6 +217,11 @@ namespace Framework::Networking::Replication {
         SerializeBaseFields(fields);
         SerializeFields(fields);
         _vds.EndSerialize(&ctx);
+        if (!ctx.anyVariablesWritten) {
+            // Nothing to deliver, so no message: the epoch prefix alone would be sent reliably on
+            // every forced refresh.
+            serializeParameters->outputBitstream[kStateChannel].Reset();
+        }
         serializeParameters->pro[kStateChannel].reliability    = MafiaNet::Reliability::ReliableOrdered;
         serializeParameters->pro[kStateChannel].orderingChannel = ToOrderingChannel(Channel::State);
 

--- a/code/framework/src/networking/replication/network_entity.h
+++ b/code/framework/src/networking/replication/network_entity.h
@@ -141,6 +141,13 @@ namespace Framework::Networking::Replication {
         // --- Authority (replicated) ---
         MafiaNet::PeerGuid ownerGUID = MafiaNet::UNASSIGNED_PEER_GUID;
 
+        // Idle refresh of an unchanged pose, so a lost final packet is repaired: every kTransformRefreshMs
+        // for kTransformRefreshBurstMs after the last change, then every kTransformHeartbeatMs. Entities
+        // that never moved since construction are not refreshed.
+        static constexpr MafiaNet::Time kTransformRefreshMs      = 500;
+        static constexpr MafiaNet::Time kTransformRefreshBurstMs = 2000;
+        static constexpr MafiaNet::Time kTransformHeartbeatMs    = 5000;
+
         // Fences server overrides against in-flight owner updates: bumped by the server on
         // ForceState, adopted by the owner from the ForceState/SetOwner RPCs and echoed back in its
         // updates; the server drops owner state carrying a stale value (sent before the owner saw the
@@ -224,6 +231,11 @@ namespace Framework::Networking::Replication {
         MafiaNet::Time GetUpdateAge() const;
         glm::vec3 GetExtrapolatedPosition() const;
 
+        // Accept the next pose whatever its timestamp; called on an ownership change.
+        void ResetTransformOrdering() {
+            _lastTransformTime = 0;
+        }
+
         // Resolve another entity in the same replicated world by NetworkID; the owning manager is
         // otherwise private. The seam for overrides that need a sibling, chiefly
         // GetInterestDependency.
@@ -280,5 +292,14 @@ namespace Framework::Networking::Replication {
         // Tracks the last value of each serialized variable per connection so updates carry only
         // what changed (the documented ReplicaManager3 delta path).
         MafiaNet::VariableDeltaSerializer _vds;
+
+        // Sender: refresh schedule state, in serialize-tick time.
+        bool _transformMoved                = false;
+        MafiaNet::Time _lastTransformChange = 0;
+        MafiaNet::Time _lastTransformSend   = 0;
+
+        // Receiver: send time of the newest applied pose. The transform channel is plain Unreliable
+        // (a sequenced stream is per channel, not per entity), so this is the per-entity ordering.
+        MafiaNet::Time _lastTransformTime = 0;
     };
 } // namespace Framework::Networking::Replication

--- a/code/framework/src/networking/replication/replication_connection.cpp
+++ b/code/framework/src/networking/replication/replication_connection.cpp
@@ -12,11 +12,16 @@
 #include "network_entity.h"
 #include "replication_manager.h"
 
+#include <cstring>
 #include <unordered_set>
 
 namespace Framework::Networking::Replication {
+    namespace {
+        constexpr int kTransformChannel = 0;
+    } // namespace
+
     ReplicationConnection::ReplicationConnection(const MafiaNet::SystemAddress &systemAddress, MafiaNet::RakNetGUID guid, ReplicationManager *manager, bool isServer)
-        : Connection_RM3(systemAddress, guid), _manager(manager), _isServer(isServer) {}
+        : Connection_RM3(systemAddress, guid), _manager(manager), _isServer(isServer), _viewerGUID(MafiaNet::ToPeerGuid(guid)) {}
 
     MafiaNet::Replica3 *ReplicationConnection::AllocReplica(MafiaNet::BitStream *allocationIdBitstream, MafiaNet::ReplicaManager3 *) {
         uint32_t typeId = 0;
@@ -54,6 +59,9 @@ namespace Framework::Networking::Replication {
             _relevantGeneration = generation;
             _relevantViewer     = viewer;
             _relevantValid      = true;
+            for (auto it = _lastTransformSend.begin(); it != _lastTransformSend.end();) {
+                it = _relevant.contains(const_cast<NetworkEntity *>(it->first)) ? std::next(it) : _lastTransformSend.erase(it);
+            }
         }
 
         for (NetworkEntity *entity : _relevant) {
@@ -70,5 +78,40 @@ namespace Framework::Networking::Replication {
                 existingReplicasToDestroy.Push(entity, _FILE_AND_LINE_);
             }
         }
+    }
+
+    uint32_t ReplicationConnection::TransformSendIntervalMs(const NetworkEntity *entity) const {
+        if (!_isServer || !_manager || !entity || !_relevantValid || !_relevantViewer || !_manager->HasSerializeRateBands()) {
+            return 0;
+        }
+        const NetworkEntity *viewer = _relevantViewer;
+        if (entity == viewer || entity->ownerGUID == _viewerGUID || entity->streaming.alwaysVisible || entity->streaming.targetGUID != MafiaNet::UNASSIGNED_PEER_GUID) {
+            return 0;
+        }
+        const SerializeRateBands &bands = _manager->GetSerializeRateBands(entity->GetTypeId());
+        if (bands.midIntervalMs == 0 && bands.farIntervalMs == 0) {
+            return 0;
+        }
+        const glm::vec3 delta = entity->position - viewer->position;
+        return ReplicationManager::TransformSendIntervalMs(bands, glm::dot(delta, delta));
+    }
+
+    MafiaNet::SendSerializeIfChangedResult ReplicationConnection::SendSerialize(MafiaNet::Replica3 *replica, bool indicesToSend[MafiaNet::RM3_NUM_OUTPUT_BITSTREAM_CHANNELS], MafiaNet::BitStream serializationData[MafiaNet::RM3_NUM_OUTPUT_BITSTREAM_CHANNELS], MafiaNet::Time timestamp, MafiaNet::PRO sendParameters[MafiaNet::RM3_NUM_OUTPUT_BITSTREAM_CHANNELS], MafiaNet::RakPeerInterface *rakPeer, unsigned char worldId, MafiaNet::Time curTime) {
+        if (indicesToSend[kTransformChannel]) {
+            const auto *entity      = static_cast<const NetworkEntity *>(replica);
+            const uint32_t interval = TransformSendIntervalMs(entity);
+            if (interval > 0) {
+                const auto it = _lastTransformSend.find(entity);
+                if (it != _lastTransformSend.end() && curTime >= it->second && curTime - it->second < interval) {
+                    // indicesToSend may be the replica's shared broadcast record.
+                    bool withheld[MafiaNet::RM3_NUM_OUTPUT_BITSTREAM_CHANNELS];
+                    std::memcpy(withheld, indicesToSend, sizeof(withheld));
+                    withheld[kTransformChannel] = false;
+                    return Connection_RM3::SendSerialize(replica, withheld, serializationData, timestamp, sendParameters, rakPeer, worldId, curTime);
+                }
+                _lastTransformSend[entity] = curTime;
+            }
+        }
+        return Connection_RM3::SendSerialize(replica, indicesToSend, serializationData, timestamp, sendParameters, rakPeer, worldId, curTime);
     }
 } // namespace Framework::Networking::Replication

--- a/code/framework/src/networking/replication/replication_connection.h
+++ b/code/framework/src/networking/replication/replication_connection.h
@@ -11,6 +11,7 @@
 #include <mafianet/ReplicaManager3.h>
 
 #include <cstdint>
+#include <unordered_map>
 #include <unordered_set>
 
 namespace Framework::Networking::Replication {
@@ -33,9 +34,19 @@ namespace Framework::Networking::Replication {
 
         void QueryReplicaList(DataStructures::List<MafiaNet::Replica3 *> &newReplicasToCreate, DataStructures::List<MafiaNet::Replica3 *> &existingReplicasToDestroy) override;
 
+        // Server: withholds the transform channel per viewer by distance band; the reliable state
+        // channel always passes.
+        MafiaNet::SendSerializeIfChangedResult SendSerialize(MafiaNet::Replica3 *replica, bool indicesToSend[MafiaNet::RM3_NUM_OUTPUT_BITSTREAM_CHANNELS], MafiaNet::BitStream serializationData[MafiaNet::RM3_NUM_OUTPUT_BITSTREAM_CHANNELS], MafiaNet::Time timestamp, MafiaNet::PRO sendParameters[MafiaNet::RM3_NUM_OUTPUT_BITSTREAM_CHANNELS], MafiaNet::RakPeerInterface *rakPeer, unsigned char worldId, MafiaNet::Time curTime) override;
+
+        uint32_t TransformSendIntervalMs(const NetworkEntity *entity) const;
+
       private:
         ReplicationManager *_manager = nullptr;
         bool _isServer               = false;
+        MafiaNet::PeerGuid _viewerGUID = MafiaNet::UNASSIGNED_PEER_GUID;
+
+        // Last transform send per replica; pruned against the interest set, keys never dereferenced.
+        std::unordered_map<const NetworkEntity *, MafiaNet::Time> _lastTransformSend;
 
         // Interest result cached against the grid generation: ReplicaManager3 calls QueryReplicaList
         // on every RakPeer::Receive(), but the grid only changes once per tick (plus removals), so

--- a/code/framework/src/networking/replication/replication_manager.cpp
+++ b/code/framework/src/networking/replication/replication_manager.cpp
@@ -8,6 +8,7 @@
 
 #include "replication_manager.h"
 
+#include "../channels.h"
 #include "../network_peer.h"
 #include "entity_registry.h"
 #include "replication_connection.h"
@@ -48,6 +49,7 @@ namespace Framework::Networking::Replication {
         _isServer = isServer;
         _myGUID   = MafiaNet::ToPeerGuid(owner->GetPeer()->GetMyGUID());
         SetNetworkIDManager(owner->GetNetworkIDManager());
+        SetDefaultOrderingChannel(ToOrderingChannel(Channel::Construction));
         owner->GetPeer()->AttachPlugin(this);
 
         // Client-only: these are server->owner pushes, so the server must never accept them inbound.
@@ -76,6 +78,16 @@ namespace Framework::Networking::Replication {
         }
     }
 
+    uint32_t ReplicationManager::TransformSendIntervalMs(const SerializeRateBands &bands, float distSq) {
+        if (distSq <= bands.nearDistance * bands.nearDistance) {
+            return 0;
+        }
+        if (distSq <= bands.midDistance * bands.midDistance) {
+            return bands.midIntervalMs;
+        }
+        return bands.farIntervalMs;
+    }
+
     void ReplicationManager::ForceState(NetworkEntity *entity) {
         // Server-only, like SetOwner: on a client this must be a no-op, not an RPC misaddressed to a
         // peer we aren't connected to (the shared scripting builtins call it on both sides).
@@ -101,6 +113,7 @@ namespace Framework::Networking::Replication {
             return;
         }
         entity->ownerGUID = guid;
+        entity->ResetTransformOrdering();
         // Serialize to an owner is withheld, so the grant can't ride normal replication: tell the new
         // owner directly. Other peers (and any prior owner) pick it up through serialize.
         if (_owner && _isServer && guid != MafiaNet::UNASSIGNED_PEER_GUID) {

--- a/code/framework/src/networking/replication/replication_manager.h
+++ b/code/framework/src/networking/replication/replication_manager.h
@@ -32,6 +32,16 @@ namespace Framework::Networking {
 } // namespace Framework::Networking
 
 namespace Framework::Networking::Replication {
+    // Server-side transform send interval by distance from the viewer: every tick inside nearDistance,
+    // midIntervalMs out to midDistance, farIntervalMs beyond. Only the transform channel is throttled;
+    // a zero interval means every tick.
+    struct SerializeRateBands {
+        float nearDistance     = 0.0f;
+        float midDistance      = 0.0f;
+        uint32_t midIntervalMs = 0;
+        uint32_t farIntervalMs = 0;
+    };
+
     // The replicated world: a ReplicaManager3 that owns the set of NetworkEntity objects. It
     // creates/destroys entities, resolves them by NetworkID, tracks each connection's "viewer"
     // entity, and drives an InterestGrid that ReplicationConnection::QueryReplicaList reads for
@@ -139,6 +149,29 @@ namespace Framework::Networking::Replication {
             return _interest.Generation();
         }
 
+        // Server: transform rate bands, default and per-type override.
+        void SetSerializeRateBands(const SerializeRateBands &bands) {
+            _rateBands = bands;
+        }
+        void SetSerializeRateBands(uint32_t typeId, const SerializeRateBands &bands) {
+            _rateBandsByType[typeId] = bands;
+        }
+        void SetSerializeRateBands(const std::string &typeName, const SerializeRateBands &bands) {
+            _rateBandsByType[EntityRegistry::Get().TypeId(typeName)] = bands;
+        }
+        const SerializeRateBands &GetSerializeRateBands(uint32_t typeId) const {
+            if (_rateBandsByType.empty()) {
+                return _rateBands;
+            }
+            const auto it = _rateBandsByType.find(typeId);
+            return it != _rateBandsByType.end() ? it->second : _rateBands;
+        }
+        bool HasSerializeRateBands() const {
+            return _rateBands.midIntervalMs != 0 || _rateBands.farIntervalMs != 0 || !_rateBandsByType.empty();
+        }
+        // Milliseconds between transform sends at squared distance distSq; 0 = every tick.
+        static uint32_t TransformSendIntervalMs(const SerializeRateBands &bands, float distSq);
+
         // Server: invoked from OnClosedConnection just before the dropped peer's avatar is destroyed,
         // while it is still resolvable. The integration layer wires its player-disconnect notification
         // here.
@@ -174,6 +207,8 @@ namespace Framework::Networking::Replication {
         NetworkPeer *_owner = nullptr;
         bool _clientRPCsRegistered = false;
         InterestGrid _interest;
+        SerializeRateBands _rateBands;
+        std::unordered_map<uint32_t, SerializeRateBands> _rateBandsByType;
         uint32_t _interestRebuildInterval = 0;
         int64_t _lastInterestRebuild      = 0;
         // Entity set changed since the last rebuild; forces one regardless of the interval.

--- a/code/framework/src/networking/replication/replication_manager.h
+++ b/code/framework/src/networking/replication/replication_manager.h
@@ -40,6 +40,15 @@ namespace Framework::Networking::Replication {
         float midDistance      = 0.0f;
         uint32_t midIntervalMs = 0;
         uint32_t farIntervalMs = 0;
+
+        // Distances are clamped to 0 <= nearDistance <= midDistance, so an inverted or negative band
+        // cannot hand a far viewer the near interval.
+        SerializeRateBands Normalized() const {
+            SerializeRateBands out = *this;
+            out.nearDistance       = nearDistance > 0.0f ? nearDistance : 0.0f;
+            out.midDistance        = midDistance > out.nearDistance ? midDistance : out.nearDistance;
+            return out;
+        }
     };
 
     // The replicated world: a ReplicaManager3 that owns the set of NetworkEntity objects. It
@@ -151,13 +160,13 @@ namespace Framework::Networking::Replication {
 
         // Server: transform rate bands, default and per-type override.
         void SetSerializeRateBands(const SerializeRateBands &bands) {
-            _rateBands = bands;
+            _rateBands = bands.Normalized();
         }
         void SetSerializeRateBands(uint32_t typeId, const SerializeRateBands &bands) {
-            _rateBandsByType[typeId] = bands;
+            _rateBandsByType[typeId] = bands.Normalized();
         }
         void SetSerializeRateBands(const std::string &typeName, const SerializeRateBands &bands) {
-            _rateBandsByType[EntityRegistry::Get().TypeId(typeName)] = bands;
+            _rateBandsByType[EntityRegistry::Get().TypeId(typeName)] = bands.Normalized();
         }
         const SerializeRateBands &GetSerializeRateBands(uint32_t typeId) const {
             if (_rateBandsByType.empty()) {

--- a/code/framework/src/voice/client/voice_client.cpp
+++ b/code/framework/src/voice/client/voice_client.cpp
@@ -9,6 +9,7 @@
 #include "voice_client.h"
 
 #include <logging/logger.h>
+#include <networking/channels.h>
 #include <networking/network_client.h>
 #include <networking/rpc/voice_settings.h>
 #include <utils/time.h>
@@ -297,6 +298,7 @@ namespace Framework::Voice {
         _client = client;
 
         client->GetPeer()->AttachPlugin(&_voice);
+        _voice.SetOrderingChannels(Framework::Networking::ToOrderingChannel(Framework::Networking::Channel::VoiceFrames), Framework::Networking::ToOrderingChannel(Framework::Networking::Channel::VoiceControl));
         _attached = true;
 
         _sink = &_localSink;

--- a/code/framework/src/voice/server/voice_server.cpp
+++ b/code/framework/src/voice/server/voice_server.cpp
@@ -12,6 +12,7 @@
 
 #include <logging/logger.h>
 #include <mafianet/MessageIdentifiers.h>
+#include <networking/channels.h>
 #include <networking/network_server.h>
 #include <networking/rpc/voice_settings.h>
 #include <utils/time.h>
@@ -34,6 +35,7 @@ namespace Framework::Voice {
         // entirely -- so setting it would only put the plugin in a contradictory state.
         // No Init() call either, so no codec is ever allocated here.
         _voice.SetRelayHost(true);
+        _voice.SetOrderingChannels(Framework::Networking::ToOrderingChannel(Framework::Networking::Channel::VoiceFrames), Framework::Networking::ToOrderingChannel(Framework::Networking::Channel::VoiceControl));
         server->GetPeer()->AttachPlugin(&_voice);
         _attached = true;
 

--- a/code/tests/framework_ut.cpp
+++ b/code/tests/framework_ut.cpp
@@ -6,7 +6,7 @@
  * See LICENSE file in the source repository for information regarding licensing.
  */
 
-#define UNIT_MAX_MODULES 25
+#define UNIT_MAX_MODULES 26
 #include "logging/logger.h"
 #include "unit.h"
 
@@ -16,6 +16,7 @@
 #include "modules/result_ut.h"
 #include "modules/network_packets_ut.h"
 #include "modules/replication_authority_ut.h"
+#include "modules/replication_rate_ut.h"
 #include "modules/interest_grid_ut.h"
 #include "modules/state_machine_ut.h"
 #include "modules/persistent_config_ut.h"
@@ -45,6 +46,7 @@ int main() {
     UNIT_MODULE(result);
     UNIT_MODULE(network_packets);
     UNIT_MODULE(replication_authority);
+    UNIT_MODULE(replication_rate);
     UNIT_MODULE(interest_grid);
     UNIT_MODULE(state_machine);
     UNIT_MODULE(persistent_config);

--- a/code/tests/modules/replication_rate_ut.h
+++ b/code/tests/modules/replication_rate_ut.h
@@ -1,0 +1,172 @@
+/*
+ * MafiaHub OSS license
+ * Copyright (c) 2021-2026, MafiaHub. All rights reserved.
+ *
+ * This file comes from MafiaHub, hosted at https://github.com/MafiaHub/Framework.
+ * See LICENSE file in the source repository for information regarding licensing.
+ */
+
+#pragma once
+
+#include "networking/channels.h"
+#include "networking/replication/network_entity.h"
+#include "networking/replication/replication_manager.h"
+
+#include <mafianet/BitStream.h>
+#include <mafianet/ReplicaManager3.h>
+
+// Transform channel rate rules: distance bands, idle refresh, and per-entity ordering.
+MODULE(replication_rate, {
+    using Framework::Networking::Channel;
+    using Framework::Networking::ToOrderingChannel;
+    using Framework::Networking::Replication::FieldSerializer;
+    using Framework::Networking::Replication::NetworkEntity;
+    using Framework::Networking::Replication::ReplicationManager;
+    using Framework::Networking::Replication::SerializeRateBands;
+
+    // Drives Serialize like ReplicaManager3 does for a broadcast-identical replica.
+    struct SerializeHarness {
+        NetworkEntity entity;
+        MafiaNet::BitStream lastSent;
+        bool first = true;
+
+        int Serialize(MafiaNet::Time now) {
+            MafiaNet::SerializeParameters sp;
+            for (int i = 0; i < MafiaNet::RM3_NUM_OUTPUT_BITSTREAM_CHANNELS; ++i) {
+                sp.lastSentBitstream[i] = nullptr;
+            }
+            sp.lastSentBitstream[0] = &lastSent;
+            sp.whenLastSerialized   = first ? 0 : 1;
+            sp.curTime              = now;
+            first                   = false;
+            entity.OnUserReplicaPreSerializeTick();
+            const int result = static_cast<int>(entity.Serialize(&sp));
+            lastSent.Reset();
+            lastSent.Write(&sp.outputBitstream[0]);
+            return result;
+        }
+    };
+
+    const int normal = static_cast<int>(MafiaNet::RM3SR_BROADCAST_IDENTICALLY);
+    const int forced = static_cast<int>(MafiaNet::RM3SR_BROADCAST_IDENTICALLY_FORCE_SERIALIZATION);
+
+    IT("keeps the transform stream on a channel of its own", {
+        const char transform = ToOrderingChannel(Channel::Transform);
+        NEQUALS(transform, ToOrderingChannel(Channel::State));
+        NEQUALS(transform, ToOrderingChannel(Channel::Assets));
+        NEQUALS(transform, ToOrderingChannel(Channel::Events));
+        NEQUALS(transform, ToOrderingChannel(Channel::Construction));
+        NEQUALS(transform, ToOrderingChannel(Channel::VoiceFrames));
+        NEQUALS(transform, ToOrderingChannel(Channel::VoiceControl));
+    });
+
+    IT("orders entity construction with the RPCs that name entities", {
+        EQUALS(ToOrderingChannel(Channel::Construction), ToOrderingChannel(Channel::Events));
+    });
+
+    IT("sends every tick when no band is configured", {
+        const SerializeRateBands off {};
+        EQUALS(static_cast<int>(ReplicationManager::TransformSendIntervalMs(off, 0.0f)), 0);
+        EQUALS(static_cast<int>(ReplicationManager::TransformSendIntervalMs(off, 1000.0f * 1000.0f)), 0);
+    });
+
+    IT("picks the interval by the band the distance falls in", {
+        const SerializeRateBands bands {50.0f, 150.0f, 33, 66};
+        EQUALS(static_cast<int>(ReplicationManager::TransformSendIntervalMs(bands, 10.0f * 10.0f)), 0);
+        EQUALS(static_cast<int>(ReplicationManager::TransformSendIntervalMs(bands, 100.0f * 100.0f)), 33);
+        EQUALS(static_cast<int>(ReplicationManager::TransformSendIntervalMs(bands, 300.0f * 300.0f)), 66);
+    });
+
+    IT("treats a band edge as inside the nearer band", {
+        const SerializeRateBands bands {50.0f, 150.0f, 33, 66};
+        EQUALS(static_cast<int>(ReplicationManager::TransformSendIntervalMs(bands, 50.0f * 50.0f)), 0);
+        EQUALS(static_cast<int>(ReplicationManager::TransformSendIntervalMs(bands, 50.5f * 50.5f)), 33);
+        EQUALS(static_cast<int>(ReplicationManager::TransformSendIntervalMs(bands, 150.0f * 150.0f)), 33);
+        EQUALS(static_cast<int>(ReplicationManager::TransformSendIntervalMs(bands, 150.5f * 150.5f)), 66);
+    });
+
+    IT("lets a type override the default bands and falls back for the rest", {
+        ReplicationManager manager;
+        manager.SetSerializeRateBands(SerializeRateBands {50.0f, 150.0f, 33, 50});
+        manager.SetSerializeRateBands(42u, SerializeRateBands {50.0f, 150.0f, 50, 100});
+        EQUALS(static_cast<int>(manager.GetSerializeRateBands(42u).farIntervalMs), 100);
+        EQUALS(static_cast<int>(manager.GetSerializeRateBands(7u).farIntervalMs), 50);
+    });
+
+    IT("never refreshes an entity that has not moved since construction", {
+        SerializeHarness h;
+        h.entity.position = glm::vec3(1.0f, 2.0f, 3.0f);
+        EQUALS(h.Serialize(1000), normal);
+        EQUALS(h.Serialize(1000 + NetworkEntity::kTransformRefreshMs), normal);
+        EQUALS(h.Serialize(1000 + NetworkEntity::kTransformHeartbeatMs), normal);
+        EQUALS(h.Serialize(1000 + 10 * NetworkEntity::kTransformHeartbeatMs), normal);
+    });
+
+    IT("refreshes a stopped entity through the burst, then on the heartbeat", {
+        SerializeHarness h;
+        const MafiaNet::Time refresh   = NetworkEntity::kTransformRefreshMs;
+        const MafiaNet::Time burst     = NetworkEntity::kTransformRefreshBurstMs;
+        const MafiaNet::Time heartbeat = NetworkEntity::kTransformHeartbeatMs;
+
+        EQUALS(h.Serialize(1000), normal);
+        h.entity.position = glm::vec3(5.0f, 0.0f, 0.0f);
+        EQUALS(h.Serialize(2000), normal);
+        EQUALS(h.Serialize(2000 + refresh - 1), normal);
+        EQUALS(h.Serialize(2000 + refresh), forced);
+        EQUALS(h.Serialize(2000 + refresh + 1), normal);
+        EQUALS(h.Serialize(2000 + 2 * refresh), forced);
+        EQUALS(h.Serialize(2000 + 3 * refresh), forced);
+        EQUALS(h.Serialize(2000 + burst), normal);
+        EQUALS(h.Serialize(2000 + 3 * refresh + heartbeat - 1), normal);
+        EQUALS(h.Serialize(2000 + 3 * refresh + heartbeat), forced);
+    });
+
+    IT("restarts the burst when the entity moves again", {
+        SerializeHarness h;
+        const MafiaNet::Time refresh = NetworkEntity::kTransformRefreshMs;
+        const MafiaNet::Time burst   = NetworkEntity::kTransformRefreshBurstMs;
+
+        EQUALS(h.Serialize(1000), normal);
+        h.entity.position = glm::vec3(5.0f, 0.0f, 0.0f);
+        EQUALS(h.Serialize(2000), normal);
+        EQUALS(h.Serialize(2000 + burst), normal);
+        h.entity.position = glm::vec3(9.0f, 0.0f, 0.0f);
+        EQUALS(h.Serialize(10000), normal);
+        EQUALS(h.Serialize(10000 + refresh), forced);
+    });
+
+    const auto deliver = [](NetworkEntity &target, const glm::vec3 &position, MafiaNet::Time sentAt) {
+        NetworkEntity source;
+        source.position = position;
+        MafiaNet::DeserializeParameters dp;
+        for (int i = 0; i < MafiaNet::RM3_NUM_OUTPUT_BITSTREAM_CHANNELS; ++i) {
+            dp.bitstreamWrittenTo[i] = false;
+        }
+        dp.bitstreamWrittenTo[0] = true;
+        dp.timeStamp             = sentAt;
+        dp.sourceConnection      = nullptr;
+        const uint8_t epoch      = 0;
+        dp.serializationBitstream[0].Write(epoch);
+        FieldSerializer fields(&dp.serializationBitstream[0], true);
+        source.SerializeTransform(fields);
+        dp.serializationBitstream[0].ResetReadPointer();
+        target.Deserialize(&dp);
+    };
+
+    IT("applies poses in send order and drops one that arrives after a newer one", {
+        NetworkEntity target;
+        deliver(target, glm::vec3(1.0f, 0.0f, 0.0f), 200);
+        EQUALS(static_cast<int>(target.position.x), 1);
+        deliver(target, glm::vec3(2.0f, 0.0f, 0.0f), 100);
+        EQUALS(static_cast<int>(target.position.x), 1);
+        deliver(target, glm::vec3(3.0f, 0.0f, 0.0f), 300);
+        EQUALS(static_cast<int>(target.position.x), 3);
+    });
+
+    IT("applies an unstamped pose rather than guessing its age", {
+        NetworkEntity target;
+        deliver(target, glm::vec3(1.0f, 0.0f, 0.0f), 200);
+        deliver(target, glm::vec3(4.0f, 0.0f, 0.0f), 0);
+        EQUALS(static_cast<int>(target.position.x), 4);
+    });
+});

--- a/code/tests/modules/replication_rate_ut.h
+++ b/code/tests/modules/replication_rate_ut.h
@@ -93,6 +93,53 @@ MODULE(replication_rate, {
         EQUALS(static_cast<int>(manager.GetSerializeRateBands(7u).farIntervalMs), 50);
     });
 
+    IT("clamps inverted and negative bands so a far viewer never gets the near interval", {
+        ReplicationManager manager;
+        manager.SetSerializeRateBands(SerializeRateBands {100.0f, 50.0f, 33, 66});
+        const SerializeRateBands &clamped = manager.GetSerializeRateBands(1u);
+        EQUALS(static_cast<int>(clamped.nearDistance), 100);
+        EQUALS(static_cast<int>(clamped.midDistance), 100);
+        EQUALS(static_cast<int>(ReplicationManager::TransformSendIntervalMs(clamped, 75.0f * 75.0f)), 0);
+        EQUALS(static_cast<int>(ReplicationManager::TransformSendIntervalMs(clamped, 101.0f * 101.0f)), 66);
+
+        manager.SetSerializeRateBands(SerializeRateBands {-50.0f, -10.0f, 33, 66});
+        const SerializeRateBands &positive = manager.GetSerializeRateBands(1u);
+        EQUALS(static_cast<int>(positive.nearDistance), 0);
+        EQUALS(static_cast<int>(positive.midDistance), 0);
+        EQUALS(static_cast<int>(ReplicationManager::TransformSendIntervalMs(positive, 30.0f * 30.0f)), 66);
+    });
+
+    IT("sends the state channel only when a field changed, refresh ticks included", {
+        NetworkEntity entity;
+        MafiaNet::BitStream lastSent;
+        const auto stateBits = [&](MafiaNet::Time now, bool firstSend, MafiaNet::PeerGuid owner) {
+            entity.ownerGUID = owner;
+            MafiaNet::SerializeParameters sp;
+            for (int i = 0; i < MafiaNet::RM3_NUM_OUTPUT_BITSTREAM_CHANNELS; ++i) {
+                sp.lastSentBitstream[i] = nullptr;
+            }
+            sp.lastSentBitstream[0] = &lastSent;
+            sp.whenLastSerialized   = firstSend ? 0 : 1;
+            sp.curTime              = now;
+            entity.OnUserReplicaPreSerializeTick();
+            entity.Serialize(&sp);
+            lastSent.Reset();
+            lastSent.Write(&sp.outputBitstream[0]);
+            return static_cast<int>(sp.outputBitstream[1].GetNumberOfBitsUsed());
+        };
+
+        // First send to a fresh system writes every field.
+        GREATER(stateBits(1000, true, MafiaNet::UNASSIGNED_PEER_GUID), 0);
+        // Nothing changed: no state message at all, not even the epoch prefix.
+        EQUALS(stateBits(1100, false, MafiaNet::UNASSIGNED_PEER_GUID), 0);
+        // A moved-then-idle entity on its refresh tick still sends no state.
+        entity.position = glm::vec3(4.0f, 0.0f, 0.0f);
+        EQUALS(stateBits(2000, false, MafiaNet::UNASSIGNED_PEER_GUID), 0);
+        EQUALS(stateBits(2000 + NetworkEntity::kTransformRefreshMs, false, MafiaNet::UNASSIGNED_PEER_GUID), 0);
+        // A field change is delivered.
+        GREATER(stateBits(3000, false, MafiaNet::PeerGuid(77)), 0);
+    });
+
     IT("never refreshes an entity that has not moved since construction", {
         SerializeHarness h;
         h.entity.position = glm::vec3(1.0f, 2.0f, 3.0f);


### PR DESCRIPTION
A tester with two players reported remote players flickering and teleporting while walking or driving, with the server's loop hitching for 600-800 ms at low CPU, and asked for script-level sync-rate and bandwidth controls. The audit found four transport-level causes that no script setting could reach. This PR fixes the three that live in the Framework; the fourth (the masterlist ping holding the tick's mutex across an HTTPS round trip) is MafiaHub/services-adapter#2, merged as `242fb25`. The Framework consumes that adapter as the prebuilt MafiaHub-Services distribution, which the `Build MafiaHub Services` workflow republishes on the next push to `develop`, so merging this PR is what ships the adapter fix; nothing in-tree pins it.

## Problem

**One ordering channel for everything.** The pose stream is `UnreliableSequenced`, and every other send site — `RPC4::Signal`, `SignalExcept`, ReplicaManager3 construction, RakVoice frames and control, the server's asset uploads — was `ReliableOrdered` on the same channel 0. In `ReliabilityLayer.cpp` a sequenced message carries the ordering index current when it was sent, and a sequenced message whose index is ahead of the expected one is held in the ordering heap until the missing ordered message is retransmitted. So one lost input edge, shot or chat message froze every remote player's movement for a retransmission timeout (`2 * RTT + 4 * deviation + 30 ms`, capped at 2 s) and then released the backlog in a burst. This is also why the reporter's host, on loopback, never saw it and the remote did.

**A sequenced stream is per channel, not per entity.** All replicas shared one sequence space, so a single reordered datagram discarded every other entity's newer pose that arrived before it.

**Idle poses were never repaired.** `RM3SR_BROADCAST_IDENTICALLY` compares the channel bytes to the last broadcast and drops identical ones. Position is quantised to about 1.2 mm, so a player who stopped produced identical bytes forever, and if the packet with the final pose was lost, the remote stayed wrong until the owner moved again.

**The server ticked at ~32 Hz on Windows.** `Instance::Update` paces with `sleep_for(1ms)` and nothing raised the timer resolution; a probe built with the repo toolchain measured `avg sleep_for(1ms) = 15.47 ms`, so the 16.67 ms budget became two quanta.

## Change

`networking/channels.h` maps traffic classes to ordering channels and every send site routes through it: the pose keeps channel 0 alone; state deltas, asset transfer, RPCs, voice frames and voice control each get their own. Construction shares the RPC channel deliberately: `SetOwner`, cosmetics and seat-warp RPCs name entities and must stay ordered after the construction that creates them, and RakNet only orders within a channel. Voice needs `RakVoice::SetOrderingChannels` from MafiaHub/MafiaNet#57, hence the pin bump in the first commit.

The transform channel becomes plain `Unreliable`, and `NetworkEntity::Deserialize` orders poses per entity by the send timestamp RakPeer already shifts to the local clock; an older pose is dropped without touching any other entity, and the floor resets on an ownership change so a new owner's clock offset cannot mute its first packets.

An entity that has moved since construction refreshes an unchanged pose every 500 ms for two seconds after its last change, then every five seconds, by returning `RM3SR_BROADCAST_IDENTICALLY_FORCE_SERIALIZATION`. The unchanged state channel is left empty by `VariableDeltaSerializer`, so the forced send carries only the pose. Entities that never moved are never refreshed, so static props cost nothing.

`ReplicationConnection::SendSerialize` throttles the pose per viewer by distance band (`SerializeRateBands`, a default plus per-type overrides). Only the unreliable pose is ever withheld; the reliable state channel always passes, because identical-broadcast deltas cannot catch a skipped connection up later. The hook is off unless a game configures bands. It uses the viewer `QueryReplicaList` already resolved and exits before any lookup when no bands exist.

The server tick warns past 100 ms with the tick's duration, at most once a second (per-phase timing is left to the existing Tracy scopes), and `Run()` holds `timeBeginPeriod(1)` in an RAII scope on Windows.

## Testing

`M2OServer` (x64), `M2OClient` (x86) and `FrameworkTests` build clean; the suite passes 302/302, 11 of them in the new `replication_rate` module: channel layout, band edges and the per-type override, the refresh burst and heartbeat, the burst restarting on movement, and a reordered pose being dropped while a newer one applies.

The debug server was booted to confirm the tick warning and the metadata export stay quiet. No two-client play-test under artificial loss has been run yet; that is the next step, and the slow-tick warning is what tells the reporter whether the server side is still involved.

## Note

MafiaHub/MafiaNet#57 merged and shipped as v0.18.0; the pin now points at the release commit.

Channel numbers are a sender-side choice, so mixed versions still decode each other; they only keep their own collisions. It is still a sync-flow change under the release rules, so the M2O side (mafia2online/Mod#11) treats it as a MAJOR when it raises `FRAMEWORK_PIN`.

Deliberately not done: FOV or frustum-based rate reduction. Both reference implementations have it, but a 150 ms band behind the camera pops when the viewer turns, which is the opposite of what this PR is for.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Networking**
  - Improved prioritization for asset, event, construction, and voice traffic.
  - Improved transform update ordering, stale-update protection, and recovery from lost final updates.

- **Performance**
  - Added distance-based throttling for transform updates to reduce unnecessary traffic while preserving responsiveness nearby.
  - Improved server hitch monitoring and warning behavior.

- **Tests**
  - Added coverage for replication timing, transform refresh behavior, channel ordering, and stale update handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


